### PR TITLE
Default URL resolvers for GP v2 notifications

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1073,6 +1073,7 @@ NOTIFICATION_CLICK_LINK_URL_MAPS = {
     'open-edx.lms.leaderboard.*': '/courses/{course_id}/cohort',
     'open-edx.lms.discussions.*': '/courses/{course_id}/discussion/{commentable_id}/threads/{thread_id}',
     'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?seqid={activity_location}',
+    'open-edx.xblock.group-project-v2.*': '/courses/{course_id}/group_work?activate_block_id={location}',
 }
 
 # list all known channel providers

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2692,6 +2692,7 @@ NOTIFICATION_CLICK_LINK_URL_MAPS = {
     'open-edx.lms.leaderboard.*': '/courses/{course_id}/cohort',
     'open-edx.lms.discussions.*': '/courses/{course_id}/discussion/{commentable_id}/threads/{thread_id}',
     'open-edx.xblock.group-project.*': '/courses/{course_id}/group_work?seqid={activity_location}',
+    'open-edx.xblock.group-project-v2.*': '/courses/{course_id}/group_work?activate_block_id={location}',
 }
 
 # list all known channel providers

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6b3393a1a5eb76224ecd3311e870ab8adf4badbf#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@effa22006bb6528bc6d3788787466eb4e74e1161#egg=xblock-adventure
 -e git+https://github.com/mckinseyacademy/xblock-poll.git@ca0e6eb4ef10c128d573c3cec015dcfee7984730#egg=xblock-poll
--e git+https://github.com/edx/edx-notifications.git@8038452f6fbb2b95ad46f8fe7a2f80b145b45b9c#egg=edx-notifications
+-e git+https://github.com/edx/edx-notifications.git@275b8354593048ecae3e06642985b702b81140cc#egg=edx-notifications
 -e git+https://github.com/open-craft/problem-builder.git@6af171bbeca26de434c75105912b563906840b62#egg=problem-builder
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@648c357c2b57fe6fa5ff68a0c29e6e72f309b9ca#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix


### PR DESCRIPTION
**Background:** Group Project XBlock sends notifications for file upload, grades posted and stage open/close dates. Group Project v2 sends the same types of messages, but uses different navigation approach, so the URLs in messages need to be different. For this to work, GP v2 has to send messages of unique types. 

**Description:** This PR switches GP v2 to use dedicated message types. Note this PR is likely slightly incomplete, as it should include a hash update of edx-notifications. If edx-notifications PR is merged before this one, the hash will be updated as part of this PR; otherwise, there would be a separate PR for that.

**Dependencies:** This PR is one of the three that fix notifications in Group Project v2 XBlock; the other two are:
* https://github.com/open-craft/xblock-group-project-v2/pull/53 - switches GP v2 to use dedicated message types
* https://github.com/edx/edx-notifications/pull/162 - registers new message types

**Related:** [YONK-146](https://openedx.atlassian.net/browse/YONK-146) was caused by changing URL resolvers for GP v1. Should not be affected by this change.

**Testing instructions:** 
The simplest way to test this is the follwoing:
1. Go to Group Project v2 page
2. Upload a file via submission view in Project Navigator.
![upload](https://cloud.githubusercontent.com/assets/3330048/9761138/79646c4c-5703-11e5-9c7d-a94cac1584c0.png)
3. Log off, than log on as a different user in the same workgroup
4. Note that "File(s) uploaded" notification was sent.
![newnotification](https://cloud.githubusercontent.com/assets/3330048/9761203/e8f212da-5703-11e5-9dfe-972d120d664a.png)
5. Click on the notification
![fileuploaded](https://cloud.githubusercontent.com/assets/3330048/9761309/9cd45132-5704-11e5-9626-a25a77b5b3b6.png)

6. You should be taken to the activity the file was uploaded for

There are three other types of notifications:
* Grades posted - sent when grade becomes available for an activity
* Stage open - sent when stage opens (likely at 00:00 on the opening date)
* Stage due - sent when stage is due (likely at 00:00 on the closing date) and three days in advance.

Note that to trigger the latter two one need to edit the GP in studio, than wait until the condition is met. Also note that they are configured to ignore the notification if the delivery date is in past (i.e. there's no point to set up open/close dates in past - notifications will be ignored)