### PR TITLE
mattdrayer/api-progress-generator-fix: Repaired existence check

### DIFF
--- a/lms/djangoapps/progress/management/commands/tests/test_generate_progress_entries.py
+++ b/lms/djangoapps/progress/management/commands/tests/test_generate_progress_entries.py
@@ -72,6 +72,13 @@ class GenerateProgressEntriesTests(TestCase):
             display_name="lab problem 1",
             metadata={'rerandomize': 'always', 'graded': True, 'format': "Lab"}
         )
+        self.problem4 = ItemFactory.create(
+            parent_location=chapter2.location,
+            category='problem',
+            data=StringResponseXMLFactory().build_xml(answer='bar'),
+            display_name="lab problem 2",
+            metadata={'rerandomize': 'always', 'graded': True, 'format': "Lab"}
+        )
 
         # Create some users and enroll them
         self.users = [UserFactory.create(username="testuser" + str(__), profile='test') for __ in xrange(3)]
@@ -128,6 +135,15 @@ class GenerateProgressEntriesTests(TestCase):
         user0_entry = StudentProgress.objects.get(user=self.users[0])
         self.assertEqual(user0_entry.completions, 3)
 
+        # The first user will be skipped this next time around because they already have a progress record
+        # and their completions have not changed, and we need to test this valid use case ('skipped')
+        # We also need to test the 'updated' use case, so we'll add a new completion record for the
+        # second user which will alter their count on this next cycle and kick off the update flow
+        completion, created = CourseModuleCompletion.objects.get_or_create(user=self.users[1],
+                                                                           course_id=self.course.id,
+                                                                           content_id=unicode(self.problem4.location),
+                                                                           stage=None)
+
         # Run the command across all users, but just for the specified course
         generate_progress_entries.Command().handle(course_ids=course_ids)
 
@@ -135,11 +151,11 @@ class GenerateProgressEntriesTests(TestCase):
         current_entries = StudentProgress.objects.all()
         self.assertEqual(len(current_entries), 3)
         current_entries = StudentProgressHistory.objects.all()
-        self.assertEqual(len(current_entries), 3)
+        self.assertEqual(len(current_entries), 4)
         user0_entry = StudentProgress.objects.get(user=self.users[0])
         self.assertEqual(user0_entry.completions, 3)
         user1_entry = StudentProgress.objects.get(user=self.users[1])
-        self.assertEqual(user1_entry.completions, 3)
+        self.assertEqual(user1_entry.completions, 4)
         user2_entry = StudentProgress.objects.get(user=self.users[2])
         self.assertEqual(user2_entry.completions, 3)
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -413,5 +413,6 @@ if FEATURES.get('STUDENT_PROGRESS', False) and "'progress'" not in INSTALLED_APP
     INSTALLED_APPS += ('progress',)
 
 ############# Organizations app #################
+FEATURES['ORGANIZATIONS_APP'] = True
 if FEATURES.get('ORGANIZATIONS_APP') and "organizations" not in INSTALLED_APPS:
     INSTALLED_APPS += ('organizations',)


### PR DESCRIPTION
@martynjames @fredsmith -- here's an updated progress generator to run in the staging environment.  We may not want to take the current tip of master due to some recent changes to organizations which require some baking time in integration/QA.  So what we should do here is merge to master and then simply put a copy of generate_progress_entries.py on the staging server, then run it.
