### PR TITLE
mattdrayer/api-gradebook-generator-fix: Added session dummy to mock

### DIFF
--- a/common/djangoapps/util/request.py
+++ b/common/djangoapps/util/request.py
@@ -92,4 +92,7 @@ class RequestMockWithoutMiddleware(RequestMock):
     """
     def request(self, **request):
         "Construct a generic request object."
-        return RequestFactory.request(self, **request)
+        request = RequestFactory.request(self, **request)
+        if not hasattr(request, 'session'):
+            request.session = {}
+        return request


### PR DESCRIPTION
@chrisndodge can you take a quick look at this, thanks -- just adding a fake session container to the mock request object

@fredsmith, FYI, fix on the way
