### PR TITLE
mattdrayer/api-workgroup-user-check: Ensure no existing workgroup assign...

### DIFF
--- a/lms/djangoapps/projects/tests/test_workgroups.py
+++ b/lms/djangoapps/projects/tests/test_workgroups.py
@@ -91,6 +91,11 @@ class WorkgroupsApiTests(TestCase):
             content_id=self.test_course_content_id
         )
 
+        self.test_project2 = Project.objects.create(
+            course_id=self.test_course_id,
+            content_id=unicode(self.test_group_project.scope_ids.usage_id)
+        )
+
         self.test_user_email = str(uuid.uuid4())
         self.test_user_username = str(uuid.uuid4())
         self.test_user = User.objects.create(
@@ -274,6 +279,60 @@ class WorkgroupsApiTests(TestCase):
         cohort = get_cohort_by_name(self.test_course.id, cohort_name, CourseUserGroup.WORKGROUP)
         self.assertIsNotNone(cohort)
         self.assertTrue(is_user_in_cohort(cohort, self.test_user.id, CourseUserGroup.WORKGROUP))
+
+
+    def test_workgroups_users_post_preexisting_workgroup(self):
+        data = {
+            'name': self.test_workgroup_name,
+            'project': self.test_project.id
+        }
+        response = self.do_post(self.test_workgroups_uri, data)
+        self.assertEqual(response.status_code, 201)
+        test_uri = '{}{}/'.format(self.test_workgroups_uri, str(response.data['id']))
+        users_uri = '{}users/'.format(test_uri)
+        data = {"id": self.test_user.id}
+        response = self.do_post(users_uri, data)
+        self.assertEqual(response.status_code, 201)
+        data = {
+            'name': "Workgroup 2",
+            'project': self.test_project.id
+        }
+        response = self.do_post(self.test_workgroups_uri, data)
+        self.assertEqual(response.status_code, 201)
+        test_uri = '{}{}/'.format(self.test_workgroups_uri, str(response.data['id']))
+        users_uri = '{}users/'.format(test_uri)
+        data = {"id": self.test_user.id}
+        response = self.do_post(users_uri, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_workgroups_users_post_preexisting_project(self):
+        data = {
+            'name': self.test_workgroup_name,
+            'project': self.test_project.id
+        }
+        response = self.do_post(self.test_workgroups_uri, data)
+        self.assertEqual(response.status_code, 201)
+        test_uri = '{}{}/'.format(self.test_workgroups_uri, str(response.data['id']))
+        users_uri = '{}users/'.format(test_uri)
+        data = {"id": self.test_user.id}
+        response = self.do_post(users_uri, data)
+        self.assertEqual(response.status_code, 201)
+
+        # Second project created in setUp, adding a new workgroup
+        data = {
+            'name': "Workgroup 2",
+            'project': self.test_project2.id
+        }
+        response = self.do_post(self.test_workgroups_uri, data)
+        self.assertEqual(response.status_code, 201)
+        test_uri = '{}{}/'.format(self.test_workgroups_uri, str(response.data['id']))
+        users_uri = '{}users/'.format(test_uri)
+
+        # Assign the test user to the alternate project/workgroup
+        data = {"id": self.test_user.id}
+        response = self.do_post(users_uri, data)
+        self.assertEqual(response.status_code, 400)
+
 
     def test_workgroups_users_post_with_cohort_backfill(self):
         """

--- a/lms/djangoapps/projects/views.py
+++ b/lms/djangoapps/projects/views.py
@@ -175,7 +175,21 @@ class WorkgroupsViewSet(viewsets.ModelViewSet):
             except ObjectDoesNotExist:
                 message = 'User {} does not exist'.format(user_id)
                 return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+
             workgroup = self.get_object()
+
+            # Ensure the user is not already assigned to a workgroup for this project
+            existing_workgroups = Workgroup.objects.filter(users=user).filter(project=workgroup.project)
+            if len(existing_workgroups):
+                message = 'User {} already assigned to a workgroup for this project'.format(user_id)
+                return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+
+            # Ensure the user is not already assigned to a project for this course
+            existing_projects = Project.objects.filter(course_id=workgroup.project.course_id).filter(workgroups__users__id=user.id)
+            if len(existing_projects):
+                message = 'User {} already assigned to a project for this course'.format(user_id)
+                return Response({"detail": message}, status.HTTP_400_BAD_REQUEST)
+
             workgroup.users.add(user)
             workgroup.save()
 


### PR DESCRIPTION
...ment

In response to PR #4364, this PR introduces a check for a preexisting workgroup assignment.  I opted to handle the assignment validation in the view, versus the model, although I suppose we could shift the logic there if need be.  @martynjames @antoviaque @aboudreault -- take a look and let me know what you think.
