### PR TITLE
Mattdrayer/api organizationsusers

### DIFF
--- a/lms/djangoapps/api_manager/organizations/serializers.py
+++ b/lms/djangoapps/api_manager/organizations/serializers.py
@@ -1,8 +1,18 @@
 """ Django REST Framework Serializers """
+from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
 from api_manager.models import Organization
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    """ Serializer for model interactions """
+
+    class Meta:
+        """ Meta class for defining additional serializer characteristics """
+        model = User
+        fields = ('id', 'url', 'username', 'email')
 
 
 class OrganizationSerializer(serializers.ModelSerializer):

--- a/lms/djangoapps/api_manager/organizations/views.py
+++ b/lms/djangoapps/api_manager/organizations/views.py
@@ -1,9 +1,14 @@
 """ ORGANIZATIONS API VIEWS """
-from rest_framework import viewsets
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from api_manager.models import Organization
 
-from .serializers import OrganizationSerializer
+from .serializers import OrganizationSerializer, UserSerializer
 
 
 class OrganizationsViewSet(viewsets.ModelViewSet):
@@ -12,3 +17,28 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
     """
     serializer_class = OrganizationSerializer
     model = Organization
+
+    @action(methods=['get', 'post'])
+    def users(self, request, pk):
+        """
+        Add a User to an Organization
+        """
+        if request.method == 'GET':
+            users = User.objects.filter(organizations=pk)
+            response_data = []
+            if users:
+                for user in users:
+                    serializer = UserSerializer(user)
+                    response_data.append(serializer.data)
+            return Response(response_data, status=status.HTTP_200_OK)
+        else:
+            user_id = request.DATA.get('id')
+            try:
+                user = User.objects.get(id=user_id)
+            except ObjectDoesNotExist:
+                message = 'User {} does not exist'.format(user_id)
+                return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+            organization = self.get_object()
+            organization.users.add(user)
+            organization.save()
+            return Response({}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
@martynjames @dino-cikatic @ziafazal -- support for adding users to an organization.  API operation is:

POST /api/organizations/(id)/users

you can additionally perform a GET on this URI to view the users for an organization.  we can add filtering/paging in a follow-on revision, if needed.
