### PR TITLE
Cohort changes

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -18,6 +18,7 @@ class CourseMetadata(object):
     # Should not be used directly. Instead the filtered_list method should
     # be used if the field needs to be filtered depending on the feature flag.
     FILTERED_LIST = [
+        'cohort_config',
         'xml_attributes',
         'start',
         'end',

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -154,7 +154,6 @@ class AdvancedSettingsPage(CoursePage):
             'cert_name_long',
             'cert_name_short',
             'certificates_display_behavior',
-            'cohort_config',
             'course_image',
             'cosmetic_display_price',
             'advertised_start',

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -391,7 +391,7 @@ class ViewsTestCase(UrlResetMixin, ModuleStoreTestCase, MockRequestSetupMixin):
 
         self.course.cohort_config = {
             'cohorted': True,
-            'inline_discussions_cohorting_default': True
+            'always_cohort_inline_discussions': True
         }
         self.store.update_item(self.course, self.student.id)
 

--- a/lms/djangoapps/django_comment_client/management/commands/export_discussion_participation.py
+++ b/lms/djangoapps/django_comment_client/management/commands/export_discussion_participation.py
@@ -13,6 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from courseware.courses import get_course
+from openedx.core.djangoapps.course_groups.cohorts import get_course_cohort_settings
 from student.models import CourseEnrollment
 
 from lms.lib.comment_client.user import User
@@ -186,7 +187,7 @@ class Command(BaseCommand):
 
         target_discussion_ids = None
         if options.get(self.COHORTED_ONLY_PARAMETER, False):
-            cohorted_discussions = course.cohort_config.get('cohorted_inline_discussions', None)
+            cohorted_discussions = get_course_cohort_settings(course_key).cohorted_discussions
             if not cohorted_discussions:
                 raise MissingCohortedConfigCommandError(
                     "Only cohorted discussions are marked for export, "

--- a/openedx/core/djangoapps/course_groups/admin.py
+++ b/openedx/core/djangoapps/course_groups/admin.py
@@ -1,0 +1,16 @@
+"""
+Provides Django admin interface for CourseCohortsSettings. Useful for when only the CMS is
+used and the normal LMS interface is unavailable.
+"""
+from django.contrib import admin
+from .models import CourseCohortsSettings
+
+
+class CourseCohortsSettingsAdmin(admin.ModelAdmin):
+    """
+    Provides editing interface for the CourseCohortsSettings model.
+    """
+    list_display = ('course_id',)
+
+
+admin.site.register(CourseCohortsSettings, CourseCohortsSettingsAdmin)

--- a/openedx/core/djangoapps/course_groups/management/commands/convert_cohort_format.py
+++ b/openedx/core/djangoapps/course_groups/management/commands/convert_cohort_format.py
@@ -1,0 +1,29 @@
+"""
+Converts the old cohort_config format to the new one.
+"""
+from django.core.management import BaseCommand
+from xmodule.modulestore.django import modulestore
+
+
+class Command(BaseCommand):
+    """
+    Command to convert settings in cohort_config to ones that can be translated by
+    the lazy converter.
+
+    For the solutions devstack, which used different property names.
+
+    It appears the only change that needs to be made is to change 'inline_discussions_cohorting_default'
+    to 'always_cohort_inline_discussions'. Every other difference can be ignored benignly.
+    """
+    help = 'Revert the multiple cohorts feature.'
+
+    def handle(self, *args, **options):
+        store = modulestore()
+        for course in store.get_courses():
+            if course.cohort_config and 'inline_discussions_cohorting_default' in course.cohort_config:
+                print "Updating affected course: %s" % unicode(course.location)
+                course.cohort_config['always_cohort_inline_discussions'] = course.cohort_config[
+                    'inline_discussions_cohorting_default'
+                ]
+                store.update_item(course, None)
+                print "%s updated." % unicode(course.location)

--- a/openedx/core/djangoapps/course_groups/management/commands/tests/test_convert_cohort_format.py
+++ b/openedx/core/djangoapps/course_groups/management/commands/tests/test_convert_cohort_format.py
@@ -1,0 +1,35 @@
+"""
+Tests to make sure the convert_cohort_format command works correctly.
+"""
+from ddt import unpack, data, ddt
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from openedx.core.djangoapps.course_groups.management.commands.convert_cohort_format import Command
+
+
+@ddt
+class TestConvertCohortFormat(ModuleStoreTestCase):
+    """
+    Make sure the format is converted correctly.
+    """
+
+    @unpack
+    @data(
+        ({'unrelated_setting': False, 'inline_discussions_cohorting_default': True}, {
+            'unrelated_setting': False, 'inline_discussions_cohorting_default': True,
+            'always_cohort_inline_discussions': True,
+        }),
+        ({'unrelated_setting': False}, {'unrelated_setting': False}),
+        (None, {})
+    )
+    def test_convert_format(self, course_config, result):
+        if course_config:
+            course = CourseFactory(metadata={'cohort_config': course_config})
+        else:
+            course = CourseFactory()
+        Command().handle()
+        # pylint: disable=no-member
+        course = modulestore().get_course(course.location.course_key)
+        self.assertEqual(
+            course.cohort_config, result)

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -103,6 +103,12 @@ class CourseCohortsSettings(models.Model):
         """Un-Jsonify the cohorted_discussions"""
         self._cohorted_discussions = json.dumps(value)
 
+    class Meta(object):
+        """
+        Meta options for this model.
+        """
+        verbose_name_plural = "Course Cohort Settings"
+
 
 class CourseCohort(models.Model):
     """


### PR DESCRIPTION
This PR:
1. Removes cohort_config from advanced settings since that setting is no longer respected.
2. Adds an Admin view for the new CourseCohortSettings model, since our course authors do not have access to the LMS
3. Updates existing code to use the API for getting course cohort settings.
4. Adds a command to convert cohort_config settings so that they will be properly understood by the lazy converter upstream made. The command needs to be run before interfacing with any of the courses. If you've already run a cypress branch, you will likely need to clear out all CourseCohortSettings objects from the DB. you can do this with CourseCohortSettings.objects.all().delete() or by truncating the relevant table.

See https://openedx.atlassian.net/browse/YONK-171

To test:

1. Use master to set up course cohort_config options. Set the key 'inline_discussions_cohorting_default' to True, adding it if needed.
2. Switch to this branch, but do not run the LMS.
3. Run `./manage.py lms convert_cohort_format --settings=devstack`. You should see the course you edited mentioned.
4. Run the LMS. You should not see cohort_config in the advanced settings. Use a superuser to enter the Django admin and look for CourseCohortSettings. Pick the one for your course and verify 'always_cohort_inline_discussions' is checked.

@bradenmacdonald @smarnach 