### PR TITLE
Production deployment fixes -> staticfiles url rewriting

### DIFF
--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -40,7 +40,7 @@ def render_individual_css(package, paths, raw=False):
     return '\n'.join(tags)
 
 
-def compressed_js(package_name):
+def compressed_js(package_name, raw=False):
     package = settings.PIPELINE_JS.get(package_name, {})
     if package:
         package = {package_name: package}
@@ -49,19 +49,23 @@ def compressed_js(package_name):
     package = packager.package_for('js', package_name)
 
     if settings.PIPELINE:
-        return render_js(package, package.output_filename)
+        return render_js(package, package.output_filename, raw=raw)
     else:
         paths = packager.compile(package.paths)
         templates = packager.pack_templates(package)
-        return render_individual_js(package, paths, templates)
+        return render_individual_js(package, paths, templates, raw=raw)
 
 
-def render_js(package, path):
+def render_js(package, path, raw=False):
     template_name = package.template_name or "mako/js.html"
     context = package.extra_context
+
+    url = try_staticfiles_lookup(path)
+    if raw:
+        url += "?raw"
     context.update({
         'type': guess_type(path, 'text/javascript'),
-        'url': try_staticfiles_lookup(path)
+        'url': url
     })
     return render_to_string(template_name, context)
 
@@ -74,8 +78,8 @@ def render_inline_js(package, js):
     return render_to_string("mako/inline_js.html", context)
 
 
-def render_individual_js(package, paths, templates=None):
-    tags = [render_js(package, js) for js in paths]
+def render_individual_js(package, paths, templates=None, raw=False):
+    tags = [render_js(package, js, raw) for js in paths]
     if templates:
         tags.append(render_inline_js(package, templates))
     return '\n'.join(tags)

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -19,12 +19,12 @@ except:
     % endfor
   %endif
 </%def>
-<%def name='js(group)'>
+<%def name='js(group, raw=False)'>
   % if settings.FEATURES['USE_DJANGO_PIPELINE']:
-    ${compressed_js(group)}
+    ${compressed_js(group, raw=raw)}
   % else:
     % for filename in settings.PIPELINE_JS[group]['source_filenames']:
-      <script type="text/javascript" src="${staticfiles_storage.url(filename.replace('.coffee', '.js'))}"></script>
+      <script type="text/javascript" src="${staticfiles_storage.url(filename.replace('.coffee', '.js'))}${"?raw" if raw else ""}"></script>
     % endfor
   %endif
 </%def>

--- a/common/templates/discussion/_discussion_inline.html
+++ b/common/templates/discussion/_discussion_inline.html
@@ -5,11 +5,11 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <%block name="js_extra">
-    <%static:js group='discussion'/>
+    <%static:js group='discussion' raw='true'/>
 </%block>
 
 <%block name="css_extra">
-    <%static:css group='discussion'/>
+    <%static:css group='discussion' raw='true'/>
 </%block>
 
 <div class="discussion-module" data-discussion-id="${discussion_id | h}">


### PR DESCRIPTION
Fixed production deployment issue caused by staticfiles url replacements (see replace_static_urls/**init**.py -> replace_static_urls)
