### PR TITLE
Hide "Visible To" dropdown for non-cohorted inline discussions

### DIFF
--- a/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
+++ b/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
@@ -319,7 +319,7 @@ browser and pasting the output.  When that file changes, this one should be rege
         <ul class="post-errors" style="display: none"></ul>
         <div class="forum-new-post-form-wrapper"></div>
         <% if (cohort_options) { %>
-        <div class="post-field">
+        <div class="post-field group-selector-wrapper">
             <label class="field-label">
                 <span class="field-label-text">
                     Visible To:

--- a/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
+++ b/common/static/coffee/spec/discussion/view/new_post_view_spec.coffee
@@ -14,8 +14,11 @@ describe "NewPostView", ->
       beforeEach ->
         @course_settings = new DiscussionCourseSettings({
           "category_map": {
-            "children": ["Topic"],
-            "entries": {"Topic": {"is_cohorted": true, "id": "topic"}}
+            "children": ["Topic", "General"],
+            "entries": {
+              "Topic": {"is_cohorted": true, "id": "topic"},
+              "General": {"is_cohorted": false, "id": "general"}
+            }
           },
           "allow_anonymous": false,
           "allow_anonymous_to_peers": false,
@@ -32,8 +35,9 @@ describe "NewPostView", ->
           mode: "tab"
         )
 
-      checkVisibility = (view, expectedVisible) =>
-        view.render()
+      checkVisibility = (view, expectedVisible, noRender) =>
+        if !noRender
+          view.render()
         expect(view.$(".js-group-select").is(":visible")).toEqual(expectedVisible)
         if expectedVisible
           expect(view.$(".js-group-select").prop("disabled")).toEqual(false)
@@ -48,6 +52,19 @@ describe "NewPostView", ->
       it "allows moderators to see the cohort selector", ->
         DiscussionSpecHelper.makeModerator()
         checkVisibility(@view, true)
+
+      it "only shows the cohort selector when applicable", ->
+        DiscussionSpecHelper.makeModerator()
+        # We start on the cohorted discussion
+        checkVisibility(@view, true)
+        # Select the uncohorted topic
+        $('.topic-title:contains(General)').click()
+        # The menu should now be hidden.
+        checkVisibility(@view, false, true)
+        # Select the cohorted topic again
+        $('.topic-title:contains(Topic)').click()
+        # It should be visible once more.
+        checkVisibility(@view, true, false)
 
       it "allows the user to make a cohort selection", ->
         DiscussionSpecHelper.makeModerator()

--- a/common/static/coffee/src/discussion/views/new_post_view.coffee
+++ b/common/static/coffee/src/discussion/views/new_post_view.coffee
@@ -50,8 +50,10 @@ if Backbone?
       toggleGroupDropdown: ($target) ->
         if $target.data('cohorted')
             $('.js-group-select').prop('disabled', false);
+            $('.group-selector-wrapper').show()
         else
             $('.js-group-select').val('').prop('disabled', true);
+            $('.group-selector-wrapper').hide()
 
       postOptionChange: (event) ->
           $target = $(event.target)


### PR DESCRIPTION
Hides the cohort dropdown menu when it does not apply.