### PR TITLE
added has_organizations filter to users api

### DIFF
--- a/lms/djangoapps/api_manager/permissions.py
+++ b/lms/djangoapps/api_manager/permissions.py
@@ -7,6 +7,8 @@ from api_manager.utils import get_client_ip_address, address_exists_in_network
 from rest_framework import permissions, generics, filters, pagination, serializers
 from rest_framework.views import APIView
 
+from api_manager.utils import str2bool
+from api_manager.models import APIUser as User
 
 log = logging.getLogger(__name__)
 
@@ -95,6 +97,24 @@ class IdsInFilterBackend(filters.BaseFilterBackend):
                 ids = ids.split(",")[:upper_bound]
             return queryset.filter(id__in=ids)
         return queryset
+
+
+class HasOrgsFilterBackend(filters.BaseFilterBackend):
+    """
+        This backend support filtering users with and organization association or not
+    """
+    def filter_queryset(self, request, queryset, view):
+        """
+        Parse querystring base on has_organizations query param
+        """
+        has_orgs = request.QUERY_PARAMS.get('has_organizations', None)
+        if has_orgs:
+            if str2bool(has_orgs):
+                queryset = queryset.filter(organizations__id__gt=0)
+            else:
+                queryset = queryset.exclude(id__in=User.objects.filter(organizations__id__gt=0).
+                                            values_list('id', flat=True))
+        return queryset.distinct()
 
 
 class CustomPaginationSerializer(pagination.PaginationSerializer):

--- a/lms/djangoapps/api_manager/users/serializers.py
+++ b/lms/djangoapps/api_manager/users/serializers.py
@@ -13,7 +13,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         """ Serializer/field specification """
         model = APIUser
-        fields = ("id", "email", "username", "first_name", "last_name", "created", "organizations")
+        fields = ("id", "email", "username", "first_name", "last_name", "created", "is_active", "organizations")
         read_only_fields = ("id", "email", "username")
 
 

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -199,6 +199,44 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 0)
 
+    def test_user_list_get_with_org_filter(self):
+        test_uri = '/api/users'
+        users = []
+        # create a 7 new users
+        for i in xrange(1, 8):
+            data = {
+                'email': 'test{}@example.com'.format(i),
+                'username': 'test_user{}'.format(i),
+                'password': 'test_pass',
+                'first_name': 'John{}'.format(i),
+                'last_name': 'Doe{}'.format(i)
+            }
+
+            response = self.do_post(test_uri, data)
+            self.assertEqual(response.status_code, 201)
+            users.append(response.data['id'])
+
+        # create organizations and add users to them
+        total_orgs = 4
+        for i in xrange(1, total_orgs):
+            data = {
+                'name': '{} {}'.format('Org', i),
+                'display_name': '{} {}'.format('Org display name', i),
+                'users': users[:i]
+            }
+            response = self.do_post(self.org_base_uri, data)
+            self.assertEqual(response.status_code, 201)
+
+        # fetch users without any organization association
+        response = self.do_get('{}?has_organizations=true'.format(test_uri))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 3)
+        self.assertIsNotNone(response.data['results'][0]['is_active'])
+
+        response = self.do_get('{}?has_organizations=false'.format(test_uri))
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(len(response.data['results']), 4)
+
     def test_user_list_post(self):
         test_uri = '/api/users'
         local_username = self.test_username + str(randint(11, 99))

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -12,11 +12,12 @@ from django.conf import settings
 from django.http import Http404
 from django.utils.translation import get_language, ugettext_lazy as _
 from rest_framework import status
+from rest_framework import filters
 from rest_framework.response import Response
 
 
 from api_manager.courseware_access import get_course, get_course_child, get_course_total_score
-from api_manager.permissions import SecureAPIView, SecureListAPIView
+from api_manager.permissions import SecureAPIView, SecureListAPIView, IdsInFilterBackend, HasOrgsFilterBackend
 from api_manager.models import GroupProfile, APIUser as User
 from api_manager.organizations.serializers import OrganizationSerializer
 from api_manager.courses.serializers import CourseModuleCompletionSerializer
@@ -101,7 +102,7 @@ class UsersList(SecureListAPIView):
     """
     ### The UsersList view allows clients to retrieve/append a list of User entities
     - URI: ```/api/users/```
-    - GET: Provides paginated list of users, it supports email, username and id filters
+    - GET: Provides paginated list of users, it supports email, username, has_organizations and id filters
         Possible use cases
         GET /api/users?ids=23
         GET /api/users?ids=11,12,13&page=2
@@ -109,6 +110,10 @@ class UsersList(SecureListAPIView):
         GET /api/users?username={john}
             * email: string, filters user set by email address
             * username: string, filters user set by username
+        GET /api/users?has_organizations={true}
+            * has_organizations: boolean, filters user set with organization association
+        GET /api/users?has_organizations={false}
+            * has_organizations: boolean, filters user set with no organization association
 
         Example JSON output {'count': '25', 'next': 'https://testserver/api/users?page=2', num_pages='3',
         'previous': None, 'results':[]}
@@ -154,6 +159,7 @@ class UsersList(SecureListAPIView):
     """
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    filter_backends = (filters.DjangoFilterBackend, IdsInFilterBackend, HasOrgsFilterBackend)
     filter_fields = ('email', 'username', )
 
     def get(self, request, *args, **kwargs):
@@ -163,7 +169,8 @@ class UsersList(SecureListAPIView):
         email = request.QUERY_PARAMS.get('email', None)
         username = request.QUERY_PARAMS.get('username', None)
         ids = request.QUERY_PARAMS.get('ids', None)
-        if email or username or ids:
+        has_orgs = request.QUERY_PARAMS.get('has_organizations', None)
+        if email or username or ids or has_orgs:
             return self.list(request, *args, **kwargs)
         else:
             return Response({'message': _('Unfiltered request is not allowed.')}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
@mattdrayer @dsego added `has_organizations` filter to /api/users. It can be passed like this
`/api/users?has_organizations=false` to get list of users who has no organization association. 
@martynjames also added `is_active` field to results of users api.
