### PR TITLE
Enforce type of the XBlocks Fields when set

### DIFF
--- a/cms/lib/xblock/mixin.py
+++ b/cms/lib/xblock/mixin.py
@@ -3,6 +3,7 @@ Mixin defining common Studio functionality
 """
 
 import datetime
+import time
 
 from xblock.fields import Scope, Field, Integer, XBlockMixin
 
@@ -19,6 +20,15 @@ class DateTuple(Field):
             return None
 
         return list(value.timetuple())
+
+    def enforce_type(self, value):
+        if isinstance(value, datetime.datetime) or value is None:
+            return value
+
+        if isinstance(value, tuple, time.struct_time):
+            return self.from_json(DateTuple)
+
+        raise TypeError("Value should be datetime, a timetuple or None, not {}".format(type(value)))
 
 
 class CmsBlockMixin(XBlockMixin):

--- a/common/lib/xmodule/xmodule/fields.py
+++ b/common/lib/xmodule/xmodule/fields.py
@@ -68,10 +68,7 @@ class Date(Field):
         """
         if value is None:
             return None
-        if isinstance(value, time.struct_time):
-            # struct_times are always utc
-            return time.strftime('%Y-%m-%dT%H:%M:%SZ', value)
-        elif isinstance(value, datetime.datetime):
+        if isinstance(value, datetime.datetime):
             if value.tzinfo is None or value.utcoffset().total_seconds() == 0:
                 # isoformat adds +00:00 rather than Z
                 return value.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -79,6 +76,8 @@ class Date(Field):
                 return value.isoformat()
         else:
             raise TypeError("Cannot convert {!r} to json".format(value))
+
+    enforce_type = from_json
 
 TIMEDELTA_REGEX = re.compile(r'^((?P<days>\d+?) day(?:s?))?(\s)?((?P<hours>\d+?) hour(?:s?))?(\s)?((?P<minutes>\d+?) minute(?:s)?)?(\s)?((?P<seconds>\d+?) second(?:s)?)?$')
 
@@ -116,6 +115,15 @@ class Timedelta(Field):
             if cur_value > 0:
                 values.append("%d %s" % (cur_value, attr))
         return ' '.join(values)
+
+    def enforce_type(self, value):
+        """
+        Ensure that when set explicitly the Field is set to a timedelta
+        """
+        if isinstance(value, datetime.timedelta) or value is None:
+            return value
+
+        return self.from_json(value)
 
 
 class RelativeTime(Field):
@@ -219,3 +227,12 @@ class RelativeTime(Field):
         if len(stringified) == 7:
             stringified = '0' + stringified
         return stringified
+
+    def enforce_type(self, value):
+        """
+        Ensure that when set explicitly the Field is set to a timedelta
+        """
+        if isinstance(value, datetime.timedelta) or value is None:
+            return None
+
+        return self.from_json(value)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 
 # Our libraries:
--e git+https://github.com/edx/XBlock.git@cfe5c37f98febd9a215d23cb206a25711056a142#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@cba8d788f0c16802b4cc468ccb6dc765b62e55e8#egg=XBlock
 -e git+https://github.com/edx/codejail.git@e3d98f9455#egg=codejail
 -e git+https://github.com/edx/diff-cover.git@v0.2.9#egg=diff_cover
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool


### PR DESCRIPTION
This updates the XBlock dependency to edX/XBlock@cba8d788f0c16802b4cc468ccb6dc765b62e55e8 and add the newly introduced enforce_type methods

**Please see edx/XBlock#200 for rationale and details.**
