### PR TITLE
Remove south table shortening call.

### DIFF
--- a/lms/djangoapps/verify_student/migrations/0004_auto__add_verificationcheckpoint__add_unique_verificationcheckpoint_co.py
+++ b/lms/djangoapps/verify_student/migrations/0004_auto__add_verificationcheckpoint__add_unique_verificationcheckpoint_co.py
@@ -17,7 +17,7 @@ class Migration(SchemaMigration):
         db.send_create_signal('verify_student', ['VerificationCheckpoint'])
 
         # Adding M2M table for field photo_verification on 'VerificationCheckpoint'
-        m2m_table_name = db.shorten_name('verify_student_verificationcheckpoint_photo_verification')
+        m2m_table_name = 'verify_student_verificationcheckpoint_photo_verification'
         db.create_table(m2m_table_name, (
             ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
             ('verificationcheckpoint', models.ForeignKey(orm['verify_student.verificationcheckpoint'], null=False)),


### PR DESCRIPTION
The shortening call here will create a table name that conflicts with a model table, and things appear to work just fine without it.