### PR TITLE
[YONK-148] Third party auth and Notifications conflict

### DIFF
--- a/lms/startup.py
+++ b/lms/startup.py
@@ -37,9 +37,6 @@ def run():
 
     add_mimetypes()
 
-    if settings.FEATURES.get('ENABLE_NOTIFICATIONS', False):
-        startup_notification_subsystem()
-
     if settings.FEATURES.get('USE_CUSTOM_THEME', False):
         enable_theme()
 
@@ -48,6 +45,9 @@ def run():
 
     if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH', False):
         enable_third_party_auth()
+
+    if settings.FEATURES.get('ENABLE_NOTIFICATIONS', False):
+        startup_notification_subsystem()
 
     # Initialize Segment.io analytics module. Flushes first time a message is received and
     # every 50 messages thereafter, or if 10 seconds have passed since last flush


### PR DESCRIPTION
**Description:** Notifications startup sequence causes importing lms/urls.py. Since it was the first step in LMS startup sequence, urls.py was processed before other apps (i.e. third_party_auth) had a chance to add themselves (and dependencies) to INSTALLED_APPS. As a result, third_party_auth did not work when notifications were enabled.

**Technical details:** The app that actually imported urls.py was `djdebug` - so the issue might not exist in environments with djdebug disabled.

**Testing Instructions:**
1. Enable both TPA and Notifications in lms.env.json -> Features (set ENABLE_NOTIFICATIONS and ENABLE_THIRD_PARTY_AUTH to true)
2. Check that notifications works (i.e. using Group Project, or just progressing through the course so that "You're number N in the cohort for Progression" notification is sent).
3. Check that third party auth works - smoke check should be enough - log in to LMS admin, check if Third Party Auth section is available and works normally.