### PR TITLE
WIP: mattdrayer/api-position-tree: Current state (debugging)

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -50,7 +50,10 @@ class SequenceModule(SequenceFields, XModule):
 
     def __init__(self, *args, **kwargs):
         super(SequenceModule, self).__init__(*args, **kwargs)
-
+        print "SELF.SYSTEM"
+        print self.system
+        print self.system.__dict__
+        print "END SELF.SYSTEM"
         # if position is specified in system, then use that instead
         if getattr(self.system, 'position', None) is not None:
             self.position = int(self.system.position)

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -14,7 +14,7 @@ from django.core.cache import cache
 from django.test import TestCase, Client
 from django.test.utils import override_settings
 from student.tests.factories import UserFactory
-from student.models import anonymous_id_for_user
+from student.models import anonymous_id_for_user, CourseEnrollment
 from projects.models import Project
 
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
@@ -644,6 +644,18 @@ class UsersApiTests(TestCase):
             data=test_data,
             display_name="Chapter 3"
         )
+        sequential1 = ItemFactory.create(
+            category="sequential",
+            parent_location=chapter3.location,
+            data=test_data,
+            display_name="Sequential 1"
+        )
+        sequential2 = ItemFactory.create(
+            category="sequential",
+            parent_location=chapter3.location,
+            data=test_data,
+            display_name="Sequential 2"
+        )
         test_uri = '/api/users'
         local_username = self.test_username + str(randint(11, 99))
         data = {'email': self.test_email, 'username': local_username, 'password':
@@ -659,11 +671,21 @@ class UsersApiTests(TestCase):
             'position': {
                 'parent_content_id': str(course.id),
                 'child_content_id': str(chapter3.location)
-
             }
         }
         response = self.do_post(test_uri, data=position_data)
         self.assertEqual(response.data['position'], chapter3.id)
+        position_data = {
+            'position': {
+                'parent_content_id': str(chapter3.id),
+                'child_content_id': str(sequential2.location)
+            }
+        }
+        response = self.do_post(test_uri, data=position_data)
+        self.assertEqual(response.data['position'], sequential2.id)
+        response = self.do_get(response.data['uri'])
+        print response.data
+        assert 0
 
     def test_user_courses_detail_post_position_invalid_user(self):
         course = CourseFactory.create()

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -129,6 +129,7 @@ def get_current_child(xmodule):
         pos = xmodule.position - 1
 
     children = xmodule.get_display_items()
+    print "GCC: SELECTED CHILD"
     if 0 <= pos < len(children):
         child = children[pos]
     elif len(children) > 0:
@@ -136,6 +137,10 @@ def get_current_child(xmodule):
         child = children[0]
     else:
         child = None
+    print child
+    if child:
+        print child.__dict__
+    print "END GCC: SELECTED CHILD"
     return child
 
 
@@ -170,19 +175,33 @@ def redirect_to_course_position(course_module):
     urlargs['section'] = section.url_name
     return redirect(reverse('courseware_section', kwargs=urlargs))
 
+from django.db import connection
 
 def save_child_position(seq_module, child_name):
     """
     child_name: url_name of the child
     """
-    print child_name
     for position, c in enumerate(seq_module.get_display_items(), start=1):
         if c.url_name == child_name:
             # Only save if position changed
             if position != seq_module.position:
                 seq_module.position = position
-    # Save this new position to the underlying KeyValueStore
-    seq_module.save()
+                print "PRE-SAVE SEQ MODULE"
+                print seq_module
+                print seq_module.__dict__
+                print "END PRE-SAVE SEQ MODULE"
+                seq_module.save()
+                print "POST-SAVE SEQ MODULE"
+                print seq_module
+                print seq_module.__dict__
+                print "END POST-SAVE SEQ MODULE"
+                print "BEGIN DIRECT SQL QUERY"
+                cursor = connection.cursor()
+                cursor.execute("SELECT * FROM courseware_studentmodule")
+                rows = cursor.fetchall()
+                print rows
+                print "END DIRECT SQL QUERY"
+
 
 
 def chat_settings(course, user):


### PR DESCRIPTION
@chrisndodge -- here's current state of the position tree implementation -- here's the CLI command to get it started:

rake fasttest_lms[lms/djangoapps/api_manager/users/tests.py:UsersApiTests.test_user_courses_detail_post_position_course_as_descriptor]

I've also confirmed that the DRF web UI does not throw errors and results in the same behavior, which is strangely comforting...
