### PR TITLE
test-fix-settings-service: Fix failing import due to settings service

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -24,7 +24,6 @@ from path import path
 from datetime import datetime
 from pytz import UTC
 
-from lms.lib.xblock.runtime import SettingsService
 from importlib import import_module
 from xmodule.errortracker import null_error_tracker, exc_info_to_str
 from xmodule.mako_module import MakoDescriptorSystem
@@ -42,6 +41,7 @@ from xmodule.tabs import StaticTab, CourseTabList
 from xblock.core import XBlock
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.exceptions import HeartbeatFailure
+from xmodule.settings_service import SettingsService
 
 log = logging.getLogger(__name__)
 
@@ -539,6 +539,8 @@ class MongoModuleStore(ModuleStoreWriteBase):
         if apply_cached_metadata:
             cached_metadata = self._get_cached_metadata_inheritance_tree(course_key)
 
+        # TODO: This needs to be moved out of the common lib, but without it some of the
+        # XBlock instantiations don't get the settings service included - why?
         services = {
             'settings': SettingsService(),
         }
@@ -814,6 +816,8 @@ class MongoModuleStore(ModuleStoreWriteBase):
             definition_data = {}
 
         if system is None:
+            # TODO: This needs to be moved out of the common lib, but without it some of the
+            # XBlock instantiations don't get the settings service included - why?
             services = {
                 'settings': SettingsService(),
             }

--- a/common/lib/xmodule/xmodule/settings_service.py
+++ b/common/lib/xmodule/xmodule/settings_service.py
@@ -1,0 +1,9 @@
+"""
+XBlock service to allow to access the server settings
+"""
+
+from django.conf import settings
+
+class SettingsService(object):
+    def get(self, setting_name):
+        return getattr(settings, setting_name)

--- a/lms/lib/xblock/runtime.py
+++ b/lms/lib/xblock/runtime.py
@@ -11,6 +11,7 @@ from user_api import user_service
 from xmodule.modulestore.django import modulestore
 from xmodule.x_module import ModuleSystem
 from xmodule.partitions.partitions_service import PartitionService
+from xmodule.settings_service import SettingsService
 
 
 def _quote_slashes(match):
@@ -209,14 +210,6 @@ class UserTagsService(object):
 
         return user_service.set_course_tag(self._get_current_user(),
                                            self.runtime.course_id, key, value)
-
-
-class SettingsService(object):
-    """
-    Allow to access the server settings
-    """
-    def get(self, setting_name):
-        return getattr(settings, setting_name)
 
 
 class LmsModuleSystem(LmsHandlerUrls, LmsCourse, LmsUser, ModuleSystem):  # pylint: disable=abstract-method


### PR DESCRIPTION
Move it to the xmodule library to address the circular import, until we
figure out how to avoid the xmodule inclusion.
