### PR TITLE
ziafazal/api-fix-bug-progress-tab: Made no of completions as percentage

### DIFF
--- a/lms/djangoapps/api_manager/courses/serializers.py
+++ b/lms/djangoapps/api_manager/courses/serializers.py
@@ -34,7 +34,7 @@ class CourseLeadersSerializer(serializers.Serializer):
         formats points_scored to two decimal points
         """
         points_scored = obj['points_scored'] or 0
-        return round(points_scored, 2)
+        return int(round(points_scored))
 
 
 class CourseCompletionsLeadersSerializer(serializers.Serializer):
@@ -43,7 +43,18 @@ class CourseCompletionsLeadersSerializer(serializers.Serializer):
     username = serializers.CharField(source='user__username')
     title = serializers.CharField(source='user__profile__title')
     avatar_url = serializers.CharField(source='user__profile__avatar_url')
-    completions = serializers.IntegerField()
+    completions = serializers.SerializerMethodField('get_completion_percentage')
+
+    def get_completion_percentage(self, obj):
+        """
+        formats get completions as percentage
+        """
+        total_completions = self.context['total_completions'] or 0
+        completions = obj['completions'] or 0
+        completion_percentage = 0
+        if total_completions > 0:
+            completion_percentage = int(round(100 * completions / total_completions))
+        return completion_percentage
 
 
 class CourseSerializer(serializers.Serializer):

--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -1571,7 +1571,7 @@ class CoursesApiTests(TestCase):
         self.assertEqual(len(response.data['leaders']), 3)
         self.assertEqual(response.data['course_avg'], 3.4)
         self.assertEqual(response.data['position'], 2)
-        self.assertEqual(response.data['points'], 4.5)
+        self.assertEqual(response.data['points'], 5)
 
         # Filter by user who has never accessed a course module
         test_user = UserFactory.create(username="testusernocoursemod")
@@ -1656,7 +1656,7 @@ class CoursesApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['leaders']), 3)
         self.assertEqual(response.data['position'], 1)
-        self.assertEqual(response.data['completions'], 10)
+        self.assertEqual(response.data['completions'], 40)
 
         # test with bogus course
         test_uri = '{}/{}/metrics/completions/leaders/'.format(self.base_courses_uri, self.test_bogus_course_id)


### PR DESCRIPTION
@dsego @mattdrayer This should fix the issue MCKIN-1944. Now api is sending completions as percentage instead of total completions by user. Also sending proficiency points as integers to make it consistent with apros .
