### PR TITLE
Third party auth: Support for running behind a reverse proxy on a non-standard port

### DIFF
--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -89,15 +89,27 @@ class ConfigurationModelStrategy(DjangoStrategy):
         return create_account_with_params(self.request, user_fields, skip_email=True)
 
     def request_host(self):
-        forwarded_host = self.request.META.get('HTTP_X_FORWARDED_HOST')
-        if forwarded_host:
-            return forwarded_host
+        """
+        Host in use for this request
+        """
+        # TODO: this override is a temporary measure until upstream python-social-auth patch is merged:
+        # https://github.com/omab/python-social-auth/pull/741
+        if self.setting('RESPECT_X_FORWARDED_HEADERS', False):
+            forwarded_host = self.request.META.get('HTTP_X_FORWARDED_HOST')
+            if forwarded_host:
+                return forwarded_host
 
         return super(ConfigurationModelStrategy, self).request_host()
 
     def request_port(self):
-        forwarded_port = self.request.META.get('HTTP_X_FORWARDED_PORT')
-        if forwarded_port:
-            return forwarded_port
+        """
+        Port in use for this request
+        """
+        # TODO: this override is a temporary measure until upstream python-social-auth patch is merged:
+        # https://github.com/omab/python-social-auth/pull/741
+        if self.setting('RESPECT_X_FORWARDED_HEADERS', False):
+            forwarded_port = self.request.META.get('HTTP_X_FORWARDED_PORT')
+            if forwarded_port:
+                return forwarded_port
 
         return super(ConfigurationModelStrategy, self).request_port()

--- a/common/djangoapps/third_party_auth/tests/test_strategy.py
+++ b/common/djangoapps/third_party_auth/tests/test_strategy.py
@@ -2,7 +2,9 @@
 import unittest
 import ddt
 import mock
-from unittest import TestCase
+
+from django.test import TestCase
+
 from third_party_auth.strategy import ConfigurationModelStrategy
 from third_party_auth.tests import testutil
 
@@ -97,30 +99,40 @@ class TestStrategy(TestCase):
         self.assertEqual(user_data['email'], expected_email)
 
     @ddt.data(
-        (None, 'host', 'host'),
-        ("", 'other_host', 'other_host'),
-        ('x_forwarded_host', 'irrelevant', 'x_forwarded_host'),
-        ('other_x_forwarded_host', 'still_irrelevant', 'other_x_forwarded_host'),
+        (True, None, 'host', 'host'),
+        (True, "", 'other_host', 'other_host'),
+        (True, 'x_forwarded_host', 'irrelevant', 'x_forwarded_host'),
+        (True, 'other_x_forwarded_host', 'still_irrelevant', 'other_x_forwarded_host'),
+        (False, None, 'host', 'host'),
+        (False, "", 'other_host', 'other_host'),
+        (False, 'x_forwarded_host', 'normal_host', 'normal_host'),
+        (False, 'other_x_forwarded_host', 'other_normal_host', 'other_normal_host'),
     )
     @ddt.unpack
-    def test_request_host(self, x_forwarded_value, get_host_value, expected_value, unused_patch):
+    def test_request_host(self, respect_x_headers, x_forwarded_value, get_host_value, expected_value, unused_patch):
         self.request_mock.META = {}
         self.request_mock.get_host.return_value = get_host_value
         if x_forwarded_value is not None:
             self.request_mock.META['HTTP_X_FORWARDED_HOST'] = x_forwarded_value
 
-        self.assertEqual(self.strategy.request_host(), expected_value)
+        with self.settings(RESPECT_X_FORWARDED_HEADERS=respect_x_headers):
+            self.assertEqual(self.strategy.request_host(), expected_value)
 
     @ddt.data(
-        (None, 'host', 'host'),
-        ("", 'other_host', 'other_host'),
-        ('x_forwarded_host', 'irrelevant', 'x_forwarded_host'),
-        ('other_x_forwarded_host', 'still_irrelevant', 'other_x_forwarded_host'),
+        (True, None, 'port', 'port'),
+        (True, "", 'other_port', 'other_port'),
+        (True, 'x_forwarded_port', 'irrelevant', 'x_forwarded_port'),
+        (True, 'other_x_forwarded_port', 'still_irrelevant', 'other_x_forwarded_port'),
+        (False, None, 'port', 'port'),
+        (False, "", 'other_port', 'other_port'),
+        (False, 'x_forwarded_port', 'normal_port', 'normal_port'),
+        (False, 'other_x_forwarded_port', 'other_normal_port', 'other_normal_port'),
     )
     @ddt.unpack
-    def test_request_port(self, x_forwarded_value, server_port_value, expected_value, unused_patch):
+    def test_request_port(self, respect_x_headers, x_forwarded_value, server_port_value, expected_value, unused_patch):
         self.request_mock.META = {'SERVER_PORT': server_port_value}
         if x_forwarded_value is not None:
             self.request_mock.META['HTTP_X_FORWARDED_PORT'] = x_forwarded_value
 
-        self.assertEqual(self.strategy.request_port(), expected_value)
+        with self.settings(RESPECT_X_FORWARDED_HEADERS=respect_x_headers):
+            self.assertEqual(self.strategy.request_port(), expected_value)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -590,6 +590,8 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
             'schedule': datetime.timedelta(hours=ENV_TOKENS.get('THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS', 24)),
         }
 
+    SOCIAL_AUTH_RESPECT_X_FORWARDED_HEADERS = ENV_TOKENS.get('SOCIAL_AUTH_RESPECT_X_FORWARDED_HEADERS')
+
     # FAKE EMAIL DOMAIN setting is used to generate an email for an automatically provisioned account in case
     # it is not provided by IdP (which should'nt normally be the case for providers with automatic provisioning)
     FAKE_EMAIL_DOMAIN = ENV_TOKENS.get('FAKE_EMAIL_DOMAIN', 'fake-email-domain.foo')


### PR DESCRIPTION
**Description:** If LMS is set up to run behind a reverse proxy, the external host and port for TPA request are not the same as internal ones. `python-social-auth` can only grab internal values, so it results in "Response was received at wrong address" authentication errors.

Common practice is to set up X-Forwarded-* headers to keep information about initial request target. Some web-servers (i.e. gunicorn) honors these headers and, if present, pass their values to Django as real host and port. Other servers does not do that (i.e. django development server used in dev environments). This PR adds an explicit support for X-Forwarded-Port and X-Forwarded-Host headers, using them for purposes of checking the TPA response destination.

**Related JIRA Ticket:** https://openedx.atlassian.net/browse/YONK-83
**Upstream PR:** https://github.com/edx/edx-platform/pull/9848
**Upstream Sandboxes:** [LMS](http://pr9848.sandbox.opencraft.com/), [Studio](http://studio.pr9848.sandbox.opencraft.com/)