### PR TITLE
Fix typo in requirements file, making "pip install" work again

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -1,7 +1,7 @@
 # Custom requirements to be customized by individual OpenEdX instances
 
 -e git+https://github.com/edx/xblock-utils.git@a0e77eeb4eb971ac57243fe1056dd8db6806f514#egg=xblock-utils
--e git+https://github.com/edx-solutions/xblock-mentoring.git@5bf410d26d80b1472c9cf60677f869a5f946a47#1egg=xblock-mentoring
+-e git+https://github.com/edx-solutions/xblock-mentoring.git@5bf410d26d80b1472c9cf60677f869a5f946a47#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@21b9bcc4f2c7917463ab18a596161ac6c58c9c4a#egg=xblock-image-explorer
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@ed24dbef753e411f2c9b17339ae21f3a89a8531c#egg=xblock-drag-and-drop-v2


### PR DESCRIPTION
@antoviaque You introduced a small typo when you updated the hashes.

I'm not sure what the right procedure is to merge this fix.  Can I just push something like this to master directly for the solutions fork?