### PR TITLE
Updated problem builder hash to use version with legacy Django migrations

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -11,4 +11,4 @@
 -e git+https://github.com/mckinseyacademy/xblock-poll.git@ca0e6eb4ef10c128d573c3cec015dcfee7984730#egg=xblock-poll
 -e git+https://github.com/OfficeDev/xblock-officemix/@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock_officemix-master
 -e git+https://github.com/edx/edx-notifications.git@1496385f16d2571bc5d958c17e30f3eac3869b8e#egg=edx-notifications
--e git+https://github.com/open-craft/problem-builder.git@dd92fd2916ba90cd9590fea0c1212b8c66236350#egg=problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@1d5391df41a459d8817b513bd2f3fb670c2e18a0#egg=problem-builder


### PR DESCRIPTION
**JIRA Ticket:** [SOL-814](https://openedx.atlassian.net/browse/SOL-814)

This is one of two alternative solutions to the problem. Another solution is in platform [PR#436](https://github.com/edx-solutions/edx-platform/pull/436)

Advantages of this solution:
* edx-platform does not contain problem-builder related configuration.

Disadvantages of this solution:
* Problem builder migrations might become incompatible with modern Django (>=1.7)
