### PR TITLE
Added wrapper around username and labels to allow for nowrap styling

### DIFF
--- a/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
+++ b/common/static/coffee/spec/discussion/discussion_spec_helper.coffee
@@ -586,6 +586,7 @@ browser and pasting the output.  When that file changes, this one should be rege
 </script>
 
 <script aria-hidden="true" type="text/template" id="post-user-display-template">
+  <span class="username-wrapper">
     <% if (username) { %>
     <a href="<%- user_url %>" class="username"><%- username %></a>
         <% if (is_community_ta) { %>
@@ -596,5 +597,6 @@ browser and pasting the output.  When that file changes, this one should be rege
     <% } else { %>
     anonymous
     <% } %>
+  </span>
 </script>
 """)

--- a/common/templates/discussion/_underscore_templates.html
+++ b/common/templates/discussion/_underscore_templates.html
@@ -596,14 +596,16 @@ ${secondaryAction("delete", "remove", _("Delete"))}
 </script>
 
 <script aria-hidden="true" type="text/template" id="post-user-display-template">
-    ${"<% if (username) { %>"}
-    <a href="${'<%- user_url %>'}" class="username">${'<%- username %>'}</a>
-        ${"<% if (is_community_ta) { %>"}
-        <span class="user-label-community-ta">${_("Community TA")}</span>
-        ${"<% } else if (is_staff) { %>"}
-        <span class="user-label-staff">${_("Staff")}</span>
+    <span class="username-wrapper">
+        ${"<% if (username) { %>"}
+        <a href="${'<%- user_url %>'}" class="username">${'<%- username %>'}</a>
+            ${"<% if (is_community_ta) { %>"}
+            <span class="user-label-community-ta">${_("Community TA")}</span>
+            ${"<% } else if (is_staff) { %>"}
+            <span class="user-label-staff">${_("Staff")}</span>
+            ${"<% } %>"}
+        ${"<% } else { %>"}
+            ${_('anonymous') | h}
         ${"<% } %>"}
-    ${"<% } else { %>"}
-    ${_('anonymous') | h}
-    ${"<% } %>"}
+    </span>
 </script>


### PR DESCRIPTION
Background: This PR adds a wrapper around username and labels in discussion threads/responses to allow for nowrap styling. Styling applied via third party-hosted edX instance.
JIRA Ticket: OC-547
Partner information: 3rd party-hosted open edX instance, for an edX solutions client.
Merge deadline: 2015-03-16
