### PR TITLE
Added xblock-utils to the requirements.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -8,3 +8,4 @@
 -e git+https://github.com/edx-solutions/xblock-group-project.git@61ec5fde38393d403ea86e8e87937a37856d4958#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-discussion.git@a4ccc0e18b0aca14a3219afaa6ec6e8036821320#egg=xblock-discussion
 -e git+https://github.com/edx-solutions/xblock-adventure.git@30894de41ee7efe7d5b6400086463d12995893f7#egg=xblock-adventure
+-e git+https://github.com/edx-solutions/xblock-utils.git@7d7201fb2b0bfc8e5d13905d1cedf88335ab4a93#egg=xblock-utils


### PR DESCRIPTION
Xblock-utils is needed by one or more of the Xblocks we're using. I've added it to the requirements. It's possible this would be better handled by placing it in the package configuration of one or more of the other xblocks, but then we'll have to sync the hashes up among all of them each time.
