### PR TITLE
Changed error message to be more in-line with possible reasons of the problem

### DIFF
--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -377,9 +377,11 @@ class UsersApiTests(ModuleStoreTestCase):
         data = {'email': self.test_email, 'username': local_username, 'password':
                 self.test_password, 'first_name': self.test_first_name, 'last_name': self.test_last_name}
         response = self.do_post(test_uri, data)
-        response = self.do_post(test_uri, data)
+        expected_message = "Username '{username}' or email '{email}' already exists".format(
+            username=local_username, email=self.test_email
+        )
         self.assertEqual(response.status_code, 409)
-        self.assertGreater(response.data['message'], 0)
+        self.assertEqual(response.data['message'], expected_message)
         self.assertEqual(response.data['field_conflict'], 'username or email')
 
     @mock.patch.dict("student.models.settings.FEATURES", {"ENABLE_DISCUSSION_EMAIL_DIGEST": True})

--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -325,7 +325,9 @@ class UsersList(SecureListAPIView):
         try:
             user = User.objects.create(email=email, username=username, is_staff=is_staff)
         except IntegrityError:
-            response_data['message'] = "User '%s' already exists" % (username)
+            response_data['message'] = _("Username '{username}' or email '{email}' already exists").format(
+                username=username, email=email
+            )
             response_data['field_conflict'] = "username or email"
             return Response(response_data, status=status.HTTP_409_CONFLICT)
 


### PR DESCRIPTION
**Description:** When existing username or email is used, LMS API fails to register users (which is right), but provides misleading error message "User '%username' already exists". This message does not reflect that conflict might be caused by duplicate email, rather than username.

This PR updates the message to reflect the fact that either username or email could have caused the conflict.

**Test instructions:**
Try three different scenarios: 
1. Username is unique, email already taken
1. Username already taken, email is unique
1. Both username and email already taken

To test this, use an external REST client (i.e. curl, Postman): send POST to `/api/server/users` with the following content:
    {
        "username": "Existing username",
        "email": "existing@email.org",
        "password": "Irrelevant, but required"
    }


Response should be 409 CONFLICT with message "Username 'username' or email 'email' already exists"