### PR TITLE
xblock-no-anonymous: Fail early if the XBlock view is called anonymously

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -803,6 +803,9 @@ def xblock_view(request, course_id, usage_id, view_name):
         resources: A list of tuples where the first element is the resource hash, and
             the second is the resource description
     """
+    if not request.user.is_authenticated():
+        raise PermissionDenied
+
     instance = _get_module_by_usage_id(request, course_id, usage_id)
 
     try:


### PR DESCRIPTION
We currently serve anonymous XBlock requests, but most XBlocks assume that the user is logged in, which can generate a lot of errors when the user is accessed or when an XBlock ajax callback is queried. Fail early to only
get one error per page load, and prevent displaying the XBlock altogether when the LMS doesn't find an active user session.

@chrisndodge @andyparsons Are you ok with this approach? I'm hoping we will be better able to identify the users/sessions which are causing these errors this way, by never displaying XBlocks when the user loses his LMS session. It should make this issue easier to spot, which would help to identify a pattern, as the whole course content will then be empty, rather than having only some of XBlocks not displaying. This should also reduce the number of these errors without silencing them, as we will only get one per page load.
