### PR TITLE
SOL-129 Remove Text category filter and add MS contentTypes

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -758,4 +758,20 @@ ADVANCED_PROBLEM_TYPES = [
 
 # Files and Uploads type filter values
 FILES_AND_UPLOAD_TYPE_FILTER = {
-    "Images": ['image/png', 'image/jpeg'], "Documents": ['application/pdf'], "Text": ['application/txt']}
+    "Images": ['image/png', 'image/jpeg'],
+    "Documents": [
+        'application/pdf',
+        'application/txt',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+        'application/vnd.openxmlformats-officedocument.presentationml.template',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+        'application/msword',
+        'application/vnd.ms-excel',
+        'application/vnd.ms-powerpoint',
+    ],
+}
+

--- a/cms/static/js/views/assets.js
+++ b/cms/static/js/views/assets.js
@@ -12,7 +12,7 @@ define(["jquery", "underscore", "gettext", "js/models/asset", "js/views/paging",
                 "click .filterable-column .column-filter-link": "toggleFilterColumn"
             },
 
-            typeData: ['Images', 'Documents', 'Text'],
+            typeData: ['Images', 'Documents'],
 
             allLabel: 'ALL',
 


### PR DESCRIPTION
@martynjames I've removed text option and added it to documents. I also added contentTypes for new and old MS Office documents. If any other are needed they can be added to settings at cms/envs/common.py
