### PR TITLE
Solves problem when course components have non-numeric values for grade-weight

### DIFF
--- a/lms/djangoapps/courseware/grades.py
+++ b/lms/djangoapps/courseware/grades.py
@@ -472,7 +472,7 @@ def get_score(course_id, user, problem_descriptor, module_creator, scores_cache=
             return (None, None)
 
     # Now we re-weight the problem, if specified
-    weight = problem_descriptor.weight
+    weight = float(problem_descriptor.weight)
     if weight is not None:
         if total == 0:
             log.exception("Cannot reweight a problem with zero total points. Problem: " + str(student_module))


### PR DESCRIPTION
Some of the xblock modules store weight as a string value when parsing the value from their xml definition. This code change ensures that we have a numeric value for the calculation, or one will get a ValueError raised, really just a few lines earlier than one would have otherwise received a problem.
