### PR TITLE
mattdrayer/api-time-series-fix: Use backticks instead of quotes

### DIFF
--- a/lms/djangoapps/api_manager/utils.py
+++ b/lms/djangoapps/api_manager/utils.py
@@ -152,7 +152,7 @@ def get_time_series_data(queryset, start, end, interval='days', date_field='crea
     _, end = get_interval_bounds(end, interval.rstrip('s'))
 
     if date_field_model:
-        date_field = '"{}"."{}"'.format(date_field_model._meta.db_table, date_field)
+        date_field = '`{}`.`{}`'.format(date_field_model._meta.db_table, date_field)
 
     sql = {
         'mysql': {
@@ -169,7 +169,7 @@ def get_time_series_data(queryset, start, end, interval='days', date_field='crea
         }
     }
     interval_sql = sql[engine][interval]
-    where_clause = '{} BETWEEN "{}" and "{}"'.format(date_field, start, end)
+    where_clause = '{} BETWEEN "{}" AND "{}"'.format(date_field, start, end)
     aggregate_data = queryset.extra(select={'d': interval_sql}, where=[where_clause]).order_by().values('d').\
         annotate(agg=aggregate)
 
@@ -182,4 +182,5 @@ def get_time_series_data(queryset, start, end, interval='days', date_field='crea
         value = data.get(dt_key, 0)
         series.append((dt_key, value,))
         dt_key += relativedelta(**{interval: 1})
+
     return series


### PR DESCRIPTION
@martynjames -- took a bit of time to get to the bottom of things, but the issue with the time series data stemmed from a MySQL syntax issue -- changing one of the query clauses to use backticks instead of quotes resolved the issue.  Apparently the quotes are valid for sqlite, which explains why the unit tests did not catch the problem.  Not sure if you're able to repro on your end, but take a look and let me know either way -- we should at least be able to see how it looks in the QA environment once merged.

@ziafazal, FYI on the syntax change
