### PR TITLE
ziafazal/api-filter-user-groups-by-data: added xblock_id filter

### DIFF
--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -535,7 +535,13 @@ class UsersApiTests(TestCase):
 
         group_url = self.groups_base_uri
         group_name = 'Alpha Group'
-        data = {'name': group_name, 'type': 'Engineer'}
+        group_xblock_id = 'location:GroupTester+TG101+1+group-project+079879fdabae47f6848f38a58f41f2c7'
+        group_test_value = 'values 2'
+        group_data = {
+            'xblock_id': group_xblock_id,
+            'key2': group_test_value
+        }
+        data = {'name': group_name, 'type': 'Engineer', 'data': group_data}
         response = self.do_post(group_url, data)
         group_id = response.data['id']
         user_groups_uri = '{}/groups'.format(test_uri)
@@ -573,6 +579,31 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['groups']), 1)
         self.assertEqual(response.data['groups'][0]['id'], group_id)
+
+        group_data_filters = {
+            'data__xblock_id': group_xblock_id,
+            'data__key2': group_test_value
+        }
+        group_type_uri = '{}?{}'.format(user_groups_uri, urlencode(group_data_filters))
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['groups']), 1)
+
+        group_type_uri = '{}?{}'.format(user_groups_uri, urlencode({'data__key2': group_test_value}))
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['groups']), 1)
+
+        group_type_uri = '{}?{}'.format(user_groups_uri, urlencode({'data__xblock_id': 'invalid_value',
+                                                                    'data__key2': group_test_value}))
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['groups']), 0)
+
+        group_type_uri = '{}?{}'.format(user_groups_uri, urlencode({'data__key2': 'invalid_value'}))
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['groups']), 0)
 
         error_type_uri = '{}?type={}'.format(user_groups_uri, 'error_type')
         response = self.do_get(error_type_uri)

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -39,7 +39,7 @@ from api_manager.courseware_access import get_course, get_course_child, get_cour
 from api_manager.permissions import SecureAPIView, SecureListAPIView, IdsInFilterBackend, HasOrgsFilterBackend
 from api_manager.models import GroupProfile, APIUser as User
 from api_manager.organizations.serializers import OrganizationSerializer
-from api_manager.utils import generate_base_uri
+from api_manager.utils import generate_base_uri, dict_has_items, extract_data_params
 from projects.serializers import BasicWorkgroupSerializer
 from .serializers import UserSerializer, UserCountByCitySerializer, UserRolesSerializer
 
@@ -572,6 +572,7 @@ class UsersGroupsList(SecureAPIView):
         * type: Set filtering parameter
         * course: Set filtering parameter to groups associated to a course or courses
         - URI: ```/api/users/{user_id}/groups/?type=series,seriesX&course=slashes%3AMITx%2B999%2BTEST_COURSE```
+        * xblock_id: filters group data and returns those groups where xblock_id matches given xblock_id
     - POST: Append a Group entity to the set of related Group entities for the specified User
         * group_id: __required__, The identifier for the Group being added
     - POST Example:
@@ -620,6 +621,7 @@ class UsersGroupsList(SecureAPIView):
             return Response({}, status=status.HTTP_404_NOT_FOUND)
         group_type = request.QUERY_PARAMS.get('type', None)
         course = request.QUERY_PARAMS.get('course', None)
+        data_params = extract_data_params(request)
         response_data = {}
         base_uri = generate_base_uri(request)
         response_data['uri'] = base_uri
@@ -630,6 +632,8 @@ class UsersGroupsList(SecureAPIView):
         if course:
             course = course.split(',')
             groups = groups.filter(coursegrouprelationship__course_id__in=course)
+        if data_params:
+            groups = [group for group in groups if dict_has_items(group.groupprofile.data, data_params)]
         response_data['groups'] = []
         for group in groups:
             group_profile = GroupProfile.objects.get(group_id=group.id)

--- a/lms/djangoapps/api_manager/utils.py
+++ b/lms/djangoapps/api_manager/utils.py
@@ -2,6 +2,7 @@
 
 import socket
 import struct
+import json
 
 
 def address_exists_in_network(ip_address, net_n_bits):
@@ -59,3 +60,30 @@ def is_int(value):
         return False
 
 
+def dict_has_items(obj, items):
+    """
+    examine a `obj` for given `items`. if all `items` are found in `obj`
+    return True otherwise false. where `obj` is a dictionary and `items`
+    is list of dictionaries
+    """
+    has_items = False
+    if isinstance(obj, basestring):
+        obj = json.loads(obj)
+    for item in items:
+        for lookup_key, lookup_val in item.iteritems():
+            if lookup_key in obj and obj[lookup_key] == lookup_val:
+                has_items = True
+            else:
+                return False
+    return has_items
+
+
+def extract_data_params(request):
+    """
+    extracts all query params which starts with data__
+    """
+    data_params = []
+    for key, val in request.QUERY_PARAMS.iteritems():
+        if key.startswith('data__'):
+            data_params.append({key[6:]: val})
+    return data_params


### PR DESCRIPTION
@mattdrayer @martynjames added `xblock_id` filter to user groups api. It would support MCKIN-2023. filter can be applied like this 
`/api/server/users/{user_id}/groups/?xblock_id={url_encoded_xblock_id}`
