### PR TITLE
ziafazal/api-fix-progress-avg-greater-than-100: fix progress value more than 100

### DIFF
--- a/lms/djangoapps/api_manager/courses/serializers.py
+++ b/lms/djangoapps/api_manager/courses/serializers.py
@@ -36,7 +36,7 @@ class CourseCompletionsLeadersSerializer(serializers.Serializer):
         completions = obj['completions'] or 0
         completion_percentage = 0
         if total_completions > 0:
-            completion_percentage = 100 * (completions / float(total_completions))
+            completion_percentage = min(100 * (completions / float(total_completions)), 100)
         return completion_percentage
 
 

--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -1752,6 +1752,7 @@ class CoursesApiTests(TestCase):
         # Make last user as observer to make sure that data is being filtered out
         allow_access(course, users[USER_COUNT-1], 'observer')
 
+        contents = []
         for i in xrange(1, 26):
             local_content_name = 'Video_Sequence{}'.format(i)
             local_content = ItemFactory.create(
@@ -1760,6 +1761,7 @@ class CoursesApiTests(TestCase):
                 data=self.test_data,
                 display_name=local_content_name
             )
+            contents.append(local_content)
             if i < 3:
                 user_id = users[0].id
             elif i < 10:
@@ -1831,6 +1833,21 @@ class CoursesApiTests(TestCase):
         self.assertIsNone(response.data.get('leaders', None))
         self.assertEqual(response.data['position'], 0)
         self.assertEqual(response.data['completions'], 0)
+
+        # test a case where completions are greater than total course modules. it should not be more than 100
+        contents.append(self.course_content)
+        for content in contents[2:]:
+            user_id = users[0].id
+            content_id = unicode(content.scope_ids.usage_id)
+            completions_data = {'content_id': content_id, 'user_id': user_id}
+            response = self.do_post(completion_uri, completions_data)
+            self.assertEqual(response.status_code, 201)
+
+        test_uri = '{}?user_id={}'.format(leaders_uri, users[0].id)
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual('{0:.3f}'.format(response.data['completions']), '100.000')
+
 
     def test_courses_metrics_grades_list_get(self):
         # Retrieve the list of grades for this course

--- a/lms/djangoapps/api_manager/courses/views.py
+++ b/lms/djangoapps/api_manager/courses/views.py
@@ -1737,7 +1737,7 @@ class CoursesMetricsCompletionsLeadersList(SecureAPIView):
             user_completions = user_data['completions']
             completion_percentage = 0
             if total_possible_completions > 0:
-                completion_percentage = 100 * (user_completions/total_possible_completions)
+                completion_percentage = min(100 * (user_completions/total_possible_completions), 100)
             data['completions'] = completion_percentage
 
         total_users_qs = CourseEnrollment.users_enrolled_in(course_key).exclude(id__in=exclude_users)
@@ -1746,7 +1746,7 @@ class CoursesMetricsCompletionsLeadersList(SecureAPIView):
         total_users = total_users_qs.count()
         if total_users and total_actual_completions:
             course_avg = total_actual_completions / float(total_users)
-            course_avg = 100 * (course_avg / total_possible_completions)  # avg in percentage
+            course_avg = min(100 * (course_avg / total_possible_completions), 100)  # avg in percentage
         data['course_avg'] = course_avg
 
         if not skipleaders:


### PR DESCRIPTION
@mattdrayer  Only case where progress average exceeds 100 is when course admin deletes a Unit/Exercise after a user has already completed it. In that case total completions by user exceed actually completable exercises in course. Putting an upper bound of 100 on progress values.
