### PR TITLE
Don't consider complete if proforma is 0; cannot possibly be

### DIFF
--- a/lms/djangoapps/api_manager/organizations/tests.py
+++ b/lms/djangoapps/api_manager/organizations/tests.py
@@ -344,7 +344,7 @@ class OrganizationsApiTests(TestCase):
 
     def test_organizations_metrics_get_courses_filter(self):
         users = []
-        for i in xrange(1, 10):
+        for i in xrange(1, 12):
             data = {
                 'email': 'test{}@example.com'.format(i),
                 'username': 'test_user{}'.format(i),
@@ -369,8 +369,11 @@ class OrganizationsApiTests(TestCase):
                 StudentGradebook.objects.create(user=user, grade=0.72, proforma_grade=0.78, course_id=course3.id)
             elif i < 9:
                 StudentGradebook.objects.create(user=user, grade=0.94, proforma_grade=0.67, course_id=course1.id)
-            else:
+            elif i < 11:
                 StudentGradebook.objects.create(user=user, grade=0.90, proforma_grade=0.91, course_id=course2.id)
+            else:
+                # Not started student - should be considered incomplete
+                StudentGradebook.objects.create(user=user, grade=0.00, proforma_grade=0.00, course_id=course2.id)
 
         data = {
             'name': self.test_organization_name,

--- a/lms/djangoapps/api_manager/organizations/views.py
+++ b/lms/djangoapps/api_manager/organizations/views.py
@@ -44,7 +44,7 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
                 courses.append(get_course_key(course_string))
             org_user_grades = org_user_grades.filter(course_id__in=courses)
         users_grade_complete_count = org_user_grades\
-            .filter(proforma_grade__lte=F('grade') + grade_complete_match_range).count()
+            .filter(proforma_grade__lte=F('grade') + grade_complete_match_range, proforma_grade__gt=0).count()
         response_data['users_grade_complete_count'] = users_grade_complete_count
         return Response(response_data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
@mattdrayer - Please review - I made a slight change to the new organizations metrics view - when pro forma grade is 0, then we don't want to consider this as graded_complete (but grade=0=proforma)
