### PR TITLE
Edit User

### DIFF
--- a/lms/djangoapps/api_manager/sessions/tests.py
+++ b/lms/djangoapps/api_manager/sessions/tests.py
@@ -143,7 +143,7 @@ class SessionsApiTests(TestCase):
         data = {'username': local_username, 'password': self.test_password}
         response = self.do_post(self.base_sessions_uri, data)
         self.assertEqual(response.status_code, 201)
-        test_uri = self.base_users_uri + str(response.data['user']['id'])
+        test_uri = self.base_sessions_uri + str(response.data['token'])
         response = self.do_delete(test_uri)
         self.assertEqual(response.status_code, 204)
         response = self.do_get(test_uri)

--- a/lms/djangoapps/api_manager/sessions/views.py
+++ b/lms/djangoapps/api_manager/sessions/views.py
@@ -4,7 +4,7 @@
 import logging
 
 from django.conf import settings
-from django.contrib.auth import authenticate, login
+from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth import SESSION_KEY, BACKEND_SESSION_KEY, load_backend
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ObjectDoesNotExist
@@ -151,4 +151,5 @@ class SessionsDetail(APIView):
         user_id = session[SESSION_KEY]
         AUDIT_LOG.info(u"API::User session terminated for user-id - {0}".format(user_id))
         session.flush()
+        logout(request)
         return Response(response_data, status=status.HTTP_204_NO_CONTENT)

--- a/lms/djangoapps/api_manager/users/test_user_password_reset.py
+++ b/lms/djangoapps/api_manager/users/test_user_password_reset.py
@@ -63,7 +63,7 @@ class UserPasswordResetTest(TestCase):
             response = self._do_post_pass_reset_request(
                 pass_reset_url, password='Test.Me64@', secure=True
             )
-            self.assertEqual(response.status_code,  201)
+            self.assertEqual(response.status_code,  200)
 
             #login successful after reset password
             response = self._do_post_request(self.session_url, 'test2', 'Test.Me64@', secure=True)
@@ -88,20 +88,17 @@ class UserPasswordResetTest(TestCase):
         response = self._do_post_pass_reset_request(
             pass_reset_url, password='Test.Me64#', secure=True
         )
-        message = 'Password Reset Successful'
-        self._assert_response(response, status=201, message=message)
+        self._assert_response(response, status=200)
 
         response = self._do_post_pass_reset_request(
             pass_reset_url, password='Test.Me64@', secure=True
         )
-        message = 'Password Reset Successful'
-        self._assert_response(response, status=201, message=message)
+        self._assert_response(response, status=200)
 
         response = self._do_post_pass_reset_request(
             pass_reset_url, password='Test.Me64^', secure=True
         )
-        message = 'Password Reset Successful'
-        self._assert_response(response, status=201, message=message)
+        self._assert_response(response, status=200)
 
         #now use previously used password
         response = self._do_post_pass_reset_request(
@@ -116,15 +113,13 @@ class UserPasswordResetTest(TestCase):
         response = self._do_post_pass_reset_request(
             pass_reset_url, password='Test.Me64&', secure=True
         )
-        message = 'Password Reset Successful'
-        self._assert_response(response, status=201, message=message)
+        self._assert_response(response, status=200)
 
         #now use previously used password
         response = self._do_post_pass_reset_request(
             pass_reset_url, password='Test.Me64!', secure=True
         )
-        message = 'Password Reset Successful'
-        self._assert_response(response, status=201, message=message)
+        self._assert_response(response, status=200)
 
     @override_settings(ADVANCED_SECURITY_CONFIG={'MIN_TIME_IN_DAYS_BETWEEN_ALLOWED_RESETS': 1})
     def test_is_password_reset_too_frequent(self):
@@ -154,8 +149,7 @@ class UserPasswordResetTest(TestCase):
             response = self._do_post_pass_reset_request(
                 pass_reset_url, password='NewP@ses34!', secure=True
             )
-            message = 'Password Reset Successful'
-            self._assert_response(response, status=201, message=message)
+            self._assert_response(response, status=200)
 
     @override_settings(ADVANCED_SECURITY_CONFIG={'MIN_TIME_IN_DAYS_BETWEEN_ALLOWED_RESETS': 0})
     def test_password_reset_rate_limiting_unblock(self):
@@ -191,7 +185,7 @@ class UserPasswordResetTest(TestCase):
             response = self._do_post_pass_reset_request(
                 pass_reset_url, password='Test.Me64@', secure=True
             )
-            self._assert_response(response, status=201)
+            self._assert_response(response, status=200)
 
     def _do_post_request(self, url, username, password, **kwargs):
         """

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -87,6 +87,15 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.data['first_name'], self.test_first_name)
         self.assertEqual(response.data['last_name'], self.test_last_name)
 
+    def test_user_list_post_inactive(self):
+        test_uri = '/api/users'
+        local_username = self.test_username + str(randint(11, 99))
+        data = {'email': self.test_email, 'username': local_username, 'password': self.test_password, 'first_name': self.test_first_name, 'last_name': self.test_last_name, 'is_active': False }
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['is_active'], False)
+
+
     def test_user_list_post_duplicate(self):
         test_uri = '/api/users'
         local_username = self.test_username + str(randint(11, 99))
@@ -112,24 +121,32 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.data['username'], local_username)
         self.assertEqual(response.data['first_name'], self.test_first_name)
         self.assertEqual(response.data['last_name'], self.test_last_name)
+        self.assertEqual(response.data['is_active'], True)
         self.assertEqual(len(response.data['resources']), 2)
 
-    def test_user_detail_delete(self):
+    def test_user_detail_get_undefined(self):
+        test_uri = '/api/users/123456789'
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 404)
+
+    def test_user_detail_post(self):
         test_uri = '/api/users'
         local_username = self.test_username + str(randint(11, 99))
         data = {'email': self.test_email, 'username': local_username, 'password': self.test_password, 'first_name': self.test_first_name, 'last_name': self.test_last_name}
         response = self.do_post(test_uri, data)
         test_uri = test_uri + '/' + str(response.data['id'])
-        response = self.do_delete(test_uri)
-        self.assertEqual(response.status_code, 204)
+        data = {'is_active': False }
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['is_active'], False)
         response = self.do_get(test_uri)
-        self.assertEqual(response.status_code, 404)
-        response = self.do_delete(test_uri)  # User no longer exists, should get a 204 all the same
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['is_active'], False)
 
-    def test_user_detail_get_undefined(self):
-        test_uri = '/api/users/123456789'
-        response = self.do_get(test_uri)
+    def test_user_detail_post_invalid_user(self):
+        test_uri = '/api/users/123124124'
+        data = {'is_active': False }
+        response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 404)
 
     def test_user_groups_list_post(self):


### PR DESCRIPTION
API now provides the ability to edit User data.  Currently only the 'is_active' field can be edited, and we can add more support as the need arises.  Access this behavior via POST /users/(user_id)

In addition, the 'is_active' value can be provided during initial creation of the user, as part of the POST /users payload.  If no value is provided the system default (True) is used.

I removed the DELETE /users/(user_id) operation which we were previously using to set 'is_active' to False.  This was an initial guess on my part at the beginning of the project, but it does not align semantically with how we are using the is_active field in edX.  Since we have no real use case for deleting a user, it's gone until the time comes when we want it back.

Lastly, when I removed the DELETE operation, the unit tests exposed an issue with DELETE /sessions/(session_id) -- I added a call to logout() which appears to have resolved the issue.

@chrisndodge @martynjames @ziafazal @muhhshoaib, FYI
