### PR TITLE
Support for linking accounts by email for custom entry points

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -535,7 +535,6 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
     Ensure that we have the necessary information about a user (either an
     existing account or registration data) to proceed with the pipeline.
     """
-
     # We're deliberately verbose here to make it clear what the intended
     # dispatch behavior is for the various pipeline entry points, given the
     # current state of the pipeline. Keep in mind the pipeline is re-entrant
@@ -725,7 +724,9 @@ def associate_by_email_if_login_api(auth_entry, backend, details, user, *args, *
 
     This association is done ONLY if the user entered the pipeline through a LOGIN API.
     """
-    if auth_entry == AUTH_ENTRY_LOGIN_API:
+    custom_auth_entry = AUTH_ENTRY_CUSTOM.get(auth_entry)
+
+    if auth_entry == AUTH_ENTRY_LOGIN_API or (custom_auth_entry and custom_auth_entry.get('link_by_email')):
         association_response = associate_by_email(backend, details, user, *args, **kwargs)
         if (
             association_response and

--- a/lms/djangoapps/api_manager/users/tests.py
+++ b/lms/djangoapps/api_manager/users/tests.py
@@ -374,15 +374,34 @@ class UsersApiTests(ModuleStoreTestCase):
     def test_user_list_post_duplicate(self):
         test_uri = self.users_base_uri
         local_username = self.test_username + str(randint(11, 99))
+
+        def post_duplicate_and_assert_409(email, username):
+            """
+            Posts user data with and asserts that return status code was 409 CONFLICT
+            """
+            data = {'email': email, 'username': username, 'password': self.test_password}
+            expected_message = "Username '{username}' or email '{email}' already exists".format(
+                username=username, email=email
+            )
+            response = self.do_post(test_uri, data)
+            self.assertEqual(response.status_code, 409)
+            self.assertEqual(response.data['message'], expected_message)
+            self.assertEqual(response.data['field_conflict'], 'username or email')
+
         data = {'email': self.test_email, 'username': local_username, 'password':
                 self.test_password, 'first_name': self.test_first_name, 'last_name': self.test_last_name}
         response = self.do_post(test_uri, data)
-        expected_message = "Username '{username}' or email '{email}' already exists".format(
-            username=local_username, email=self.test_email
-        )
-        self.assertEqual(response.status_code, 409)
-        self.assertEqual(response.data['message'], expected_message)
-        self.assertEqual(response.data['field_conflict'], 'username or email')
+        self.assertEqual(response.status_code, 201)
+
+        # try creating a user with same email and username
+        post_duplicate_and_assert_409(self.test_email, local_username)
+
+        # try creating a user with same username
+        post_duplicate_and_assert_409(str(uuid.uuid4()) + '@test.org', local_username)
+
+        # creating a user with same email - does not work, since auth_user table in test database does not have unique
+        # constraint on email, added by a migration in common/djangoapps/student/migrations/0004_add_email_index.py
+        # Test engine uses in-memory sqlite DB, so migrations are not applied to it
 
     @mock.patch.dict("student.models.settings.FEATURES", {"ENABLE_DISCUSSION_EMAIL_DIGEST": True})
     def test_user_list_post_discussion_digest_email(self):
@@ -839,6 +858,26 @@ class UsersApiTests(ModuleStoreTestCase):
         self.assertEqual(response.data['uri'], confirm_uri)
         self.assertEqual(response.data['id'], unicode(self.course.id))
         self.assertTrue(response.data['is_active'])
+
+    def test_user_courses_list_post_duplicate(self):
+        # creating user
+        test_uri = self.users_base_uri
+        local_username = self.test_username + str(randint(11, 99))
+        data = {'email': self.test_email, 'username': local_username, 'password':
+                self.test_password, 'first_name': self.test_first_name, 'last_name': self.test_last_name}
+        response = self.do_post(test_uri, data)
+        user_id = response.data['id']
+
+        # adding it to a cohort
+        test_uri = '{}/{}/courses'.format(test_uri, str(user_id))
+        data = {'course_id': unicode(self.course.id)}
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 201)
+
+        # and trying to add it second time
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("already added to cohort", response.data['message'])
 
     def test_user_courses_list_post_undefined_user(self):
         course = CourseFactory.create(org='TUCLPUU', run='TUCLPUU1')

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -267,6 +267,12 @@ THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = {
         'url': '/misc/my-custom-registration-form',
         'error_url': '/misc/my-custom-sso-error-page'
     },
+    'custom2': {
+        'secret_key': 'opensesame',
+        'url': '/misc/my-custom-registration-form',
+        'error_url': '/misc/my-custom-sso-error-page',
+        'link_by_email': True
+    },
 }
 
 ################################## OPENID #####################################

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -20,6 +20,13 @@ from student.models import get_user_by_username_or_email
 from .models import CourseUserGroup, CourseCohort, CourseCohortsSettings, CourseUserGroupPartitionGroup
 
 
+class AlreadyAddedToCohortException(ValueError):
+    """
+    Raised when an attempt is made to add user to a cohort he's already added to
+    """
+    pass
+
+
 log = logging.getLogger(__name__)
 
 
@@ -386,7 +393,7 @@ def add_user_to_cohort(cohort, username_or_email):
     )
     if course_cohorts.exists():
         if course_cohorts[0] == cohort:
-            raise ValueError("User {user_name} already present in cohort {cohort_name}".format(
+            raise AlreadyAddedToCohortException("User {user_name} already present in cohort {cohort_name}".format(
                 user_name=user.username,
                 cohort_name=cohort.name
             ))

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -706,9 +706,9 @@ class TestCohorts(ModuleStoreTestCase):
             }
         )
         # Error cases
-        # Should get ValueError if user already in cohort
+        # Should get AlreadyAddedToCohortException if user already in cohort
         self.assertRaises(
-            ValueError,
+            cohorts.AlreadyAddedToCohortException,
             lambda: cohorts.add_user_to_cohort(second_cohort, "Username")
         )
         # UserDoesNotExist if user truly does not exist


### PR DESCRIPTION
This PR extends custom entry points support by allowing custom entry points to opt-in for automatically linking accounts by email.

Test instructions - part of two-PR changeset - instructions are given on the [other one](https://github.com/mckinseyacademy/mcka_apros/pull/1215) (not testable without third party app anyway).