### PR TITLE
Apply hotfix version hash for problem builder

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -11,7 +11,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@bd93e4851c15d9cb1522e692f8b692cf584d23b1#egg=xblock-poll
 -e git+https://github.com/edx/edx-notifications.git@484014cc87278a5c474e6cc1bca14c417fb35599#egg=edx-notifications
--e git+https://github.com/open-craft/problem-builder.git@1db52e843aaff07e97d02897729716f6be6bec6d#egg=problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@c02f6eb82ccaf69ed9663b1f25ee14cebd911672#egg=problem-builder
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@2040d58e08653e6db733e6a069abcb1efa3d6e87#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/edx-solutions/xblock.git@d25a661454da9e6b149d6c559de50ddcd0770857#egg=xblock


### PR DESCRIPTION
Bump the problem builder hash so that we include an important hotfix (exponential slowdown in large step builder assessments).