### PR TITLE
Add python-memcached to the Paver requirements

### DIFF
--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,3 +4,4 @@ psutil==1.2.1
 lazy==1.1
 path.py==3.0.1
 watchdog==0.7.1
+python-memcached==1.48


### PR DESCRIPTION
`pavelib/utils/envs.py` imports `memcache`
