### PR TITLE
Added problem_builder config for finding migrations

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -904,6 +904,7 @@ if 'SOUTH_MIGRATION_MODULES' not in vars() and 'SOUTH_MIGRATION_MODULES' not in 
 
 SOUTH_MIGRATION_MODULES.update({
     'edx_notifications': 'edx_notifications.stores.sql.migrations',
+    'problem_builder': 'problem_builder.south_migrations',
 })
 
 # to prevent run-away queries from happening

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2052,6 +2052,7 @@ if not 'SOUTH_MIGRATION_MODULES' in vars() and not 'SOUTH_MIGRATION_MODULES' in 
 
 SOUTH_MIGRATION_MODULES.update({
     'edx_notifications': 'edx_notifications.stores.sql.migrations',
+    'problem_builder': 'problem_builder.south_migrations',
 })
 
 # to prevent run-away queries from happening


### PR DESCRIPTION
*JIRA Ticket:* [SOL_814](https://openedx.atlassian.net/browse/SOL-814)
*Description:* Problem builder uses `south_migration` folder to store migrations; as a result, they are not automatically picked by migration. This PR configures migration machinery to look for Problem Builder migrations where they are.

This is one of two alternative solutions to the problem. Another solution is contains two components:

* https://github.com/open-craft/problem-builder/pull/23
* https://github.com/edx-solutions/edx-platform/pull/437

Advantages of this solution:
* Problem builder migrations remain compatible with modern Django (>=1.7)

Disadvantages of this solution:
* edx-platform contains problem-builder related configuration.
