### PR TITLE
Update hash of group work v2

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/open-craft/xblock-poll.git@bd93e4851c15d9cb1522e692f8b692cf584d23b1#egg=xblock-poll
 -e git+https://github.com/edx/edx-notifications.git@484014cc87278a5c474e6cc1bca14c417fb35599#egg=edx-notifications
 -e git+https://github.com/open-craft/problem-builder.git@1db52e843aaff07e97d02897729716f6be6bec6d#egg=problem-builder
--e git+https://github.com/open-craft/xblock-group-project-v2.git@2040d58e08653e6db733e6a069abcb1efa3d6e87#egg=xblock-group-project-v2
+-e git+https://github.com/open-craft/xblock-group-project-v2.git@49b2cad9060165a7b3809b533dddbb4536e5285d#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/edx-solutions/xblock.git@d25a661454da9e6b149d6c559de50ddcd0770857#egg=xblock
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@e87e0bc5bc2dda94d2d358a63759bffa2b0cba3c#egg=xblock-diagnostic-feedback


### PR DESCRIPTION
This bumps the hash of Group Work v2 to include changes already reviewed in: 

- https://github.com/open-craft/xblock-group-project-v2/pull/83