### PR TITLE
Add inline_discussions_cohorting_default and cohorted_inline_discussions in course settings

### DIFF
--- a/common/djangoapps/course_groups/cohorts.py
+++ b/common/djangoapps/course_groups/cohorts.py
@@ -74,6 +74,8 @@ def is_commentable_cohorted(course_key, commentable_id):
         # top level discussions have to be manually configured as cohorted
         # (default is not)
         ans = commentable_id in course.cohorted_discussions
+    elif course.inline_discussions_cohorting_default == False:
+        ans = commentable_id in course.cohorted_inline_discussions
     else:
         # inline discussions are cohorted by default
         ans = True

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -678,6 +678,33 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         return set(config.get("cohorted_discussions", []))
 
     @property
+    def inline_discussions_cohorting_default(self):
+        """
+        This allow to change the default behavior of inline discussions cohorting. By setting this to
+        False, all inline discussions are non-cohorted.
+
+        """
+        config = self.cohort_config
+        if config is None:
+            return True
+
+        return bool(config.get("inline_discussions_cohorting_default", True))
+
+    @property
+    def cohorted_inline_discussions(self):
+        """
+        When inline_discussions_cohorting_default is False, this is used to set a discussion cohorted.
+        Return the set of inline discussions that are explicitly cohorted. It may be the empty set.
+        By adding an inline discussion id in this setting, it becomes cohorted.
+
+        """
+        config = self.cohort_config
+        if config is None:
+            return set()
+
+        return set(config.get("cohorted_inline_discussions", []))
+
+    @property
     def is_newish(self):
         """
         Returns if the course has been flagged as new. If


### PR DESCRIPTION
A simple way to support noncohorted inline discussions for a cohorted course. The idea is to not edit the course setting manually but through the xblock discussion... but we can set that manually through advanded settings (cohort_config):

```
   "noncohorted_inline_discussions": [
        "2ff9533b31214c82b385d45ccfe73243"
    ],
```
