### PR TITLE
ziafazal/fix-progress-avg-difference: remove orphan count

### DIFF
--- a/lms/djangoapps/api_manager/courseware_access.py
+++ b/lms/djangoapps/api_manager/courseware_access.py
@@ -70,11 +70,13 @@ def get_course_leaf_nodes(course_key):
     """
     nodes = []
     detached_categories = getattr(settings, 'PROGRESS_DETACHED_CATEGORIES', [])
-    verticals = get_modulestore().get_items(course_key,  qualifiers={'category': 'vertical'})
+    store = get_modulestore()
+    verticals = store.get_items(course_key,  qualifiers={'category': 'vertical'})
+    orphans = store.get_orphans(course_key)
     for vertical in verticals:
-        if hasattr(vertical, 'children'):
+        if hasattr(vertical, 'children') and vertical.location not in orphans:
             nodes.extend([unit for unit in vertical.children
-                if getattr(unit, 'category') not in detached_categories])
+                          if getattr(unit, 'category') not in detached_categories])
     return nodes
 
 


### PR DESCRIPTION
@mattdrayer workaround to get rid of deleted modules from counting is to grab all orphan modules and then skip them while counting.
