### PR TITLE
xblock-settings: Add service to allow access to settings from XBlocks (WIP)

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -24,6 +24,7 @@ from path import path
 from datetime import datetime
 from pytz import UTC
 
+from lms.lib.xblock.runtime import SettingsService
 from importlib import import_module
 from xmodule.errortracker import null_error_tracker, exc_info_to_str
 from xmodule.mako_module import MakoDescriptorSystem
@@ -538,7 +539,9 @@ class MongoModuleStore(ModuleStoreWriteBase):
         if apply_cached_metadata:
             cached_metadata = self._get_cached_metadata_inheritance_tree(course_key)
 
-        services = {}
+        services = {
+            'settings': SettingsService(),
+        }
         if self.i18n_service:
             services["i18n"] = self.i18n_service
 
@@ -811,7 +814,9 @@ class MongoModuleStore(ModuleStoreWriteBase):
             definition_data = {}
 
         if system is None:
-            services = {}
+            services = {
+                'settings': SettingsService(),
+            }
             if self.i18n_service:
                 services["i18n"] = self.i18n_service
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -25,7 +25,7 @@ from courseware.access import has_access, get_user_role
 from courseware.masquerade import setup_masquerade
 from courseware.model_data import FieldDataCache, DjangoKeyValueStore
 from lms.lib.xblock.field_data import LmsFieldData
-from lms.lib.xblock.runtime import LmsModuleSystem, unquote_slashes, quote_slashes
+from lms.lib.xblock.runtime import LmsModuleSystem, SettingsService, unquote_slashes, quote_slashes
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from psychometrics.psychoanalyze import make_psychometrics_data_update_handler
@@ -525,6 +525,7 @@ def get_module_system_for_user(user, field_data_cache,
         get_real_user=user_by_anonymous_id,
         services={
             'i18n': ModuleI18nService(),
+            'settings': SettingsService(),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor.runtime,

--- a/lms/lib/xblock/runtime.py
+++ b/lms/lib/xblock/runtime.py
@@ -211,12 +211,21 @@ class UserTagsService(object):
                                            self.runtime.course_id, key, value)
 
 
+class SettingsService(object):
+    """
+    Allow to access the server settings
+    """
+    def get(self, setting_name):
+        return getattr(settings, setting_name)
+
+
 class LmsModuleSystem(LmsHandlerUrls, LmsCourse, LmsUser, ModuleSystem):  # pylint: disable=abstract-method
     """
     ModuleSystem specialized to the LMS
     """
     def __init__(self, **kwargs):
         services = kwargs.setdefault('services', {})
+        services['settings'] = SettingsService()
         services['user_tags'] = UserTagsService(self)
         services['partitions'] = LmsPartitionService(
             user_tags_service=services['user_tags'],


### PR DESCRIPTION
Work in progress, initial version to allow access to settings from XBlocks.

To do:
- Figure out why we need to add the service in the ModuleStore object init - adding it to the LMSModuleSystem should be enough, but from the Ooyala XBlock `student_view()`, only the i18n service seem to be listed as a service.
- Better define the way to set settings meant for XBlocks - maybe a specific dict instead of the whole LMS settings environment?
- Add tests
