### PR TITLE
mattdrayer/api-session-check-existing: Skip login if already logged in

### DIFF
--- a/lms/djangoapps/api_manager/sessions/tests.py
+++ b/lms/djangoapps/api_manager/sessions/tests.py
@@ -88,6 +88,18 @@ class SessionsApiTests(TestCase):
         self.assertEqual(str(response.data['user']['username']), local_username)
         self.assertEqual(response.data['user']['id'], user_id)
 
+    def test_session_list_post_already_logged_in(self):
+        local_username = self.test_username + str(randint(11, 99))
+        local_username = local_username[3:-1]  # username is a 32-character field
+        data = {'email': self.test_email, 'username': local_username, 'password': self.test_password}
+        response = self.do_post(self.base_users_uri, data)
+        user_id = response.data['id']
+        data = {'username': local_username, 'password': self.test_password}
+        response = self.do_post(self.base_sessions_uri, data)
+        self.assertEqual(response.status_code, 201)
+        response = self.do_post(self.base_sessions_uri, data)
+        self.assertEqual(response.status_code, 200)
+
     def test_session_list_post_invalid(self):
         local_username = self.test_username + str(randint(11, 99))
         local_username = local_username[3:-1]  # username is a 32-character field

--- a/lms/djangoapps/api_manager/sessions/views.py
+++ b/lms/djangoapps/api_manager/sessions/views.py
@@ -1,12 +1,14 @@
 # pylint: disable=E1101
 
 """ API implementation for session-oriented interactions. """
+from datetime import datetime
 import logging
 
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth import SESSION_KEY, BACKEND_SESSION_KEY, load_backend
 from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.sessions.models import Session
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.importlib import import_module
 from django.utils.translation import ugettext as _
@@ -23,6 +25,45 @@ from student.models import (
     LoginFailures, PasswordHistory
 )
 AUDIT_LOG = logging.getLogger("audit")
+
+def _get_all_logged_in_users():
+    # Query all non-expired sessions
+    sessions = Session.objects.filter(expire_date__gte=datetime.now())
+    uid_list = []
+
+    # Build a list of user ids from that query
+    for session in sessions:
+        data = session.get_decoded()
+        uid_list.append(data.get('_auth_user_id', None))
+
+    # Query all logged in users based on id list
+    return User.objects.filter(id__in=uid_list)
+
+
+def _get_user_session(user):
+    user_session = None
+    sessions = Session.objects.filter(expire_date__gte=datetime.now())
+    for session in sessions:
+        data = session.get_decoded()
+        if user.id == data.get('_auth_user_id', None):
+            user_session = session
+            user_session_store = _get_session_store(session.session_key)
+            user_session.get_expiry_age = user_session_store.get_expiry_age
+    return user_session
+
+
+def _is_logged_in(user):
+    try:
+        logged_in_user = _get_all_logged_in_users().get(id=user.id)
+        logged_in = True
+    except User.DoesNotExist:
+        logged_in = False
+    return logged_in
+
+def _get_session_store(session_id):
+    engine = import_module(settings.SESSION_ENGINE)
+    session_store = engine.SessionStore(session_id)
+    return session_store
 
 
 class SessionsList(SecureAPIView):
@@ -66,40 +107,49 @@ class SessionsList(SecureAPIView):
         except ObjectDoesNotExist:
             existing_user = None
 
-        # see if account has been locked out due to excessive login failures
-        if existing_user and LoginFailures.is_feature_enabled():
-            if LoginFailures.is_user_locked_out(existing_user):
-                response_status = status.HTTP_403_FORBIDDEN
-                response_data['message'] = _('This account has been temporarily locked due to excessive login failures. '
-                                             'Try again later.')
-                return Response(response_data, status=response_status)
-
-         # see if the user must reset his/her password due to any policy settings
-        if existing_user and PasswordHistory.should_user_reset_password_now(existing_user):
-            response_status = status.HTTP_403_FORBIDDEN
-            response_data['message'] = _(
-                'Your password has expired due to password policy on this account. '
-                'You must reset your password before you can log in again.'
-            )
-            return Response(response_data, status=response_status)
 
         if existing_user:
+
+            # see if account has been locked out due to excessive login failures
+            if LoginFailures.is_feature_enabled():
+                if LoginFailures.is_user_locked_out(existing_user):
+                    response_status = status.HTTP_403_FORBIDDEN
+                    response_data['message'] = _('This account has been temporarily locked due to excessive login failures. '
+                                                 'Try again later.')
+                    return Response(response_data, status=response_status)
+
+             # see if the user must reset his/her password due to any policy settings
+            if PasswordHistory.should_user_reset_password_now(existing_user):
+                response_status = status.HTTP_403_FORBIDDEN
+                response_data['message'] = _(
+                    'Your password has expired due to password policy on this account. '
+                    'You must reset your password before you can log in again.'
+                )
+                return Response(response_data, status=response_status)
+
             user = authenticate(username=existing_user.username, password=request.DATA['password'])
             if user is not None:
 
                 # successful login, clear failed login attempts counters, if applicable
                 if LoginFailures.is_feature_enabled():
                     LoginFailures.clear_lockout_counter(user)
-
                 if user.is_active:
-                    login(request, user)
-                    response_data['token'] = request.session.session_key
-                    response_data['expires'] = request.session.get_expiry_age()
-                    user_dto = UserSerializer(user)
-                    response_data['user'] = user_dto.data
-                    response_data['uri'] = '{}/{}'.format(base_uri, request.session.session_key)
-                    response_status = status.HTTP_201_CREATED
-
+                    if _is_logged_in(user):
+                        user_session = _get_user_session(user)
+                        response_data['token'] = user_session.session_key
+                        response_data['expires'] = user_session.get_expiry_age()
+                        user_dto = UserSerializer(user)
+                        response_data['user'] = user_dto.data
+                        response_data['uri'] = '{}/{}'.format(base_uri, user_session.session_key)
+                        response_status = status.HTTP_200_OK
+                    else:
+                        login(request, user)
+                        response_data['token'] = request.session.session_key
+                        response_data['expires'] = request.session.get_expiry_age()
+                        user_dto = UserSerializer(user)
+                        response_data['user'] = user_dto.data
+                        response_data['uri'] = '{}/{}'.format(base_uri, request.session.session_key)
+                        response_status = status.HTTP_201_CREATED
                     # add to audit log
                     AUDIT_LOG.info(u"API::User logged in successfully with user-id - {0}".format(user.id))
                 else:
@@ -143,31 +193,28 @@ class SessionsDetail(SecureAPIView):
     def get(self, request, session_id):
         response_data = {}
         base_uri = generate_base_uri(request)
-        engine = import_module(settings.SESSION_ENGINE)
-        session = engine.SessionStore(session_id)
+        session_store = _get_session_store(session_id)
         try:
-            user_id = session[SESSION_KEY]
-            backend_path = session[BACKEND_SESSION_KEY]
+            user_id = session_store[SESSION_KEY]
+            backend_path = session_store[BACKEND_SESSION_KEY]
             backend = load_backend(backend_path)
             user = backend.get_user(user_id) or AnonymousUser()
         except KeyError:
             user = AnonymousUser()
-        if user.is_authenticated():
-            response_data['token'] = session.session_key
-            response_data['expires'] = session.get_expiry_age()
-            response_data['uri'] = base_uri
-            response_data['user_id'] = user.id
-            return Response(response_data, status=status.HTTP_200_OK)
-        else:
+        if not user.is_authenticated():
             return Response(response_data, status=status.HTTP_404_NOT_FOUND)
+        response_data['token'] = session_store.session_key
+        response_data['expires'] = session_store.get_expiry_age()
+        response_data['uri'] = base_uri
+        response_data['user_id'] = user.id
+        return Response(response_data, status=status.HTTP_200_OK)
 
     def delete(self, request, session_id):
-        engine = import_module(settings.SESSION_ENGINE)
-        session = engine.SessionStore(session_id)
-        if session is None or not SESSION_KEY in session:
+        session_store = _get_session_store(session_id)
+        if session_store is None or not SESSION_KEY in session_store:
             return Response({}, status=status.HTTP_204_NO_CONTENT)
-        user_id = session[SESSION_KEY]
-        session.flush()
+        user_id = session_store[SESSION_KEY]
+        session_store.flush()
         if request.user is not None and not request.user.is_anonymous():
             logout(request)
         AUDIT_LOG.info(u"API::User session terminated for user-id - {0}".format(user_id))


### PR DESCRIPTION
@chrisndodge @martynjames -- updated the POST /sessions workflow to skip the login() routine if the user is already logged in -- had to move some code around and added some helper functions along the way.  Let me know what you think.

@fredsmith, FYI on this change -- we'll need to figure out how to work it into the deployment stream -- if we set up a release candidate branch we could cherry-pick the commit into it -- or I suppose we could close this PR and resubmit to the RC, then merge back to master -- however we want to manage the code is fine w/ me
