### PR TITLE
mattdrayer/MCKIN-3046: Added multi-course grade query

### DIFF
--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -1407,6 +1407,15 @@ class UsersApiTests(TestCase):
         self.assertEqual(response.data['current_grade'], 0.73)
         self.assertEqual(response.data['proforma_grade'], 0.9375)
 
+        test_uri = '{}/{}/courses/grades'.format(self.users_base_uri, user_id)
+
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]['course_id'], unicode(course.id))
+        self.assertEqual(response.data[0]['current_grade'], 0.73)
+        self.assertEqual(response.data[0]['proforma_grade'], 0.9375)
+        self.assertEqual(response.data[0]['complete_status'], False)
+
     def is_user_profile_created_updated(self, response, data):
         """This function compare response with user profile data """
 

--- a/lms/djangoapps/api_manager/users/urls.py
+++ b/lms/djangoapps/api_manager/users/urls.py
@@ -8,6 +8,7 @@ from api_manager.users import views as users_views
 urlpatterns = patterns(
     '',
     url(r'^metrics/cities/$', users_views.UsersMetricsCitiesList.as_view(), name='apimgr-users-metrics-cities-list'),
+    url(r'^(?P<user_id>[a-zA-Z0-9]+)/courses/grades$', users_views.UsersCoursesGradesList.as_view(), name='users-courses-grades-list'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/grades$', users_views.UsersCoursesGradesDetail.as_view(), name='users-courses-grades-detail'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/metrics/social/$', users_views.UsersSocialMetrics.as_view(), name='users-social-metrics'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/courses/(?P<course_id>[^/]+/[^/]+/[^/]+)/completions/$', users_views.UsersCoursesCompletionsList.as_view(), name='users-courses-completions-list'),

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -916,6 +916,39 @@ class UsersCoursesDetail(SecureAPIView):
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 
+class UsersCoursesGradesList(SecureAPIView):
+    """
+    ### The UsersCoursesGradesList view allows clients to interact with the User's gradebook across courses
+    - URI: ```/api/users/{user_id}/courses/grades?courses={course_id1,course_id2}```
+    - GET: Returns a JSON representation of the matched set from the gradebook
+        * courses (optional): Set filtering parameter consisting of comma-separated course identifiers
+
+    ### Use Cases/Notes:
+    * Use the UsersCoursesGradesList view to interact with the User's gradebook across multiple Course enrollments
+    * Use GET to retrieve all of the Course gradebook entries for the specified User
+    """
+    def get(self, request, user_id):  # pylint: disable=unused-argument
+        """
+        GET /api/users/{user_id}/courses/grades
+        """
+        grade_complete_match_range = getattr(settings, 'GRADEBOOK_GRADE_COMPLETE_PROFORMA_MATCH_RANGE', 0.01)
+        queryset = StudentGradebook.objects.filter(user=user_id)
+        response_data = []
+        for record in queryset:
+            complete_status = False
+            if record.proforma_grade <= record.grade + grade_complete_match_range:
+                complete_status = True
+            response_data.append(
+                {
+                    'course_id': unicode(record.course_id),
+                    'current_grade': record.grade,
+                    'proforma_grade': record.proforma_grade,
+                    'complete_status': complete_status
+                }
+            )
+        return Response(response_data, status=status.HTTP_200_OK)
+
+
 class UsersCoursesGradesDetail(SecureAPIView):
     """
     ### The UsersCoursesGradesDetail view allows clients to interact with the User's gradebook for a particular Course


### PR DESCRIPTION
@marjev @martynjames -- I've posted a changeset here for you to review.  It contains a new API workflow which should return all of the user's gradebook entries.  Take a look and let me know if you need additional gradebook fields to be returned in the payload (currently just course_id, grade, proforma_grade).  Once we have the operation working to your liking, we'll merge to master.