### PR TITLE
ziafazal/api-update-user-time-when-emtpy:accept empty user title

### DIFF
--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -231,7 +231,7 @@ class CoursesApiTests(TestCase):
                 )
 
         self.test_course_id = unicode(self.course.id)
-        self.test_bogus_course_id = 'i4x://foo/bar/baz'
+        self.test_bogus_course_id = 'foo/bar/baz'
         self.test_course_name = self.course.display_name
         self.test_course_number = self.course.number
         self.test_course_org = self.course.org

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -461,6 +461,7 @@ class UsersApiTests(TestCase):
 
         data["country"] = "US"
         data["year_of_birth"] = "1990"
+        data["title"] = ""
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 200)
         response = self.do_get(test_uri)

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -564,9 +564,8 @@ class UsersDetail(SecureAPIView):
             gender = request.DATA.get('gender')
             if gender:
                 existing_user_profile.gender = gender
-            title = request.DATA.get('title')
-            if title:
-                existing_user_profile.title = title
+            title = request.DATA.get('title', None)
+            existing_user_profile.title = title
             avatar_url = request.DATA.get('avatar_url')
             if avatar_url:
                 existing_user_profile.avatar_url = avatar_url


### PR DESCRIPTION
@mattdrayer  @dino-cikatic user detail api now saves empty `title`. test_bogus_course_id was not complying to new course url pattern settings so updated it to pass couple of failing tests.
