### PR TITLE
ziafazal/api-additional-fields-to-course-detail: added include_fields

### DIFF
--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -383,6 +383,14 @@ class CoursesApiTests(TestCase):
         self.assertEqual(response.data['uri'], confirm_uri)
         self.assertGreater(len(response.data['children']), 0)
 
+    def test_course_content_detail_get_with_extra_fields(self):
+        test_uri = self.base_course_content_uri + '/' + self.test_course_content_id
+        response = self.do_get('{}?include_fields=course_edit_method,edited_by'.format(test_uri))
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(len(response.data), 0)
+        self.assertIsNotNone(response.data['course_edit_method'])
+        self.assertIsNotNone(response.data['edited_by'])
+
     def test_course_content_detail_get_course(self):
         test_uri = self.base_course_content_uri + '/' + self.test_course_id
         response = self.do_get(test_uri)

--- a/lms/djangoapps/api_manager/courses/views.py
+++ b/lms/djangoapps/api_manager/courses/views.py
@@ -104,6 +104,11 @@ def _serialize_content(request, content_key, content_descriptor):
 
     data['start'] = getattr(content_descriptor, 'start', None)
     data['end'] = getattr(content_descriptor, 'end', None)
+    include_fields = request.QUERY_PARAMS.get('include_fields', None)
+    if include_fields:
+        include_fields = include_fields.split(',')
+        for field in include_fields:
+            data[field] = getattr(content_descriptor, field, None)
     return data
 
 


### PR DESCRIPTION
@mattdrayer  @martynjames added `include_fields` parameter to course module detail api to support MCKIN-1961.
