### PR TITLE
ziafazal/api-add-filters-to-users-api

### DIFF
--- a/lms/djangoapps/api_manager/groups/views.py
+++ b/lms/djangoapps/api_manager/groups/views.py
@@ -513,7 +513,7 @@ class GroupsCoursesList(SecureAPIView):
 
     def post(self, request, group_id):
         """
-        POST /api/groups/{group_id}/courses/{course_id}
+        POST /api/groups/{group_id}/courses/
         """
         response_data = {}
         try:

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -551,6 +551,10 @@ class UsersApiTests(TestCase):
         response = self.do_post(user_groups_uri, data)
         self.assertEqual(response.status_code, 201)
 
+        course_id = unicode(self.course.id)
+        response = self.do_post('{}/{}/courses/'.format(group_url, group_id), {'course_id': course_id})
+        self.assertEqual(response.status_code, 201)
+
         response = self.do_get(fail_user_id_group_uri)
         self.assertEqual(response.status_code, 404)
 
@@ -562,6 +566,13 @@ class UsersApiTests(TestCase):
         response = self.do_get(group_type_uri)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['groups']), 1)
+
+        course = {'course': course_id}
+        group_type_uri = '{}?{}'.format(user_groups_uri, urlencode(course))
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['groups']), 1)
+        self.assertEqual(response.data['groups'][0]['id'], group_id)
 
         error_type_uri = '{}?type={}'.format(user_groups_uri, 'error_type')
         response = self.do_get(error_type_uri)

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -552,6 +552,8 @@ class UsersGroupsList(SecureAPIView):
     - URI: ```/api/users/{user_id}/groups/```
     - GET: Returns a JSON representation (array) of the set of related Group entities
         * type: Set filtering parameter
+        * course: Set filtering parameter to groups associated to a course or courses
+        - URI: ```/api/users/{user_id}/groups/?type=series,seriesX&course=slashes%3AMITx%2B999%2BTEST_COURSE```
     - POST: Append a Group entity to the set of related Group entities for the specified User
         * group_id: __required__, The identifier for the Group being added
     - POST Example:
@@ -599,12 +601,17 @@ class UsersGroupsList(SecureAPIView):
         except ObjectDoesNotExist:
             return Response({}, status=status.HTTP_404_NOT_FOUND)
         group_type = request.QUERY_PARAMS.get('type', None)
+        course = request.QUERY_PARAMS.get('course', None)
         response_data = {}
         base_uri = generate_base_uri(request)
         response_data['uri'] = base_uri
         groups = existing_user.groups.all()
         if group_type:
-            groups = groups.filter(groupprofile__group_type=group_type)
+            group_type = group_type.split(',')
+            groups = groups.filter(groupprofile__group_type__in=group_type)
+        if course:
+            course = course.split(',')
+            groups = groups.filter(coursegrouprelationship__course_id__in=course)
         response_data['groups'] = []
         for group in groups:
             group_profile = GroupProfile.objects.get(group_id=group.id)


### PR DESCRIPTION
@mattdrayer @martynjames added `course` filter to user groups api and modified `type` filter to accept multiple values
`/server/users/{user_id}/groups/?type=series,seriesX&course=slashes%3AMITx%2B999%2BTEST_COURSE``
It would support MCKIN-1985
