### PR TITLE
mattdrayer/gradebook-script-rename: Fixed conflicted command name

### DIFF
--- a/lms/djangoapps/api_manager/management/commands/migrate_courseids_v2.py
+++ b/lms/djangoapps/api_manager/management/commands/migrate_courseids_v2.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         for cg in course_groups:
             current_course_id = cg.course_id
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             cg.course_id = oldstyle_course_id
             cg.save()
         log.warning('Complete!')
@@ -32,12 +32,12 @@ class Command(BaseCommand):
         for ccg in course_content_groups:
             current_course_id = ccg.course_id
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             ccg.course_id = oldstyle_course_id
 
             current_content_id = ccg.content_id
             oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
+            oldstyle_content_id = oldstyle_content_id.replace("+", "/")
             ccg.content_id = oldstyle_content_id
             ccg.save()
         log.warning('Complete!')
@@ -47,18 +47,18 @@ class Command(BaseCommand):
         for cmc in course_module_completions:
             current_course_id = cmc.course_id
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             cmc.course_id = oldstyle_course_id
 
             current_content_id = cmc.content_id
             oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
+            oldstyle_content_id = oldstyle_content_id.replace("+", "/")
             cmc.content_id = oldstyle_content_id
 
             if cmc.stage is not None:
                 current_stage = cmc.stage
                 oldstyle_stage = current_stage.replace("slashes:", "")
-                oldstyle_stage = current_stage.replace("+", "/")
+                oldstyle_stage = oldstyle_stage.replace("+", "/")
                 cmc.stage = oldstyle_stage
                 cmc.save()
         log.warning('Complete!')

--- a/lms/djangoapps/gradebook/management/commands/migrate_gradebook_courseids_v2.py
+++ b/lms/djangoapps/gradebook/management/commands/migrate_gradebook_courseids_v2.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         for gbe in gradebook_entries:
             current_course_id = unicode(gbe.course_id)
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             gbe.course_id = CourseKey.from_string(oldstyle_course_id)
             gbe.save()
         log.warning('Complete!')
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         for he in history_entries:
             current_course_id = unicode(he.course_id)
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             he.course_id = oldstyle_course_id
             he.save()
         log.warning('Complete!')

--- a/lms/djangoapps/gradebook/management/commands/tests/test_migrate_gradebook_courseids_v2.py
+++ b/lms/djangoapps/gradebook/management/commands/tests/test_migrate_gradebook_courseids_v2.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from gradebook import models as gradebook_models
-from gradebook.management.commands import migrate_courseids_v2
+from gradebook.management.commands import migrate_gradebook_courseids_v2
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
@@ -75,7 +75,7 @@ class MigrateCourseIdsTests(TestCase):
 
 
         # Run the data migration
-        migrate_courseids_v2.Command().handle()
+        migrate_gradebook_courseids_v2.Command().handle()
 
 
         # Confirm that the data has been properly migrated

--- a/lms/djangoapps/projects/management/commands/migrate_project_courseids_v2.py
+++ b/lms/djangoapps/projects/management/commands/migrate_project_courseids_v2.py
@@ -21,12 +21,12 @@ class Command(BaseCommand):
         for project in projects:
             current_course_id = project.course_id
             oldstyle_course_id = current_course_id.replace("slashes:", "")
-            oldstyle_course_id = current_course_id.replace("+", "/")
+            oldstyle_course_id = oldstyle_course_id.replace("+", "/")
             project.course_id = oldstyle_course_id
 
             current_content_id = project.content_id
             oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
+            oldstyle_content_id = oldstyle_content_id.replace("+", "/")
             project.content_id = oldstyle_content_id
             project.save()
         log.warning('Complete!')
@@ -34,29 +34,32 @@ class Command(BaseCommand):
         log.warning('Migrating Workgroup Reviews...')
         workgroup_reviews = WorkgroupReview.objects.all()
         for wr in workgroup_reviews:
-            current_content_id = wr.content_id
-            oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
-            wr.content_id = oldstyle_content_id
-            wr.save()
+            if wr.content_id is not None:
+                current_content_id = wr.content_id
+                oldstyle_content_id = current_content_id.replace("slashes:", "")
+                oldstyle_content_id = oldstyle_content_id.replace("+", "/")
+                wr.content_id = oldstyle_content_id
+                wr.save()
         log.warning('Complete!')
 
         log.warning('Migrating Workgroup Peer Reviews...')
         workgroup_peer_reviews = WorkgroupPeerReview.objects.all()
         for wpr in workgroup_reviews:
-            current_content_id = wpr.content_id
-            oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
-            wpr.content_id = oldstyle_content_id
-            wpr.save()
+            if wpr.content_id is not None:
+                current_content_id = wpr.content_id
+                oldstyle_content_id = current_content_id.replace("slashes:", "")
+                oldstyle_content_id = oldstyle_content_id.replace("+", "/")
+                wpr.content_id = oldstyle_content_id
+                wpr.save()
         log.warning('Complete!')
 
         log.warning('Migrating Workgroup Submission Reviews...')
         workgroup_submission_reviews = WorkgroupSubmissionReview.objects.all()
         for wsr in workgroup_submission_reviews:
-            current_content_id = wsr.content_id
-            oldstyle_content_id = current_content_id.replace("slashes:", "")
-            oldstyle_content_id = current_content_id.replace("+", "/")
-            wsr.content_id = oldstyle_content_id
-            wsr.save()
+            if wsr.content_id is not None:
+                current_content_id = wsr.content_id
+                oldstyle_content_id = current_content_id.replace("slashes:", "")
+                oldstyle_content_id = oldstyle_content_id.replace("+", "/")
+                wsr.content_id = oldstyle_content_id
+                wsr.save()
         log.warning('Complete!')


### PR DESCRIPTION
@martynjames -- renamed the gradebook data migration script to avoid a conflict w/ the one from api_manager.  I've also added some protection around missing content ids in the projects app that @fredsmith encountered during a migration run.
