### PR TITLE
ziafazal/ability-to-set-grade-event: ability to store grades only for a specific score type

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -372,7 +372,13 @@ def get_module_system_for_user(user, field_data_cache,
     def publish(block, event_type, event):
         """A function that allows XModules to publish events."""
         if event_type == 'grade':
-            handle_grade_event(block, event_type, event)
+            grade_on_proficiency = settings.FEATURES.get('GRADING_ON_PROFICIENCY_SCORE', False)
+            if grade_on_proficiency:
+                score_type = event.get('score_type')
+                if score_type == 'proficiency':
+                    handle_grade_event(block, event_type, event)
+            else:
+                handle_grade_event(block, event_type, event)
         elif event_type == 'progress':
             # expose another special case event type which gets sent
             # into the CourseCompletions models

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -270,6 +270,9 @@ FEATURES = {
     # nonzero grade cutoff is met
     'SHOW_PROGRESS_SUCCESS_BUTTON': False,
 
+    # Grade only if score type is proficiency
+    'GRADING_ON_PROFICIENCY_SCORE': False,
+
     # Whether an xBlock publishing a 'grade' event should be considered a 'progress' event as well
     'MARK_PROGRESS_ON_GRADING_EVENT': False
 }


### PR DESCRIPTION
@mattdrayer @martynjames @chrisndodge . Added ability to store grades only for a specific score type to support MCKIN-2068. It can be controlled by `GRADING_ON_PROFICIENCY_SCORE` setting.
