### PR TITLE
Revised fix: prevent unicode errors without changing anonymous ID digest

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -90,7 +90,7 @@ def anonymous_id_for_user(user, course_id, save=True):
     hasher.update(settings.SECRET_KEY)
     hasher.update(unicode(user.id))
     if course_id:
-        hasher.update(unicode(course_id).encode('utf-8'))
+        hasher.update(course_id.to_deprecated_string().encode('utf-8'))
     digest = hasher.hexdigest()
 
     if not hasattr(user, '_anonymous_id'):


### PR DESCRIPTION
This fixes some new test failures introduced by #230. 

When I suggested the previous fix, I took the opportunity to change from the old `.to_deprecated_string()` to the new opaque key unicode representation. But unfortunately that changes the anonymous ID construction (see below). Although the keys are stored in a table and thus are actually backwards compatible even if the digest computation gets changed, there are [a couple of unit tests](https://github.com/edx/edx-platform/blob/4f5d8b30de625fe16687d1828401e24c23351442/lms/djangoapps/courseware/tests/test_module_render.py#L819) and [a runtime warning in the logs](https://github.com/edx/edx-platform/blob/4f5d8b30de625fe16687d1828401e24c23351442/common/djangoapps/student/models.py#L120) that occur if the digest format ever changes. (When to_deprecated_string is eventually completely removed, it will be necessary to change the digest format and remove the tests/warnings about the change, though it should not actually cause any problems.)

This is a hotfix for solutions, with the corresponding upstream change [pending review](https://github.com/edx/edx-platform/pull/5386).

Demonstration of the problem:

```
>>> from opaque_keys.edx.locations import Location
>>> from opaque_keys.edx.locations import SlashSeparatedCourseKey
>>> course_id=SlashSeparatedCourseKey('MITx', '6.00x', '2012_Fall')
>>> import hashlib
>>> hashlib.md5(course_id.to_deprecated_string()).hexdigest()
'06a589e79fcb3477b9c856fb9276ac4b'
>>> hashlib.md5(unicode(course_id).encode('utf-8')).hexdigest()
'9427687cf459834279dba6d888e6f763'
>>> course_id.to_deprecated_string()
u'MITx/6.00x/2012_Fall'
>>> unicode(course_id)
u'slashes:MITx+6.00x+2012_Fall'
>>> hashlib.md5(course_id.to_deprecated_string().encode('utf-8')).hexdigest()
'06a589e79fcb3477b9c856fb9276ac4b'
```
