### PR TITLE
Mattdrayer/api secureapiview fix

### DIFF
--- a/lms/djangoapps/api_manager/permissions.py
+++ b/lms/djangoapps/api_manager/permissions.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from api_manager.utils import get_client_ip_address, address_exists_in_network
 from rest_framework import permissions, generics, filters, pagination, serializers
-
+from rest_framework.views import APIView
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +102,11 @@ class CustomPaginationSerializer(pagination.PaginationSerializer):
     num_pages = serializers.Field(source='paginator.num_pages')
 
 
-class SecureAPIView(generics.ListAPIView):
+class SecureAPIView(APIView):
+    permission_classes = (ApiKeyHeaderPermission, )
+
+
+class SecureListAPIView(generics.ListAPIView):
     """
         Inherited from ListAPIView
     """

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 
 from django.db.models import Q
 
-from api_manager.permissions import SecureAPIView
+from api_manager.permissions import SecureAPIView, SecureListAPIView
 from api_manager.models import GroupProfile
 from .serializers import UserSerializer
 
@@ -114,7 +114,7 @@ def _save_content_position(request, user, course_id, course_descriptor, position
     return saved_content.id
 
 
-class UsersList(SecureAPIView):
+class UsersList(SecureListAPIView):
     """
     ### The UsersList view allows clients to retrieve/append a list of User entities
     - URI: ```/api/users/```


### PR DESCRIPTION
@martynjames @dino-cikatic @dsego @ziafazal -- 

I figured out what was going on with the funky DRF UI behavior.  It seems that the recent change of the SecureAPIView class to support filtering was causing issues with view classes that do not have serializers defined.  For some reason this issue was only manifesting when interacting with the API via the web interface.

I resolved the issue by returning SecureAPIView to its original implementation and creating a new SecureListAPIView class for the classes supporting paging/filtering (ie, UsersList)
