### PR TITLE
mattdrayer/api-session-del-user-check: Guard against some negative cases

### DIFF
--- a/lms/djangoapps/api_manager/sessions/test_login_ratelimit.py
+++ b/lms/djangoapps/api_manager/sessions/test_login_ratelimit.py
@@ -16,6 +16,7 @@ from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
 from django.core.cache import cache
 from student.tests.factories import UserFactory
+from student.models import UserProfile
 
 TEST_API_KEY = str(uuid.uuid4())
 
@@ -34,6 +35,9 @@ class SessionApiRateLimitingProtectionTest(TestCase):
         self.user = UserFactory.build(username='test', email='test@edx.org')
         self.user.set_password('test_password')
         self.user.save()
+        profile = UserProfile(user=self.user)
+        profile.city = 'Boston'
+        profile.save()
 
         # Create the test client
         self.client = Client()

--- a/lms/djangoapps/api_manager/sessions/test_security.py
+++ b/lms/djangoapps/api_manager/sessions/test_security.py
@@ -14,6 +14,7 @@ from django.test.client import Client
 from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
 from django.core.cache import cache
+from student.models import UserProfile
 from student.tests.factories import UserFactory
 
 TEST_API_KEY = str(uuid.uuid4())
@@ -35,6 +36,9 @@ class SessionApiSecurityTest(TestCase):
         self.user = UserFactory.build(username='test', email='test@edx.org')
         self.user.set_password('test_password')
         self.user.save()
+        profile = UserProfile(user=self.user)
+        profile.city = 'Boston'
+        profile.save()
 
         # Create the test client
         self.client = Client()

--- a/lms/djangoapps/api_manager/sessions/tests.py
+++ b/lms/djangoapps/api_manager/sessions/tests.py
@@ -151,3 +151,8 @@ class SessionsApiTests(TestCase):
         self.assertEqual(response.status_code, 204)
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 404)
+
+    def test_session_detail_delete_invalid_session(self):
+        test_uri = self.base_sessions_uri + "214viouadblah124324blahblah"
+        response = self.do_delete(test_uri)
+        self.assertEqual(response.status_code, 204)


### PR DESCRIPTION
@chrisndodge, here's an enhanced session delete operation which guards against the negative cases we discussed.  I was also going to include a guard against a bad session engine specification, but it appears the middleware catches that problem prior to the execution of the view.
