### PR TITLE
ziafazal/api-fix-bug-progress-tab: fix progress

### DIFF
--- a/lms/djangoapps/api_manager/courseware_access.py
+++ b/lms/djangoapps/api_manager/courseware_access.py
@@ -80,3 +80,15 @@ def get_course_total_score(course_summary):
             if section['section_total']:
                 score += section['section_total'][1]
     return score
+
+
+def get_course_leaf_nodes(course_key, detached_categories):
+    """
+    Get count of the leaf nodes with ability to exclude some categories
+    """
+    nodes = []
+    verticals = modulestore().get_items(course_key, category='vertical')
+    for vertical in verticals:
+        nodes.extend([unit.location for unit in vertical.get_children()
+                      if getattr(unit, 'category') not in detached_categories])
+    return nodes

--- a/lms/djangoapps/api_manager/groups/tests.py
+++ b/lms/djangoapps/api_manager/groups/tests.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from random import randint
 import uuid
 import json
+import mock
 from urllib import urlencode
 
 from django.core.cache import cache
@@ -32,6 +33,10 @@ class SecureClient(Client):
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
 @override_settings(EDX_API_KEY=TEST_API_KEY)
+@mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,
+                                                   'ADVANCED_SECURITY': False,
+                                                   'PREVENT_CONCURRENT_LOGINS': False
+                                                   })
 class GroupsApiTests(TestCase):
     """ Test suite for Groups API views """
 

--- a/lms/djangoapps/api_manager/organizations/tests.py
+++ b/lms/djangoapps/api_manager/organizations/tests.py
@@ -6,6 +6,7 @@ Run these tests @ Devstack:
 """
 import json
 import uuid
+import mock
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -30,6 +31,10 @@ class SecureClient(Client):
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
 @override_settings(EDX_API_KEY=TEST_API_KEY)
+@mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,
+                                                   'ADVANCED_SECURITY': False,
+                                                   'PREVENT_CONCURRENT_LOGINS': False
+                                                   })
 class OrganizationsApiTests(TestCase):
 
     """ Test suite for Users API views """

--- a/lms/djangoapps/api_manager/sessions/test_login_ratelimit.py
+++ b/lms/djangoapps/api_manager/sessions/test_login_ratelimit.py
@@ -21,7 +21,8 @@ TEST_API_KEY = str(uuid.uuid4())
 
 
 @override_settings(EDX_API_KEY=TEST_API_KEY)
-@patch.dict("django.conf.settings.FEATURES", {'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': False})
+@patch.dict("django.conf.settings.FEATURES", {'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': False,
+                                              'PREVENT_CONCURRENT_LOGINS': False})
 class SessionApiRateLimitingProtectionTest(TestCase):
     """
     Test api_manager.session.login.ratelimit

--- a/lms/djangoapps/api_manager/sessions/test_security.py
+++ b/lms/djangoapps/api_manager/sessions/test_security.py
@@ -20,8 +20,9 @@ TEST_API_KEY = str(uuid.uuid4())
 
 
 @override_settings(EDX_API_KEY=TEST_API_KEY)
-@patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': True})
-@patch.dict("django.conf.settings.FEATURES", {'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True})
+@patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': True,
+                                              'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True,
+                                              'PREVENT_CONCURRENT_LOGINS': False})
 class SessionApiSecurityTest(TestCase):
     """
     Test api_manager.session.session_list view

--- a/lms/djangoapps/api_manager/sessions/tests.py
+++ b/lms/djangoapps/api_manager/sessions/tests.py
@@ -7,6 +7,7 @@ Run these tests @ Devstack:
 """
 from random import randint
 import uuid
+import mock
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -25,6 +26,10 @@ class SecureClient(Client):
 
 
 @override_settings(EDX_API_KEY=TEST_API_KEY)
+@mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,
+                                                   'ADVANCED_SECURITY': False,
+                                                   'PREVENT_CONCURRENT_LOGINS': False
+                                                   })
 class SessionsApiTests(TestCase):
     """ Test suite for Sessions API views """
 

--- a/lms/djangoapps/api_manager/test_permissions.py
+++ b/lms/djangoapps/api_manager/test_permissions.py
@@ -4,6 +4,7 @@ Run these tests @ Devstack:
 """
 from random import randint
 import uuid
+import mock
 
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -12,6 +13,10 @@ TEST_API_KEY = "123456ABCDEF"
 
 
 @override_settings(API_ALLOWED_IP_ADDRESSES=['127.0.0.1', '10.0.2.2', '192.168.0.0/24'])
+@mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,
+                                                   'ADVANCED_SECURITY': False,
+                                                   'PREVENT_CONCURRENT_LOGINS': False
+                                                   })
 class PermissionsTests(TestCase):
     """ Test suite for Permissions helper classes """
     def setUp(self):

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -35,7 +35,6 @@ from notification_prefs import NOTIFICATION_PREF_KEY
 
 TEST_API_KEY = str(uuid.uuid4())
 
-
 class SecureClient(Client):
 
     """ Django test client using a "secure" connection. """
@@ -58,7 +57,7 @@ class UsersApiTests(TestCase):
     def setUp(self):
         self.test_server_prefix = 'https://testserver'
         self.test_username = str(uuid.uuid4())
-        self.test_password = str(uuid.uuid4())
+        self.test_password = 'Test.Me64!'
         self.test_email = str(uuid.uuid4()) + '@test.org'
         self.test_first_name = str(uuid.uuid4())
         self.test_last_name = str(uuid.uuid4())
@@ -85,11 +84,6 @@ class UsersApiTests(TestCase):
             due=datetime(2016, 5, 16, 14, 30),
             display_name="View_Sequence"
         )
-        self.test_project = Project.objects.create(
-            course_id=unicode(self.course.id),
-            content_id=unicode(self.course_content.scope_ids.usage_id)
-        )
-
         self.course2 = CourseFactory.create(display_name="TEST COURSE2", org='TESTORG2')
         self.course2_content = ItemFactory.create(
             category="videosequence",
@@ -97,10 +91,6 @@ class UsersApiTests(TestCase):
             data=self.test_course_data,
             due=datetime(2016, 5, 16, 14, 30),
             display_name="View_Sequence2"
-        )
-        self.second_test_project = Project.objects.create(
-            course_id=unicode(self.course2.id),
-            content_id=unicode(self.course2_content.scope_ids.usage_id)
         )
 
         self.user = UserFactory()
@@ -169,7 +159,7 @@ class UsersApiTests(TestCase):
             data = {
                 'email': 'test{}@example.com'.format(i),
                 'username': 'test_user{}'.format(i),
-                'password': 'test_pass',
+                'password': self.test_password,
                 'first_name': 'John{}'.format(i),
                 'last_name': 'Doe{}'.format(i)
             }
@@ -234,7 +224,7 @@ class UsersApiTests(TestCase):
             data = {
                 'email': 'test{}@example.com'.format(i),
                 'username': 'test_user{}'.format(i),
-                'password': 'test_pass',
+                'password': self.test_password,
                 'first_name': 'John{}'.format(i),
                 'last_name': 'Doe{}'.format(i)
             }
@@ -1285,12 +1275,24 @@ class UsersApiTests(TestCase):
         # create anonymous user
         anonymous_id = anonymous_id_for_user(self.user, self.course.id)
         for i in xrange(1, 12):
-            project_id = self.test_project.id
-            if i > 7:  # set to other project
-                project_id = self.second_test_project.id
+            course = CourseFactory.create(
+                display_name="TEST COURSE {}".format(i),
+            )
+
+            course_content = ItemFactory.create(
+                category="videosequence",
+                parent_location=course.location,
+                data=self.test_course_data,
+                display_name="View_Sequence"
+            )
+
+            test_project = Project.objects.create(
+                course_id=unicode(course.id),
+                content_id=unicode(course_content.scope_ids.usage_id)
+            )
             data = {
                 'name': 'Workgroup ' + str(i),
-                'project': project_id
+                'project': test_project.id
             }
             response = self.do_post(test_workgroups_uri, data)
             self.assertEqual(response.status_code, 201)
@@ -1308,11 +1310,11 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.data['num_pages'], 2)
 
         # test with course_id filter and integer user id
-        course_id = {'course_id': unicode(self.course.id)}
+        course_id = {'course_id': unicode(course.id)}
         response = self.do_get('{}/{}/workgroups/?{}'.format(self.users_base_uri, user_id, urlencode(course_id)))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['count'], 7)
-        self.assertEqual(len(response.data['results']), 7)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(len(response.data['results']), 1)
         self.assertIsNotNone(response.data['results'][0]['name'])
         self.assertIsNotNone(response.data['results'][0]['project'])
 


### PR DESCRIPTION
@mattdrayer @martynjames @dsego 
1) Fixed progress value by using total modules in the course as denominator. 
2) Changed completion avg to percentage. We have to change it on apros accordingly
3) Fixed bug in serialiser which was causing multiple calls to `auth_user` in CourseModuleCompletionList as reported by @chrisndodge  
