### PR TITLE
Merge course discussion IDs for cohort config conversion.

### DIFF
--- a/openedx/core/djangoapps/course_groups/management/commands/convert_cohort_format.py
+++ b/openedx/core/djangoapps/course_groups/management/commands/convert_cohort_format.py
@@ -20,10 +20,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         store = modulestore()
         for course in store.get_courses():
-            if course.cohort_config and 'inline_discussions_cohorting_default' in course.cohort_config:
+            if course.cohort_config:
                 print "Updating affected course: %s" % unicode(course.location)
-                course.cohort_config['always_cohort_inline_discussions'] = course.cohort_config[
-                    'inline_discussions_cohorting_default'
-                ]
+                if 'inline_discussions_cohorting_default' in course.cohort_config:
+                    course.cohort_config['always_cohort_inline_discussions'] = course.cohort_config[
+                        'inline_discussions_cohorting_default'
+                    ]
+                inlines = course.cohort_config.get('cohorted_inline_discussions', [])
+                course_discussions = course.cohort_config.get('cohorted_course_wide_discussions', [])
+                if inlines or course_discussions:
+                    course.cohort_config['cohorted_discussions'] = inlines + course_discussions
                 store.update_item(course, None)
                 print "%s updated." % unicode(course.location)

--- a/openedx/core/djangoapps/course_groups/management/commands/tests/test_convert_cohort_format.py
+++ b/openedx/core/djangoapps/course_groups/management/commands/tests/test_convert_cohort_format.py
@@ -16,10 +16,47 @@ class TestConvertCohortFormat(ModuleStoreTestCase):
 
     @unpack
     @data(
-        ({'unrelated_setting': False, 'inline_discussions_cohorting_default': True}, {
-            'unrelated_setting': False, 'inline_discussions_cohorting_default': True,
-            'always_cohort_inline_discussions': True,
-        }),
+        (
+            {
+                'unrelated_setting': False, 'inline_discussions_cohorting_default': True,
+                'cohorted_inline_discussions': ['test1', 'test2'],
+                'cohorted_course_wide_discussions': ['test3', 'test4']
+            },
+            {
+                'unrelated_setting': False, 'inline_discussions_cohorting_default': True,
+                'cohorted_inline_discussions': ['test1', 'test2'],
+                'cohorted_course_wide_discussions': ['test3', 'test4'],
+                'cohorted_discussions': ['test1', 'test2', 'test3', 'test4'],
+                'always_cohort_inline_discussions': True,
+            }
+        ),
+        (
+            {
+                'cohorted_inline_discussions': ['test1', 'test2'],
+            },
+            {
+                'cohorted_inline_discussions': ['test1', 'test2'],
+                'cohorted_discussions': ['test1', 'test2'],
+            }
+        ),
+        (
+            {
+                'cohorted_course_wide_discussions': ['test3', 'test4'],
+            },
+            {
+                'cohorted_course_wide_discussions': ['test3', 'test4'],
+                'cohorted_discussions': ['test3', 'test4']
+            }
+        ),
+        (
+            {
+                'inline_discussions_cohorting_default': True
+            },
+            {
+                'inline_discussions_cohorting_default': True,
+                'always_cohort_inline_discussions': True
+            }
+        ),
         ({'unrelated_setting': False}, {'unrelated_setting': False}),
         (None, {})
     )


### PR DESCRIPTION
Cohorted discussion IDs were not being properly handled and merged for conversion. See https://openedx.atlassian.net/browse/YONK-211

@bradenmacdonald @smarnach Please review at first opportunity so we can get this in the release if possible.