### PR TITLE
(MCKIN-3367) Preserve user's title upon changing user's name

### DIFF
--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -224,9 +224,9 @@ class UsersApiTests(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
         # ID 1 is a Robot Test (results[0]) so the users list starts with ID 2 (results[1])
-        self.assertEqual(response.data['results'][1]['is_staff'], False)        
-        self.assertEqual(response.data['results'][3]['is_staff'], False)        
-        self.assertEqual(response.data['results'][5]['is_staff'], False)        
+        self.assertEqual(response.data['results'][1]['is_staff'], False)
+        self.assertEqual(response.data['results'][3]['is_staff'], False)
+        self.assertEqual(response.data['results'][5]['is_staff'], False)
         self.assertTrue(response.data['results'][2]['is_staff'])
         self.assertTrue(response.data['results'][4]['is_staff'])
         self.assertTrue(response.data['results'][6]['is_staff'])
@@ -547,6 +547,13 @@ class UsersApiTests(ModuleStoreTestCase):
 
         # Testing profile updating scenario.
         # Must be updated
+
+        data['first_name'] = "First Name"
+        data['last_name'] = "Surname"
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 200)
+        response = self.do_get(test_uri)
+        self.is_user_profile_created_updated(response, data)
 
         data["country"] = "US"
         data["year_of_birth"] = "1990"
@@ -1495,7 +1502,9 @@ class UsersApiTests(ModuleStoreTestCase):
     def is_user_profile_created_updated(self, response, data):
         """This function compare response with user profile data """
 
-        fullname = '{} {}'.format(self.test_first_name, self.test_last_name)
+        first_name = data.get('first_name', self.test_first_name)
+        last_name = data.get('last_name', self.test_last_name)
+        fullname = '{} {}'.format(first_name, last_name)
         self.assertEqual(response.data['full_name'], fullname)
         self.assertEqual(response.data['city'], data["city"])
         self.assertEqual(response.data['country'], data["country"])

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -588,7 +588,7 @@ class UsersDetail(SecureAPIView):
             if gender:
                 existing_user_profile.gender = gender
             # Empty title is also allowed
-            title = request.DATA.get('title', None)
+            title = request.DATA.get('title', existing_user_profile.title)
             existing_user_profile.title = title
             avatar_url = request.DATA.get('avatar_url')
             if avatar_url:


### PR DESCRIPTION
JIRA ticket: https://edx-wiki.atlassian.net/browse/MCKIN-3367

Steps to reproduce:
1) update the title in profile dropdown
2) updating the name shouldn't remove the user's title

@mattdrayer I've changed the api side to fix the bug reported in the ticket linked above. Could you perhaps review this sometimes this week?