### PR TITLE
Cached_has_permissions in templates instead of pre-calculated context variables

### DIFF
--- a/common/templates/discussion/_discussion_course.html
+++ b/common/templates/discussion/_discussion_course.html
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<%! from django_comment_client.permissions import cached_has_permission %>
 
 <%namespace name='static' file='../static_content.html'/>
 
@@ -12,7 +13,7 @@
 
 <div class="discussion-course">
 
-  % if enable_new_post_btn and has_permission_to_create_thread:
+  % if enable_new_post_btn and cached_has_permission(user, "create_thread", course_id):
   <div class="discussion-course-new right">
     <a href="#" class="new-post-btn" role="button"><span class="icon icon-edit new-post-icon"></span>${_("New Post")}</a>
   </div>

--- a/common/templates/discussion/_discussion_course_navigation.html
+++ b/common/templates/discussion/_discussion_course_navigation.html
@@ -1,9 +1,9 @@
 <%! from django.utils.translation import ugettext as _ %>
-<%! from django_comment_client.permissions import has_permission %>
+<%! from django_comment_client.permissions import cached_has_permission %>
 <%inherit file="../courseware/course_navigation.html" />
 
 <%block name="extratabs">
-% if has_permission(user, 'create_thread', course.id):
+% if cached_has_permission(user, 'create_thread', course.id):
     <li class="right"><a href="#" class="new-post-btn" role="button"><span class="icon icon-edit new-post-icon"></span>${_("New Post")}</a></li>
 % endif
 </%block>

--- a/common/templates/discussion/_discussion_inline.html
+++ b/common/templates/discussion/_discussion_inline.html
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
-<%! from django_comment_client.permissions import has_permission %>
+<%! from django_comment_client.permissions import cached_has_permission %>
 <%include file="_underscore_templates.html" />
 
 <%namespace name='static' file='../static_content.html'/>
@@ -14,7 +14,7 @@
 
 <div class="discussion-module" data-discussion-id="${discussion_id | h}">
     <a class="discussion-show control-button" href="javascript:void(0)" data-discussion-id="${discussion_id | h}" role="button"><span class="show-hide-discussion-icon"></span><span class="button-text">${_("Show Discussion")}</span></a>
-    % if has_permission(user, 'create_thread', course.id):
+    % if cached_has_permission(user, 'create_thread', course.id):
         <a href="#" class="new-post-btn" role="button"><span class="icon icon-edit new-post-icon"></span>${_("New Post")}</a>
     % endif
 </div>

--- a/lms/djangoapps/django_comment_client/forum/views.py
+++ b/lms/djangoapps/django_comment_client/forum/views.py
@@ -319,11 +319,7 @@ def single_thread(request, course_id, discussion_id, thread_id):
             'sort_preference': cc_user.default_sort_key,
             'category_map': course_settings["category_map"],
             'course_settings': _attr_safe_json(course_settings),
-            'cohorted_commentables': (get_cohorted_commentables(course_id)),
-            'has_permission_to_create_thread': cached_has_permission(request.user, "create_thread", course_id),
-            'has_permission_to_create_comment': cached_has_permission(request.user, "create_comment", course_id),
-            'has_permission_to_create_subcomment': cached_has_permission(request.user, "create_subcomment", course_id),
-            'has_permission_to_openclose_thread': cached_has_permission(request.user, "openclose_thread", course_id)
+            'cohorted_commentables': (get_cohorted_commentables(course_id))
         }
         return render_to_response('discussion/index.html', context)
 


### PR DESCRIPTION
Switched to using cached_has_permission in templates, rather than having those permissions in template context
