### PR TITLE
Bump Problem Builder to latest version

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -762,6 +762,7 @@ MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60
 
 OPTIONAL_APPS = (
     'mentoring',
+    'problem_builder',
 
     # edx-ora2
     'submissions',
@@ -824,6 +825,7 @@ ADVANCED_COMPONENT_TYPES = [
     'graphical_slider_tool',
     'lti',
     'library_content',
+    'problem-builder',
     # XBlocks from pmitros repos are prototypes. They should not be used
     # except for edX Learning Sciences experiments on edge.edx.org without
     # further work to make them robust, maintainable, finalize data formats,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1974,6 +1974,7 @@ ALL_LANGUAGES = (
 ### Apps only installed in some instances
 OPTIONAL_APPS = (
     'mentoring',
+    'problem_builder',
 
     # edx-ora2
     'submissions',

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -1,6 +1,6 @@
 # Custom requirements to be customized by individual OpenEdX instances
 
--e git+https://github.com/edx/xblock-utils.git@8193ee7eb7a94d339435fdceb57e63964d271c3d#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@b2a17fa3793e98e67bdb86273317c41b6297dcbb#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@873b93d3f6e23d88f22d786629e9c5608ad07c75#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@21b9bcc4f2c7917463ab18a596161ac6c58c9c4a#egg=xblock-image-explorer
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
@@ -11,4 +11,4 @@
 -e git+https://github.com/mckinseyacademy/xblock-poll.git@ca0e6eb4ef10c128d573c3cec015dcfee7984730#egg=xblock-poll
 -e git+https://github.com/OfficeDev/xblock-officemix/@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock_officemix-master
 -e git+https://github.com/edx/edx-notifications.git@1496385f16d2571bc5d958c17e30f3eac3869b8e#egg=edx-notifications
--e git+https://github.com/open-craft/problem-builder.git@c3a2af39941471d1499992d64407bb59fba96024#egg=problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@d4a7b510e629cd54e79c42de480fd50f0ef6f59b#egg=problem-builder


### PR DESCRIPTION
This bumps Problem Builder to the latest version.

Will fix a [DB issue](https://openedx.atlassian.net/browse/OSPR-547) as well as SOL-782 and SOL-787 - see https://github.com/open-craft/problem-builder/pull/21
