### PR TITLE
mattdrayer/api-group-name-edit: Support name edit on POST

### DIFF
--- a/lms/djangoapps/api_manager/groups/tests.py
+++ b/lms/djangoapps/api_manager/groups/tests.py
@@ -266,9 +266,10 @@ class GroupsApiTests(TestCase):
         group_id = response.data['id']
         test_uri = response.data['uri']
         self.assertEqual(response.status_code, 201)
+        group_name = 'Updated Name'
         group_type = 'seriesX'
         data = {
-            'name': self.test_group_name,
+            'name': group_name,
             'type': group_type,
             'data': {
                 'display_name': 'My updated series'
@@ -277,7 +278,7 @@ class GroupsApiTests(TestCase):
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['id'], group_id)
-        self.assertEqual(response.data['name'], self.test_group_name)
+        self.assertEqual(response.data['name'], group_name)
         self.assertEqual(response.data['uri'], test_uri)
 
     def test_group_detail_post_invalid_group(self):

--- a/lms/djangoapps/api_manager/groups/views.py
+++ b/lms/djangoapps/api_manager/groups/views.py
@@ -148,12 +148,18 @@ class GroupsDetail(SecureAPIView):
         except ObjectDoesNotExist:
             return Response({}, status.HTTP_404_NOT_FOUND)
         profile, _ = GroupProfile.objects.get_or_create(group_id=group_id)
+        group_name = request.DATA.get('name', None)
+        if group_name:
+            formatted_name = '{:04d}: {}'.format(existing_group.id, group_name)
+            existing_group.name = formatted_name
+            profile.name = group_name
         group_type = request.DATA.get('type', None)
         if group_type:
             profile.group_type = group_type
         data = request.DATA.get('data', None)
         if data:
             profile.data = json.dumps(data)
+        existing_group.save()
         profile.save()
         response_data['id'] = existing_group.id
         response_data['name'] = profile.name


### PR DESCRIPTION
@dsego -- added support for updating the group name via POST /groups/{id} -- take a look and let me know if you need anything else
