### PR TITLE
Custom SSO entry points

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -93,3 +93,6 @@ def apply_settings(django_settings):
         django_settings.SOCIAL_AUTH_USER_FIELDS = getattr(
             django_settings, 'USER_FIELDS', ['username', 'email', 'first_name', 'last_name', 'fullname']
         )
+
+    if not hasattr(django_settings, 'THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS'):
+        django_settings.THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = {}

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -4,6 +4,7 @@ ConfigurationModels rather than django.settings
 """
 import logging
 from .models import OAuth2ProviderConfig
+from .pipeline import AUTH_ENTRY_CUSTOM
 from social.backends.oauth import BaseOAuth2
 from social.strategies.django_strategy import DjangoStrategy
 
@@ -33,6 +34,15 @@ class ConfigurationModelStrategy(DjangoStrategy):
                 return provider_config.get_setting(name)
             except KeyError:
                 pass
+
+        # special case handling of login error URL if we're using a custom auth entry point:
+        if name == 'LOGIN_ERROR_URL':
+            auth_entry = self.request.session.get('auth_entry')
+            if auth_entry and auth_entry in AUTH_ENTRY_CUSTOM:
+                error_url = AUTH_ENTRY_CUSTOM[auth_entry].get('error_url')
+                if error_url:
+                    return error_url
+
         # At this point, we know 'name' is not set in a [OAuth2|SAML]ProviderConfig row.
         # It's probably a global Django setting like 'FIELDS_STORED_IN_SESSION':
         return super(ConfigurationModelStrategy, self).setting(name, default, backend)

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -87,3 +87,17 @@ class ConfigurationModelStrategy(DjangoStrategy):
 
         # when autoprovisioning we need to skip email activation, hence skip_email is True
         return create_account_with_params(self.request, user_fields, skip_email=True)
+
+    def request_host(self):
+        forwarded_host = self.request.META.get('HTTP_X_FORWARDED_HOST')
+        if forwarded_host:
+            return forwarded_host
+
+        return super(ConfigurationModelStrategy, self).request_host()
+
+    def request_port(self):
+        forwarded_port = self.request.META.get('HTTP_X_FORWARDED_PORT')
+        if forwarded_port:
+            return forwarded_port
+
+        return super(ConfigurationModelStrategy, self).request_port()

--- a/common/djangoapps/third_party_auth/templates/third_party_auth/post_custom_auth_entry.html
+++ b/common/djangoapps/third_party_auth/templates/third_party_auth/post_custom_auth_entry.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{% trans "Please wait" %}</title>
+    <style type="text/css">
+    #djDebug {display:none;}
+    </style>
+</head>
+<body>
+    <form id="sso-data-form" action="{{post_url}}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="sso_data" value="{{data}}">
+        <input type="hidden" name="sso_data_hmac" value="{{hmac}}">
+        <noscript>
+        <input id="submit-button" type="submit" value="Click to continue" autofocus>
+        </noscript>
+    </form>
+    <script>
+    document.getElementById('sso-data-form').submit();
+    </script>
+</body>
+</html>

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -1,7 +1,17 @@
 """Integration tests for Google providers."""
 
-from third_party_auth import provider
+import base64
+import hashlib
+import hmac
+from django.conf import settings
+from django.core.urlresolvers import reverse
+import json
+from mock import patch
+from social.exceptions import AuthException
+from student.tests.factories import UserFactory
+from third_party_auth import pipeline
 from third_party_auth.tests.specs import base
+from urlparse import urlparse, parse_qs
 
 
 class GoogleOauth2IntegrationTest(base.Oauth2IntegrationTest):
@@ -35,3 +45,89 @@ class GoogleOauth2IntegrationTest(base.Oauth2IntegrationTest):
 
     def get_username(self):
         return self.get_response_data().get('email').split('@')[0]
+
+    def assert_redirect_to_provider_looks_correct(self, response):
+        super(GoogleOauth2IntegrationTest, self).assert_redirect_to_provider_looks_correct(response)
+        self.assertIn('google.com', response['Location'])
+
+    def test_custom_form(self):
+        """
+        Use the Google provider to test the custom login/register form feature.
+        """
+        # The pipeline starts by a user GETting /auth/login/google-oauth2/?auth_entry=custom1
+        # Synthesize that request and check that it redirects to the correct
+        # provider page.
+        auth_entry = 'custom1'  # See definition in lms/envs/test.py
+        login_url = pipeline.get_login_url(self.provider.provider_id, auth_entry)
+        login_url += "&next=/misc/final-destination"
+        self.assert_redirect_to_provider_looks_correct(self.client.get(login_url))
+
+        def fake_auth_complete(inst, *args, **kwargs):
+            """ Mock the backend's auth_complete() method """
+            kwargs.update({'response': self.get_response_data(), 'backend': inst})
+            return inst.strategy.authenticate(*args, **kwargs)
+
+        # Next, the provider makes a request against /auth/complete/<provider>.
+        complete_url = pipeline.get_complete_url(self.provider.backend_name)
+        with patch.object(self.provider.backend_class, 'auth_complete', fake_auth_complete):
+            response = self.client.get(complete_url)
+        # This should redirect to the custom login/register form:
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'][:50], 'http://testserver/misc/my-custom-registration-form')
+        redirect_query = parse_qs(urlparse(response['Location']).query)
+        self.assertIn('data', redirect_query)
+        self.assertIn('hmac', redirect_query)
+        data_decoded = base64.b64decode(redirect_query['data'][0])
+        data_parsed = json.loads(data_decoded)
+        # The user's details get passed to the custom page as a base64 encoded query parameter:
+        self.assertEqual(data_parsed, {
+            'user_details': {
+                'username': 'email_value',
+                'email': 'email_value@example.com',
+                'fullname': 'name_value',
+                'first_name': 'given_name_value',
+                'last_name': 'family_name_value',
+            }
+        })
+        # Check the hash that is used to confirm the user's data in the GET parameter is correct
+        secret_key = settings.THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS['custom1']['secret_key']
+        hmac_expected = hmac.new(secret_key, msg=data_decoded, digestmod=hashlib.sha256).digest()
+        self.assertEqual(base64.b64decode(redirect_query['hmac'][0]), hmac_expected)
+
+        # Now our custom registration form creates or logs in the user:
+        email, password = data_parsed['user_details']['email'], 'random_password'
+        created_user = UserFactory(email=email, password=password)
+        login_response = self.client.post(reverse('login'), {'email': email, 'password': password})
+        self.assertEqual(login_response.status_code, 200)
+
+        # Now our custom login/registration page must resume the pipeline:
+        response = self.client.get(complete_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/misc/final-destination')
+
+        _, strategy = self.get_request_and_strategy()
+        self.assert_social_auth_exists_for_user(created_user, strategy)
+
+    def test_custom_form_error(self):
+        """
+        Use the Google provider to test the custom login/register failure redirects.
+        """
+        # The pipeline starts by a user GETting /auth/login/google-oauth2/?auth_entry=custom1
+        # Synthesize that request and check that it redirects to the correct
+        # provider page.
+        auth_entry = 'custom1'  # See definition in lms/envs/test.py
+        login_url = pipeline.get_login_url(self.provider.provider_id, auth_entry)
+        login_url += "&next=/misc/final-destination"
+        self.assert_redirect_to_provider_looks_correct(self.client.get(login_url))
+
+        def fake_auth_complete_error(_inst, *_args, **_kwargs):
+            """ Mock the backend's auth_complete() method """
+            raise AuthException("Mock login failed")
+
+        # Next, the provider makes a request against /auth/complete/<provider>.
+        complete_url = pipeline.get_complete_url(self.provider.backend_name)
+        with patch.object(self.provider.backend_class, 'auth_complete', fake_auth_complete_error):
+            response = self.client.get(complete_url)
+        # This should redirect to the custom error URL
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], 'http://testserver/misc/my-custom-sso-error-page')

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -2,11 +2,12 @@
 
 from django.conf.urls import include, patterns, url
 
-from .views import inactive_user_view, saml_metadata_view
+from .views import inactive_user_view, saml_metadata_view, post_to_custom_auth_form
 
 urlpatterns = patterns(
     '',
     url(r'^auth/inactive', inactive_user_view),
+    url(r'^auth/custom_auth_entry', post_to_custom_auth_form, name='tpa_post_to_custom_auth_form'),
     url(r'^auth/saml/metadata.xml', saml_metadata_view),
     url(r'^auth/', include('social.apps.django_app.urls', namespace='social')),
 )

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -4,7 +4,7 @@ Extra views required for SSO
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError, Http404
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from social.apps.django_app.utils import load_strategy, load_backend
 from .models import SAMLConfiguration
 
@@ -36,3 +36,26 @@ def saml_metadata_view(request):
     if not errors:
         return HttpResponse(content=metadata, content_type='text/xml')
     return HttpResponseServerError(content=', '.join(errors))
+
+
+def post_to_custom_auth_form(request):
+    """
+    Redirect to a custom login/register page.
+
+    Since we can't do a redirect-to-POST, this view is used to pass SSO data from
+    the third_party_auth pipeline to a custom login/register form (possibly on another server).
+    """
+    pipeline_data = request.session.pop('tpa_custom_auth_entry_data', None)
+    if not pipeline_data:
+        raise Http404
+    # Verify the format of pipeline_data:
+    data = {
+        'post_url': pipeline_data['post_url'],
+        # The user's name, email, etc. as base64 encoded JSON
+        # It's base64 encoded because it's signed cryptographically and we don't want whitespace
+        # or ordering issues affecting the hash/signature.
+        'data': pipeline_data['data'],
+        # The cryptographic hash of user_data:
+        'hmac': pipeline_data['hmac'],
+    }
+    return render(request, 'third_party_auth/post_custom_auth_entry.html', data)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -598,6 +598,11 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     # IdP provided name is empty, missing or does not pass minimal length check
     THIRD_PARTY_AUTH_FALLBACK_FULL_NAME = ENV_TOKENS.get('THIRD_PARTY_AUTH_FALLBACK_FULL_NAME', "Unknown")
 
+    # The following can be used to integrate a custom login form with third_party_auth.
+    # It should be a dict where the key is a word passed via ?auth_entry=, and the value is a
+    # dict with an arbitrary 'secret_key' and a 'url'.
+    THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = AUTH_TOKENS.get('THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS', {})
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
     OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -261,6 +261,14 @@ AUTHENTICATION_BACKENDS = (
 FAKE_EMAIL_DOMAIN = 'fake-email-domain.foo'
 THIRD_PARTY_AUTH_FALLBACK_FULL_NAME = "Unknown"
 
+THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = {
+    'custom1': {
+        'secret_key': 'opensesame',
+        'url': '/misc/my-custom-registration-form',
+        'error_url': '/misc/my-custom-sso-error-page'
+    },
+}
+
 ################################## OPENID #####################################
 FEATURES['AUTH_USE_OPENID'] = True
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True


### PR DESCRIPTION
This PR makes a simple change to `third_party_auth` so that we can configure "custom auth entry points" on a server. This basically means we can have a custom URL acting as the login/register page, and it will be correctly integrated with the SSO pipeline. It can be an internal URL that's part of the LMS or an external URL.

This PR also tweaks the solutions server API so that we can login a user by "upgrading" their existing anonymous session rather than creating a new session. This is required to preserve the third_party_auth pipeline during SSO logins.

**JIRA**: This is part of [YONK-81](https://openedx.atlassian.net/browse/YONK-81)

**For more context and real world use**: See Apros PR 1189.

**Example**:

First, one would configure a custom auth entry point called `marketing` in `lms.auth.json`:

```
    "THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS": {
        "marketing": {"key": "opensesame", "url": "http://marketing.mylms.com/sso-login"}
    }
```

Then one can send users to `/auth/login/:provider/?auth_entry=marketing&next=/final/url`. Users will then be prompted to login to their provider, then redirected to the `url` set in `THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS['marketing']`. (It is important that this parameter is configured via settings and not via the URL, to avoid attacks where users are given a malicious URL that leads them to fill out fake registration forms that submit data to a third party).

The custom login/register page can then do whatever it wants in terms of logging in / registering the user, and it will get the user's basic information (username, email, name, etc.) passed as POST data and signed with a message authentication code. Finally, the custom login/register page must send the user to `/auth/complete/:provider/` to finish the SSO process and link the user's account to the provider.

**Reviewers**

@e-kolpakov and TBD