### PR TITLE
mattdrayer/api-org-course-avg: Added average grade to response

### DIFF
--- a/lms/djangoapps/api_manager/organizations/tests.py
+++ b/lms/djangoapps/api_manager/organizations/tests.py
@@ -339,6 +339,7 @@ class OrganizationsApiTests(TestCase):
         metrics_uri = '{}metrics/'.format(test_uri)
         response = self.do_get(metrics_uri)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['users_grade_average'], 0.838)
         self.assertEqual(response.data['users_grade_complete_count'], 4)
 
 
@@ -391,7 +392,7 @@ class OrganizationsApiTests(TestCase):
         metrics_uri = '{}metrics/'.format(test_uri)
         response = self.do_get(metrics_uri)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['users_grade_complete_count'], 5)
+        self.assertEqual(response.data['users_grade_complete_count'], 6)
 
         courses = {'courses': unicode(course1.id)}
         filtered_metrics_uri = '{}?{}'.format(metrics_uri, urlencode(courses))
@@ -399,8 +400,14 @@ class OrganizationsApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['users_grade_complete_count'], 2)
 
+        courses = {'courses': unicode(course2.id)}
+        filtered_metrics_uri = '{}?{}'.format(metrics_uri, urlencode(courses))
+        response = self.do_get(filtered_metrics_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['users_grade_complete_count'], 4)
+
         courses = {'courses': '{},{}'.format(course1.id, course2.id)}
         filtered_metrics_uri = '{}?{}'.format(metrics_uri, urlencode(courses))
         response = self.do_get(filtered_metrics_uri)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['users_grade_complete_count'], 5)
+        self.assertEqual(response.data['users_grade_complete_count'], 6)

--- a/lms/djangoapps/api_manager/organizations/views.py
+++ b/lms/djangoapps/api_manager/organizations/views.py
@@ -4,7 +4,7 @@
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import F
+from django.db.models import Avg, F
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -43,9 +43,14 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
             for course_string in courses_filter:
                 courses.append(get_course_key(course_string))
             org_user_grades = org_user_grades.filter(course_id__in=courses)
+
+        users_grade_average = org_user_grades.aggregate(Avg('grade'))
+        response_data['users_grade_average'] = float('{0:.3f}'.format(float(users_grade_average['grade__avg'])))
+
         users_grade_complete_count = org_user_grades\
             .filter(proforma_grade__lte=F('grade') + grade_complete_match_range, proforma_grade__gt=0).count()
         response_data['users_grade_complete_count'] = users_grade_complete_count
+
         return Response(response_data, status=status.HTTP_200_OK)
 
     @action(methods=['get', 'post'])


### PR DESCRIPTION
@dino-cikatic, added average grade to the response for /organizations/(id)/metrics -- note that the value represents the average grade across all users matching the query criteria.  So, if you filter by multiple course_id values (courses=course1,course2,course3) you will get the average grade across these three courses.  Filtering by a single value will provide you with the average for those organization users, for the specified course.
