### PR TITLE
mattdrayer/ascii-exception-fix: Support unicode characters

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -90,7 +90,7 @@ def anonymous_id_for_user(user, course_id, save=True):
     hasher.update(settings.SECRET_KEY)
     hasher.update(unicode(user.id))
     if course_id:
-        hasher.update(course_id.to_deprecated_string())
+        hasher.update(unicode(course_id).encode('utf-8'))
     digest = hasher.hexdigest()
 
     if not hasattr(user, '_anonymous_id'):


### PR DESCRIPTION
@antoviaque --- here is the corresponding fix to Braden's upstream change for the "ascii codec" unit test failures.
