### PR TITLE
Allow for us of the old commentable_id if the user does not select a topic

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -177,6 +177,14 @@ def update_thread(request, course_id, thread_id):
     if "commentable_id" in request.POST:
         course = get_course_with_access(request.user, 'load', course_key)
         commentable_ids = get_discussion_categories_ids(course)
+        # The commentable ID on thread creation may not be available in the
+        # topic menu, such as when the thread is concerning the current
+        # unit in context. In this case the topic menu will be blank, but the
+        # old commentable_id will be sent.
+        try:
+            commentable_ids.append(thread.commentable_id)
+        except AttributeError:
+            pass
         if request.POST.get("commentable_id") in commentable_ids:
             thread.commentable_id = request.POST["commentable_id"]
         else:


### PR DESCRIPTION
Fixes issue where updating a thread will cause a 'Topic does not exist' message in the case that a user does not explicitly select a topic.