### PR TITLE
XBlock-utils hash update

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -1,5 +1,9 @@
 # Custom requirements to be customized by individual OpenEdX instances
 
+# When updating a hash of an XBlock that uses xblock-utils, please update xblock-utils version hash here and in
+# github.txt as well. Deployments install custom.txt before github.txt and github.txt installs xblock-utils. This might
+# lead to installing an outdated version of xblock-utils and causing regressions. A note in github.txt is added to
+# keep xblock-utils version there in sync with this one.
 -e git+https://github.com/edx/xblock-utils.git@25f15734ec8d29fde0e114bbd199fd48638865ae#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@bd0b3f413ae7e8274985555adfd7de7af3eca84c#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@21b9bcc4f2c7917463ab18a596161ac6c58c9c4a#egg=xblock-image-explorer

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -50,7 +50,8 @@ git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 -e git+https://github.com/edx/edx-search.git@release-2015-07-03#egg=edx-search
 -e git+https://github.com/edx/edx-milestones.git@release-2015-06-17#egg=edx-milestones
 git+https://github.com/edx/edx-lint.git@ed8c8d2a0267d4d42f43642d193e25f8bd575d9b#egg=edx_lint==0.2.3
--e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
+# Note for the next rebase: custom.txt or one of XBlocks installed there might require a newer version of xblock-utils - please check versions
+-e git+https://github.com/edx/xblock-utils.git@25f15734ec8d29fde0e114bbd199fd48638865ae#egg=xblock-utils
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@a286e89c73e1b788e35ac5b08a54b71a9fa63cfd#egg=edx-reverification-block
 git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-client==1.0.0


### PR DESCRIPTION
Updating github.txt xblock-utils hash to match custom.txt version, since deployments install [custom requirements](https://github.com/edx/configuration/blob/368b717b4ac8dae96a9db6af4ab3aea4b4618c91/playbooks/roles/edxapp/tasks/deploy.yml#L168) just before [github requirements](https://github.com/edx/configuration/blob/368b717b4ac8dae96a9db6af4ab3aea4b4618c91/playbooks/roles/edxapp/tasks/deploy.yml#L179) and github installs outdated version.