### PR TITLE
Group selector unique css class

### DIFF
--- a/common/templates/discussion/_underscore_templates.html
+++ b/common/templates/discussion/_underscore_templates.html
@@ -387,7 +387,7 @@
         <ul class="post-errors" style="display: none"></ul>
         <div class="forum-new-post-form-wrapper"></div>
         ${'<% if (cohort_options) { %>'}
-        <div class="post-field">
+        <div class="post-field group-selector-wrapper">
             <label class="field-label">
                 <span class="field-label-text">
                     ## Translators: This labels the selector for which group of students can view a post


### PR DESCRIPTION
Background: Group selector is always shown to Admins/Moderators/TAs if course is cohorted, regardless of if **discussion** is cohorted. However, backend code just ignores `group_id` parameter if discussion is not cohorted. This PR adds a unique css class to group selector wrapper element, so this control can be targeted in css and hidden. It is a workaround to fix critical issue reported by a client before the release. Other part of fix is in named client private repository.

Partner information: 3rd party-hosted open edX instance, for an edX solutions client.

Merge deadline: before release is released.
