### PR TITLE
mattdrayer/api-2632-fix: Filter out zero completions entries

### DIFF
--- a/lms/djangoapps/progress/models.py
+++ b/lms/djangoapps/progress/models.py
@@ -46,7 +46,8 @@ class StudentProgress(TimeStampedModel):
         """
         queryset = cls.objects.filter(course_id__exact=course_key, user__is_active=True,
                                       user__courseenrollment__is_active=True,
-                                      user__courseenrollment__course_id__exact=course_key)\
+                                      user__courseenrollment__course_id__exact=course_key,
+                                      completions__gt=0)\
             .exclude(user__id__in=exclude_users)
         if org_ids:
             queryset = queryset.filter(user__organizations__in=org_ids)


### PR DESCRIPTION
@martynjames -- added a filter to the method that retrieves the number of users who have 'started' a course to exclude records in the progress_studentprogress table having zero completions.

@ziafazal, FYI
