### PR TITLE
Add cohorted_threads_privacy cohort setting

### DIFF
--- a/common/djangoapps/course_groups/cohorts.py
+++ b/common/djangoapps/course_groups/cohorts.py
@@ -44,6 +44,16 @@ def is_course_cohorted(course_key):
     return courses.get_course_by_id(course_key).is_cohorted
 
 
+def get_cohorted_threads_privacy(course_key):
+    """
+    Given a course key, return the cohorted threads privacy setting.
+
+    Raises:
+       Http404 if the course doesn't exist.
+    """
+    return courses.get_course_by_id(course_key).cohorted_threads_privacy
+
+
 def get_cohort_id(user, course_key, group_type=CourseUserGroup.COHORT):
     """
     Given a course key and a user, return the id of the cohort that user is

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -678,6 +678,18 @@ class CourseDescriptor(CourseFields, SequenceDescriptor):
         return set(config.get("cohorted_discussions", []))
 
     @property
+    def cohorted_threads_privacy(self):
+        """
+        Return whether the course cohorted threads pricacy. If the privacy is set to 'cohort-only',
+        a user that is not in a cohort will only see threads that are not cohorted.
+        """
+        config = self.cohort_config
+        if config is None:
+            return 'public'
+
+        return config.get("cohorted_threads_privacy", 'public')
+
+    @property
     def inline_discussions_cohorting_default(self):
         """
         This allow to change the default behavior of inline discussions cohorting. By setting this to

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -14,6 +14,7 @@ from edxmako.shortcuts import render_to_response
 from courseware.courses import get_course_with_access
 from course_groups.cohorts import CourseUserGroup
 from course_groups.cohorts import (is_course_cohorted, get_cohort, get_cohort_id,
+                                   get_cohorted_threads_privacy,
                                    is_commentable_cohorted, get_cohorted_commentables,
                                    get_course_cohorts, get_cohort_by_id)
 from courseware.access import has_access
@@ -79,6 +80,8 @@ def get_threads(request, course_id, discussion_id=None, per_page=THREADS_PER_PAG
                                       group_type=CourseUserGroup.ANY, allow_multiple=True)
             user_cohort_ids = [str(cohort.id) for cohort in user_cohorts]
             group_ids = user_cohort_ids
+            if not group_ids and get_cohorted_threads_privacy(course_id) == 'cohort-only':
+                default_query_params['exclude_groups'] = True
     else:
         group_ids.append(group_id)
 


### PR DESCRIPTION
Add cohorted_threads_privacy cohort setting: a user that is not in any cohort will only see non-cohorted threads.
