### PR TITLE
mattdrayer/api-csrftoken: Include CSRF token in the response payload

### DIFF
--- a/lms/djangoapps/api_manager/system/tests.py
+++ b/lms/djangoapps/api_manager/system/tests.py
@@ -69,6 +69,7 @@ class SystemApiTests(TestCase):
         self.assertIsNotNone(response.data['uri'])
         self.assertGreater(len(response.data['uri']), 0)
         self.assertEqual(response.data['uri'], test_uri)
+        self.assertGreater(len(response.data['csrf_token']), 0)
         self.assertIsNotNone(response.data['documentation'])
         self.assertGreater(len(response.data['documentation']), 0)
         self.assertIsNotNone(response.data['name'])

--- a/lms/djangoapps/api_manager/system/views.py
+++ b/lms/djangoapps/api_manager/system/views.py
@@ -1,4 +1,5 @@
 """ BASE API VIEWS """
+from django.middleware.csrf import get_token
 
 from rest_framework import status
 from rest_framework.response import Response
@@ -47,6 +48,7 @@ class ApiDetail(APIView):
         response_data['description'] = "Machine interface for interactions with Open edX."
         response_data['documentation'] = "http://docs.openedxapi.apiary.io"
         response_data['uri'] = base_uri
+        response_data['csrf_token'] = get_token(request)
         response_data['resources'] = []
         response_data['resources'].append({'uri': base_uri + 'courses'})
         response_data['resources'].append({'uri': base_uri + 'groups'})


### PR DESCRIPTION
CSRF Token is now available via GET /api

@chrisndodge
