### PR TITLE
get workgroups by course

### DIFF
--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -1474,3 +1474,34 @@ class CoursesApiTests(TestCase):
         # test with bogus course
         response = self.do_get(course_metrics_uri.format(self.test_bogus_course_id))
         self.assertEqual(response.status_code, 404)
+
+    def test_course_workgroups_list(self):
+        projects_uri = '/api/projects/'
+        data = {
+            'course_id': self.test_course_id,
+            'content_id': 'self.test_course_content_id'
+        }
+        response = self.do_post(projects_uri, data)
+        self.assertEqual(response.status_code, 201)
+        project_id = response.data['id']
+
+        test_workgroups_uri = '/api/workgroups/'
+        for i in xrange(1, 12):
+            data = {
+                'name': '{} {}'.format('Workgroup', i),
+                'project': project_id
+            }
+            response = self.do_post(test_workgroups_uri, data)
+            self.assertEqual(response.status_code, 201)
+
+        # get workgroups associated to course
+        test_uri = '/api/courses/{}/workgroups/?page_size=10'.format(self.test_course_id)
+        response = self.do_get(test_uri)
+        self.assertEqual(response.data['count'], 11)
+        self.assertEqual(len(response.data['results']), 10)
+        self.assertEqual(response.data['num_pages'], 2)
+
+        # test with bogus course
+        test_uri = '/api/courses/{}/workgroups/'.format(self.test_bogus_course_id)
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 404)

--- a/lms/djangoapps/api_manager/courses/urls.py
+++ b/lms/djangoapps/api_manager/courses/urls.py
@@ -21,6 +21,7 @@ urlpatterns = patterns(
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/grades/*$', courses_views.CoursesGradesList.as_view()),
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/groups/(?P<group_id>[0-9]+)$', courses_views.CoursesGroupsDetail.as_view()),
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/groups/*$', courses_views.CoursesGroupsList.as_view()),
+    url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/workgroups/*$', courses_views.CoursesWorkgroupsList.as_view()),
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/overview/*$', courses_views.CoursesOverview.as_view()),
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/updates/*$', courses_views.CoursesUpdates.as_view()),
     url(r'^(?P<course_id>[^/]+/[^/]+/[^/]+)/static_tabs/(?P<tab_id>[a-zA-Z0-9/_:]+)$', courses_views.CoursesStaticTabsDetail.as_view()),

--- a/lms/djangoapps/api_manager/courses/views.py
+++ b/lms/djangoapps/api_manager/courses/views.py
@@ -30,8 +30,8 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore import Location, InvalidLocationError
 from api_manager.permissions import SecureAPIView, SecureListAPIView
 from api_manager.utils import generate_base_uri
-from projects.models import Project
-from projects.serializers import ProjectSerializer
+from projects.models import Project, Workgroup
+from projects.serializers import ProjectSerializer, BasicWorkgroupSerializer
 
 from .serializers import CourseModuleCompletionSerializer
 from .serializers import GradeSerializer, CourseLeadersSerializer, CourseCompletionsLeadersSerializer
@@ -1540,3 +1540,24 @@ class CoursesCompletionsLeadersList(SecureAPIView):
         serializer = CourseCompletionsLeadersSerializer(queryset, many=True)
         data['leaders'] = serializer.data  # pylint: disable=E1101
         return Response(data, status=status.HTTP_200_OK)
+
+
+class CoursesWorkgroupsList(SecureListAPIView):
+    """
+    ### The CoursesWorkgroupsList view allows clients to retrieve a list of workgroups
+    associated to a course
+    - URI: ```/api/courses/{course_id}/workgroups/```
+    - GET: Provides paginated list of workgroups associated to a course
+    """
+
+    serializer_class = BasicWorkgroupSerializer
+
+    def get_queryset(self):
+        course_id = self.kwargs['course_id']
+        try:
+            get_course(course_id)
+        except ValueError:
+            raise Http404
+
+        queryset = Workgroup.objects.filter(project__course_id=course_id)
+        return queryset


### PR DESCRIPTION
@mattdrayer @dino-cikatic added new api to get list of workgroups associated with a course using this uri
/api/courses/{course_id}/workgroups/
