### PR TITLE
opaquekeys-update: Parse the short-lived slashes and locations syntax

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -30,6 +30,6 @@
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@release-2014-09-12T14.26#egg=edx-ora2
--e git+https://github.com/edx/opaque-keys.git@a7c506befdf9b97bbbb6961e0b0c7fa4807003eb#egg=opaque-keys
+-e git+https://github.com/edx/opaque-keys.git@cba8e23f53ff3ce9d1f45871986c8974576185c0#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n-tools


### PR DESCRIPTION
Update hash to include the fix for opaque keys parsing of slashes and location syntaxes.
