### PR TITLE
mattdrayer/MCKIN-2988: Added stop to backwards data migration.

### DIFF
--- a/lms/djangoapps/progress/migrations/0003_move_cmc_data.py
+++ b/lms/djangoapps/progress/migrations/0003_move_cmc_data.py
@@ -35,7 +35,7 @@ class Migration(DataMigration):
 
     def backwards(self, orm):
         "Write your backwards methods here."
-        pass
+        raise RuntimeError("Cannot reverse data migration at this time.")
 
     models = {
         'auth.group': {


### PR DESCRIPTION
@chrisndodge @martynjames @smagoun -- added a stop to the backwards data migration for the progress app, which was the acute cause of the data loss incurred back in December.  We could think about logging a follow-on story for implementing a robust backwards migration, but for now this will prevent any repeat performances.