### PR TITLE
ziafazal/api-org-groups-relationship: added groups

### DIFF
--- a/lms/djangoapps/api_manager/groups/serializers.py
+++ b/lms/djangoapps/api_manager/groups/serializers.py
@@ -1,0 +1,53 @@
+import json
+from django.core.exceptions import ObjectDoesNotExist
+
+from django.contrib.auth.models import Group
+from rest_framework import serializers
+
+
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    """ Serializer for model interactions """
+    name = serializers.SerializerMethodField('get_group_name')
+    type = serializers.SerializerMethodField('get_group_type')
+    data = serializers.SerializerMethodField('get_group_data')
+
+    def get_group_name(self, group):
+        """
+        Group name is actually stored on the profile record, in order to
+        allow for duplicate name values in the system.
+        """
+        try:
+            group_profile = group.groupprofile
+            if group_profile and group_profile.name:
+                return group_profile.name
+            else:
+                return group.name
+        except ObjectDoesNotExist:
+            return group.name
+
+    def get_group_type(self, group):
+        """
+        Loads data from group profile
+        """
+        try:
+            group_profile = group.groupprofile
+            return group_profile.group_type
+        except ObjectDoesNotExist:
+            return None
+
+    def get_group_data(self, group):
+        """
+        Loads data from group profile
+        """
+        try:
+            group_profile = group.groupprofile
+            if group_profile.data:
+                return json.loads(group_profile.data)
+        except ObjectDoesNotExist:
+            return None
+
+    class Meta:
+        """ Meta class for defining additional serializer characteristics """
+        model = Group
+        fields = ('id', 'url', 'name', 'type', 'data')
+

--- a/lms/djangoapps/api_manager/organizations/tests.py
+++ b/lms/djangoapps/api_manager/organizations/tests.py
@@ -256,6 +256,45 @@ class OrganizationsApiTests(TestCase):
         response = self.do_post(users_uri, data)
         self.assertEqual(response.status_code, 400)
 
+    def test_organizations_groups_get_post(self):
+        data = {
+            'name': self.test_organization_name,
+            'display_name': self.test_organization_display_name,
+            'contact_name': self.test_organization_contact_name,
+            'contact_email': self.test_organization_contact_email,
+            'contact_phone': self.test_organization_contact_phone
+        }
+        response = self.do_post(self.base_organizations_uri, data)
+        self.assertEqual(response.status_code, 201)
+        org_id = response.data['id']
+
+        # create groups
+        max_groups, groups = 4, []
+        for i in xrange(1, max_groups + 1):
+            data = {
+                'name': '{} {}'.format('Test Group', i),
+                'type': 'contactgroup',
+                'data': {'display_name': 'organization contacts group'}
+            }
+            response = self.do_post(self.base_groups_uri, data)
+            self.assertEqual(response.status_code, 201)
+            groups.append(response.data['id'])
+
+        test_uri = '{}{}/'.format(self.base_organizations_uri, org_id)
+        groups_uri = '{}groups/'.format(test_uri)
+        for group in groups:
+            data = {"id": group}
+            response = self.do_post(groups_uri, data)
+            self.assertEqual(response.status_code, 201)
+        response = self.do_get(groups_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), max_groups)
+
+        # post an invalid group
+        data = {"id": '45533333'}
+        response = self.do_post(groups_uri, data)
+        self.assertEqual(response.status_code, 400)
+
     def test_organizations_users_get(self):
         data = {
             'name': self.test_organization_name,

--- a/lms/djangoapps/projects/serializers.py
+++ b/lms/djangoapps/projects/serializers.py
@@ -1,11 +1,10 @@
 """ Django REST Framework Serializers """
 
-import json
-from django.contrib.auth.models import Group, User
-from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
+from api_manager.groups.serializers import GroupSerializer
 from .models import Project, Workgroup, WorkgroupSubmission
 from .models import WorkgroupReview, WorkgroupSubmissionReview, WorkgroupPeerReview
 
@@ -17,53 +16,6 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         """ Meta class for defining additional serializer characteristics """
         model = User
         fields = ('id', 'url', 'username', 'email')
-
-
-class GroupSerializer(serializers.HyperlinkedModelSerializer):
-    """ Serializer for model interactions """
-    name = serializers.SerializerMethodField('get_group_name')
-    type = serializers.SerializerMethodField('get_group_type')
-    data = serializers.SerializerMethodField('get_group_data')
-
-    def get_group_name(self, group):
-        """
-        Group name is actually stored on the profile record, in order to
-        allow for duplicate name values in the system.
-        """
-        try:
-            group_profile = group.groupprofile
-            if group_profile and group_profile.name:
-                return group_profile.name
-            else:
-                return group.name
-        except ObjectDoesNotExist:
-            return group.name
-
-    def get_group_type(self, group):
-        """
-        Loads data from group profile
-        """
-        try:
-            group_profile = group.groupprofile
-            return group_profile.group_type
-        except ObjectDoesNotExist:
-            return None
-
-    def get_group_data(self, group):
-        """
-        Loads data from group profile
-        """
-        try:
-            group_profile = group.groupprofile
-            if group_profile.data:
-                return json.loads(group_profile.data)
-        except ObjectDoesNotExist:
-            return None
-
-    class Meta:
-        """ Meta class for defining additional serializer characteristics """
-        model = Group
-        fields = ('id', 'url', 'name', 'type', 'data')
 
 
 class GradeSerializer(serializers.Serializer):

--- a/lms/djangoapps/projects/tests/test_workgroups.py
+++ b/lms/djangoapps/projects/tests/test_workgroups.py
@@ -17,6 +17,7 @@ from django.test.utils import override_settings
 from api_manager.models import GroupProfile
 from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
 from projects.models import Project, Workgroup
+from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from course_groups.cohorts import (get_cohort_by_name, remove_user_from_cohort,
                                    delete_empty_cohort, is_user_in_cohort, get_course_cohort_names)
@@ -110,6 +111,8 @@ class WorkgroupsApiTests(TestCase):
             username=self.test_user_username2
         )
 
+        CourseEnrollmentFactory.create(user=self.test_user, course_id=self.test_course.id)
+        CourseEnrollmentFactory.create(user=self.test_user2, course_id=self.test_course.id)
         self.client = SecureClient()
         cache.clear()
 


### PR DESCRIPTION
@mattdrayer  @martynjames Added groups association with organisation so groups for an orgazanition can be retrieved or linked to an organization via `GET` and `POST` to '/api/server/organizations/{id}/groups' . Also moved GroupSerializer in api_manager/groups
