### PR TITLE
A few patches to fix dependency issues with Organizations.

### DIFF
--- a/cms/envs/bok_choy.env.json
+++ b/cms/envs/bok_choy.env.json
@@ -63,6 +63,8 @@
     "DEFAULT_FROM_EMAIL": "registration@example.com",
     "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
     "FEATURES": {
+        "API": true,
+        "ORGANIZATIONS_APP": true,
         "AUTH_USE_OPENID_PROVIDER": true,
         "CERTIFICATES_ENABLED": true,
         "ENABLE_DISCUSSION_SERVICE": true,

--- a/lms/djangoapps/organizations/management/commands/tests/test_move_organizations_entries.py
+++ b/lms/djangoapps/organizations/management/commands/tests/test_move_organizations_entries.py
@@ -9,7 +9,6 @@ from projects.models import Workgroup, Project
 from model_utils.models import TimeStampedModel
 from south.db import db
 
-@mock.patch.dict("django.conf.settings.FEATURES", {'ORGANIZATIONS_APP': True})
 class MoveOrganizationEntriesTests(TestCase):
     """
     Test suite for organization table data copy from api_manager to organizations
@@ -29,56 +28,6 @@ class MoveOrganizationEntriesTests(TestCase):
         workgroup.name = 'Test workgroup'
         workgroup.project = proj
         workgroup.save()
-
-        attrs = {
-            'name': models.CharField(max_length=255),
-            'display_name': models.CharField(max_length=255, null=True, blank=True),
-            'contact_name': models.CharField(max_length=255, null=True, blank=True),
-            'contact_email': models.EmailField(max_length=255, null=True, blank=True),
-            'contact_phone': models.CharField(max_length=50, null=True, blank=True),
-            'logo_url': models.CharField(max_length=255, blank=True, null=True),
-            'workgroups': models.ManyToManyField(Workgroup, related_name="organizations"),
-            'users': models.ManyToManyField(User, related_name="organizations"),
-            'groups': models.ManyToManyField(Group, related_name="organizations"),
-            '__module__': 'api_manager.models'
-        }
-        self.organization = type("Organization", (TimeStampedModel,), attrs)
-        fields = [(f.name, f) for f in self.organization._meta.local_fields]
-        table_name = self.organization._meta.db_table
-        db.create_table(table_name, fields)
-
-        attrs = {
-            'organization_id': models.IntegerField(),
-            'user_id': models.IntegerField(),
-            '__module__': 'api_manager.models'
-        }
-
-        self.organization_users = type("organization_users", (models.Model,), attrs)
-        fields = [(f.name, f) for f in self.organization_users._meta.local_fields]
-        table_name = self.organization_users._meta.db_table
-        db.create_table(table_name, fields)
-
-        attrs = {
-            'organization_id': models.IntegerField(),
-            'group_id': models.IntegerField(),
-            '__module__': 'api_manager.models'
-        }
-
-        self.organization_groups = type("organization_groups", (models.Model,), attrs)
-        fields = [(f.name, f) for f in self.organization_groups._meta.local_fields]
-        table_name = self.organization_groups._meta.db_table
-        db.create_table(table_name, fields)
-
-        attrs = {
-            'organization_id': models.IntegerField(),
-            'workgroup_id': models.IntegerField(),
-            '__module__': 'api_manager.models'
-        }
-
-        self.organization_workgroups = type("organization_workgroups", (models.Model,), attrs)
-        fields = [(f.name, f) for f in self.organization_workgroups._meta.local_fields]
-        table_name = self.organization_workgroups._meta.db_table
-        db.create_table(table_name, fields)
 
         for i in xrange(1, 9):
             org = self.organization()

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -63,6 +63,8 @@
     "DEFAULT_FROM_EMAIL": "registration@example.com",
     "EMAIL_BACKEND": "django.core.mail.backends.smtp.EmailBackend",
     "FEATURES": {
+        "API": "true",
+        "ORGANIZATIONS_APP": true,
         "AUTH_USE_OPENID_PROVIDER": true,
         "CERTIFICATES_ENABLED": true,
         "ENABLE_DISCUSSION_SERVICE": true,


### PR DESCRIPTION
@mattdrayer @martynjames This PR should fix the biggest share of the issues I was sending you.

The Organizations app needs to be added to the bokchoy environment JSON in order to make sure bokchoy can run, as this app appears to be required by default now. But adding it in also makes the work by one of the tests to modify the database redundant. When running the tests after this change, the schema change causes failures all along down the line after a certain point. This patch fixes that by removing the custom DB changes and allowing the inclusion of ORGANIZATIONS_APP in the features list to handle it.

Please let me know of any feedback as soon as you can. Merging this in will make test failures clearer for a PR I need to review. Thanks in advance! @antoviaque @e-kolpakov
