### PR TITLE
ziafazal/api-fix-for-single-user-filter: fixed bug when single value filter is applied

### DIFF
--- a/lms/djangoapps/api_manager/permissions.py
+++ b/lms/djangoapps/api_manager/permissions.py
@@ -93,8 +93,7 @@ class IdsInFilterBackend(filters.BaseFilterBackend):
         upper_bound = getattr(settings, 'API_LOOKUP_UPPER_BOUND', 100)
         ids = request.QUERY_PARAMS.get('ids')
         if ids:
-            if ',' in ids:
-                ids = ids.split(",")[:upper_bound]
+            ids = ids.split(",")[:upper_bound]
             return queryset.filter(id__in=ids)
         return queryset
 

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -187,7 +187,7 @@ class UsersApiTests(TestCase):
         response = self.do_get('{}?ids={}&page=5'.format(test_uri, '2,3,7,11,6,21,34'))
         self.assertEqual(response.status_code, 404)
         # fetch user data by single id
-        response = self.do_get('{}?ids={}'.format(test_uri, '3'))
+        response = self.do_get('{}?ids={}'.format(test_uri, '23'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(len(response.data['results'][0]['organizations']), total_orgs)


### PR DESCRIPTION
@mattdrayer @martynjames fixed bug when single value filter is applied in users api. it would support MCKIN-1956
