### PR TITLE
slashes: formatted ids removed

### DIFF
--- a/lms/djangoapps/api_manager/groups/tests.py
+++ b/lms/djangoapps/api_manager/groups/tests.py
@@ -896,9 +896,6 @@ class GroupsApiTests(TestCase):
         response = self.do_post(self.base_groups_uri, data)
         self.assertEqual(response.status_code, 201)
         test_uri = response.data['uri'] + '/courses'
-        data = {'course_id': "slashes:invalid+course+id"}
-        response = self.do_post(test_uri, data)
-        self.assertEqual(response.status_code, 404)
         data = {'course_id': "invalid/course/id"}
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 404)

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -760,7 +760,7 @@ class UsersApiTests(TestCase):
         response = self.do_post(test_uri, data)
         user_id = response.data['id']
         test_uri = '{}/{}/courses'.format(test_uri, str(user_id))
-        data = {'course_id': 'slashes:234asdfapsdf+2sdfs+sdf'}
+        data = {'course_id': '234asdfapsdf/2sdfs/sdf'}
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 404)
         data = {'course_id': 'really-invalid-course-id-oh-boy-watch-out'}
@@ -1084,7 +1084,7 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.status_code, 204)
 
     def test_user_course_grades_course_not_found(self):
-        test_uri = '{}/{}/courses/slashes:some+unknown+course/grades'.format(self.users_base_uri, self.user.id)
+        test_uri = '{}/{}/courses/some/unknown/course/grades'.format(self.users_base_uri, self.user.id)
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 404)
 

--- a/lms/djangoapps/gradebook/management/commands/generate_gradebook_entries.py
+++ b/lms/djangoapps/gradebook/management/commands/generate_gradebook_entries.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                 "--course_ids",
                 dest="course_ids",
                 help="List of courses for which to generate grades",
-                metavar="slashes:first+course+id,slashes:second+course+id"
+                metavar="first/course/id,second/course/id"
             ),
             make_option(
                 "-u",

--- a/lms/djangoapps/gradebook/management/commands/tests/test_generate_gradebook_entries.py
+++ b/lms/djangoapps/gradebook/management/commands/tests/test_generate_gradebook_entries.py
@@ -139,7 +139,7 @@ class GenerateGradebookEntriesTests(TestCase):
         Test the gradebook entry generator
         """
         # Set up the command context
-        course_ids = '{},slashes:bogus+course+id'.format(self.course.id)
+        course_ids = '{},bogus/course/id'.format(self.course.id)
         user_ids = '{}'.format(self.users[0].id)
         current_entries = StudentGradebook.objects.all()
         self.assertEqual(len(current_entries), 0)

--- a/lms/djangoapps/progress/management/commands/generate_progress_entries.py
+++ b/lms/djangoapps/progress/management/commands/generate_progress_entries.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                 "--course_ids",
                 dest="course_ids",
                 help="List of courses for which to generate progress",
-                metavar="slashes:first+course+id,slashes:second+course+id"
+                metavar="first/course/id,second/course/id"
             ),
             make_option(
                 "-u",

--- a/lms/djangoapps/progress/management/commands/tests/test_generate_progress_entries.py
+++ b/lms/djangoapps/progress/management/commands/tests/test_generate_progress_entries.py
@@ -110,7 +110,7 @@ class GenerateProgressEntriesTests(TestCase):
         Test the progress entry generator
         """
         # Set up the command context
-        course_ids = '{},slashes:bogus+course+id'.format(self.course.id)
+        course_ids = '{},bogus/course/id'.format(self.course.id)
         user_ids = '{}'.format(self.users[0].id)
         current_entries = StudentProgress.objects.all()
         self.assertEqual(len(current_entries), 0)


### PR DESCRIPTION
@mattdrayer - This is mostly changes in tests to use the new format of ids (a couple of metavar documentation instances too)
