### PR TITLE
Added back discussion id displaying in studio

### DIFF
--- a/common/templates/discussion/_discussion_inline_studio.html
+++ b/common/templates/discussion/_discussion_inline_studio.html
@@ -5,6 +5,7 @@
         <span class="discussion-preview">
             <span class="icon icon-comment"/>
             ${_("To view live discussions, click Preview or View Live in Unit Settings.")}
+            ${_("Discussion ID: {discussion_id}").format(discussion_id=discussion_id)}
         </span>
     </p>
 </div>


### PR DESCRIPTION
Background: I believe title is self-descriptive - discussion IDs used to be displayed in studio, but during merging xblock-discussion with edx-platform this feature was unintentionally removed.

Partner information: 3rd party-hosted open edX instance, for an edX solutions client.

Merge deadline: before release cuts off.
