### PR TITLE
Revert "Updated GP v1 notifications URL resolver to use new querystring attribute"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1072,7 +1072,7 @@ NOTIFICATION_CLICK_LINK_URL_MAPS = {
     'open-edx.studio.announcements.*': '/courses/{course_id}/announcements',
     'open-edx.lms.leaderboard.*': '/courses/{course_id}/cohort',
     'open-edx.lms.discussions.*': '/courses/{course_id}/discussion/{commentable_id}/threads/{thread_id}',
-    'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?actid={activity_location}',
+    'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?seqid={activity_location}',
 }
 
 # list all known channel providers

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2691,7 +2691,7 @@ NOTIFICATION_CLICK_LINK_URL_MAPS = {
     'open-edx.studio.announcements.*': '/courses/{course_id}/announcements',
     'open-edx.lms.leaderboard.*': '/courses/{course_id}/cohort',
     'open-edx.lms.discussions.*': '/courses/{course_id}/discussion/{commentable_id}/threads/{thread_id}',
-    'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?actid={activity_location}',
+    'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?seqid={activity_location}',
 }
 
 # list all known channel providers


### PR DESCRIPTION

This reverts commit c083c903c14d8e4aa21d9b6fe3a2b2d8193b2b02.

When groupwork fires off a notification, the platform uses the edx-notifications library to transform that notification into a URL the user can click.

Before Eugeny's change, it used a querystring parameter of 'seqid', which eugeny changed to better reflect what the parameter was actually pointing to, which was an activity. He updated it there and in Apros, visible in the other PR.

However every link that had previously been transformed was stored, causing the issue in https://openedx.atlassian.net/browse/YONK-146

All of the links used 'seqid' instead of 'actid'. New notifications, once the platform was updated, would use 'actid', but this hasn't happened in production yet since the production settings were never changed to use actid. They're still using seqid, so production is broken as well. This, along with https://github.com/mckinseyacademy/mcka_apros/pull/1180 should fix the issue.