### PR TITLE
mattdrayer/rebase-fixes: Truncate floats in leaderboard statistics

### DIFF
--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -1743,7 +1743,7 @@ class CoursesApiTests(TestCase):
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['leaders']), 4)
-        self.assertEqual(response.data['course_avg'], 14)
+        self.assertEqual(response.data['course_avg'], 13.889)
 
         # without count filter and user_id
         test_uri = '{}/{}/metrics/completions/leaders/?user_id={}'.format(self.base_courses_uri, self.test_course_id,
@@ -1752,7 +1752,7 @@ class CoursesApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['leaders']), 3)
         self.assertEqual(response.data['position'], 2)
-        self.assertEqual(response.data['completions'], 19)
+        self.assertEqual(response.data['completions'], 19.444)
 
         # with skipleaders filter
         test_uri = '{}/{}/metrics/completions/leaders/?user_id={}&skipleaders=true'.format(self.base_courses_uri,
@@ -1762,7 +1762,7 @@ class CoursesApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(response.data.get('leaders', None))
         self.assertIsNone(response.data.get('position', None))
-        self.assertEqual(response.data['completions'], 19)
+        self.assertEqual(response.data['completions'], 19.444)
 
         # test with bogus course
         test_uri = '{}/{}/metrics/completions/leaders/'.format(self.base_courses_uri, self.test_bogus_course_id)

--- a/lms/djangoapps/api_manager/courses/views.py
+++ b/lms/djangoapps/api_manager/courses/views.py
@@ -1632,13 +1632,13 @@ class CoursesMetricsCompletionsLeadersList(SecureAPIView):
             completion_percentage = 0
             if total_possible_completions > 0:
                 completion_percentage = 100 * user_completions/total_possible_completions
-            data['completions'] = completion_percentage
+            data['completions'] = float('{0:.3f}'.format(float(completion_percentage)))
 
         total_users = CourseEnrollment.users_enrolled_in(course_key).exclude(id__in=exclude_users).count()
         if total_users and total_actual_completions:
             course_avg = total_actual_completions / float(total_users)
             course_avg = 100 * course_avg / total_possible_completions  # avg in percentage
-        data['course_avg'] = course_avg
+        data['course_avg'] = float('{0:.3f}'.format(float(course_avg)))
         if not skipleaders:
             queryset = queryset.filter(user__is_active=True).values('user__id', 'user__username',
                                                                     'user__profile__title',


### PR DESCRIPTION
@martynjames -- had to update one failing test in the api_manager suite, I believe due to the removal of the rounding in the completions leaderboard.  I've modified the operation to return a truncated float value with three decimal places -- let me know if you'd like something different.
