### PR TITLE
Mattdrayer/api authn 401to403

### DIFF
--- a/lms/djangoapps/api_manager/sessions/tests.py
+++ b/lms/djangoapps/api_manager/sessions/tests.py
@@ -105,7 +105,7 @@ class SessionsApiTests(TestCase):
         user.save()
         data = {'username': local_username, 'password': self.test_password}
         response = self.do_post(self.base_sessions_uri, data)
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
 
     def test_session_list_post_invalid_notfound(self):
         data = {'username': 'user_12321452334', 'password': self.test_password}

--- a/lms/djangoapps/api_manager/sessions/views.py
+++ b/lms/djangoapps/api_manager/sessions/views.py
@@ -98,7 +98,7 @@ class SessionsList(SecureAPIView):
                     # add to audit log
                     AUDIT_LOG.info(u"API::User logged in successfully with user-id - {0}".format(user.id))
                 else:
-                    response_status = status.HTTP_401_UNAUTHORIZED
+                    response_status = status.HTTP_403_FORBIDDEN
             else:
                 limiter.tick_bad_request_counter(request)
                 # tick the failed login counters if the user exists in the database


### PR DESCRIPTION
@martynjames, as discussed I've changed the system's response for invalid authentication -- when a call to authenticate() yields None -- from 401 Unauthorized to 403 Forbidden.  @ziafazal, FYI
