### PR TITLE
added workgroup users delete support

### DIFF
--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -898,7 +898,7 @@ class UsersWorkgroupsList(SecureListAPIView):
     - URI: ```/api/users/{user_id}/workgroups/```
     - GET: Provides paginated list of workgroups for a user
     To filter the user's workgroup set by course
-    GET ```/api/users/{user_id}/workgroups/?course={course_id}```
+    GET ```/api/users/{user_id}/workgroups/?course_id={course_id}```
     """
 
     serializer_class = BasicWorkgroupSerializer

--- a/lms/djangoapps/projects/tests/test_workgroups.py
+++ b/lms/djangoapps/projects/tests/test_workgroups.py
@@ -29,6 +29,11 @@ class SecureClient(Client):
         kwargs.update({'SERVER_PORT': 443, 'wsgi.url_scheme': 'https'})
         super(SecureClient, self).__init__(*args, **kwargs)
 
+    def delete_with_data(self, *args, **kwargs):
+        """ Construct a DELETE request that includes data."""
+        kwargs.update({'REQUEST_METHOD': 'DELETE'})
+        return super(SecureClient, self).put(*args, **kwargs)
+
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
 @override_settings(EDX_API_KEY=TEST_API_KEY)
@@ -122,6 +127,16 @@ class WorkgroupsApiTests(TestCase):
         }
         response = self.client.delete(uri, headers=headers)
         return response
+
+    def do_delete_with_data(self, uri, data):
+        """Submit an HTTP DELETE request with payload """
+        headers = {
+            'Content-Type': 'application/json',
+            'X-Edx-Api-Key': str(TEST_API_KEY),
+        }
+        response = self.client.delete_with_data(uri, data, headers=headers)
+        return response
+
 
     def test_workgroups_list_post(self):
         data = {
@@ -232,6 +247,37 @@ class WorkgroupsApiTests(TestCase):
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['users'][0]['id'], self.test_user.id)
+
+    def test_workgroups_users_delete(self):
+        data = {
+            'name': self.test_workgroup_name,
+            'project': self.test_project.id
+        }
+        response = self.do_post(self.test_workgroups_uri, data)
+        self.assertEqual(response.status_code, 201)
+        test_workgroup_uri = response.data['url']
+        test_uri = '{}{}/'.format(self.test_workgroups_uri, str(response.data['id']))
+        users_uri = '{}users/'.format(test_uri)
+        data = {"id": self.test_user.id}
+        response = self.do_post(users_uri, data)
+        self.assertEqual(response.status_code, 201)
+        # test if workgroup has exactly one user
+        response = self.do_get(test_workgroup_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['users']), 1)
+
+        # test to delete a user from workgroup
+        data = {"id": self.test_user.id}
+        response = self.do_delete_with_data(users_uri, data)
+        self.assertEqual(response.status_code, 204)
+        response = self.do_get(test_workgroup_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['users']), 0)
+
+        # test to delete an invalide user from workgroup
+        data = {"id": '345345344'}
+        response = self.do_delete_with_data(users_uri, data)
+        self.assertEqual(response.status_code, 400)
 
     def test_workgroups_users_get(self):
         data = {

--- a/lms/djangoapps/projects/views.py
+++ b/lms/djangoapps/projects/views.py
@@ -73,7 +73,7 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
             print workgroup.groups.all()
             return Response({}, status=status.HTTP_201_CREATED)
 
-    @action(methods=['get', 'post'])
+    @action(methods=['get', 'post', 'delete'])
     def users(self, request, pk):
         """
         Add a User to a Workgroup
@@ -86,7 +86,7 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
                     serializer = UserSerializer(user)
                     response_data.append(serializer.data)
             return Response(response_data, status=status.HTTP_200_OK)
-        else:
+        elif request.method == 'POST':
             user_id = request.DATA.get('id')
             try:
                 user = User.objects.get(id=user_id)
@@ -97,6 +97,16 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
             workgroup.users.add(user)
             workgroup.save()
             return Response({}, status=status.HTTP_201_CREATED)
+        else:
+            user_id = request.DATA.get('id')
+            try:
+                user = User.objects.get(id=user_id)
+            except ObjectDoesNotExist:
+                message = 'User {} does not exist'.format(user_id)
+                return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+            workgroup = self.get_object()
+            workgroup.users.remove(user)
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     @link()
     def peer_reviews(self, request, pk):


### PR DESCRIPTION
@mattdrayer 
added delete users from workgroup support to api 
for example to delete user id 1 from a workgroup make a delete request to
/api/workgroups/(workgroup_id)/users/
with this payload
{"id": 1}
