### PR TITLE
Remove broken hotfix remnant.

### DIFF
--- a/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
+++ b/common/static/coffee/src/discussion/views/discussion_thread_view.coffee
@@ -22,12 +22,6 @@ if Backbone?
       if @mode not in ["tab", "inline"]
         throw new Error("invalid mode: " + @mode)
 
-      # Quick fix to have an actual model when we're receiving new models from
-      # the server.
-      @model.collection.on "reset", (collection) =>
-        id = @model.get("id")
-        @model = collection.get(id) if collection.get(id)
-
       @createShowView()
       @responses = new Comments()
       @loadedResponses = false


### PR DESCRIPTION
A section of the initial hotfix no longer applies and needed to be removed for functionality to be restored.