### PR TITLE
Improve performance of Organization list and retrieve APIs

### DIFF
--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -52,7 +52,7 @@ from progress.serializers import CourseModuleCompletionSerializer
 from api_manager.courseware_access import get_course, get_course_child, get_course_key, course_exists
 from api_manager.permissions import SecureAPIView, SecureListAPIView, IdsInFilterBackend, HasOrgsFilterBackend
 from api_manager.models import GroupProfile, APIUser as User
-from organizations.serializers import OrganizationSerializer
+from organizations.serializers import BasicOrganizationSerializer
 from api_manager.utils import generate_base_uri, dict_has_items, extract_data_params
 from projects.serializers import BasicWorkgroupSerializer
 from .serializers import UserSerializer, UserCountByCitySerializer, UserRolesSerializer
@@ -1216,7 +1216,7 @@ class UsersOrganizationsList(SecureListAPIView):
     - GET: Provides paginated list of organizations for a user
     """
 
-    serializer_class = OrganizationSerializer
+    serializer_class = BasicOrganizationSerializer
 
     def get_queryset(self):
         user_id = self.kwargs['user_id']

--- a/lms/djangoapps/organizations/serializers.py
+++ b/lms/djangoapps/organizations/serializers.py
@@ -23,5 +23,6 @@ class BasicOrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         """ Serializer/field specification """
         model = Organization
-        fields = ('url', 'id', 'name', 'created', 'display_name', 'logo_url')
+        fields = ('url', 'id', 'name', 'display_name', 'contact_name', 'contact_email', 'contact_phone',
+                  'logo_url', 'created', 'modified')
         read_only = ('url', 'id', 'created',)

--- a/lms/djangoapps/organizations/views.py
+++ b/lms/djangoapps/organizations/views.py
@@ -109,10 +109,6 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
             view = request.QUERY_PARAMS.get('view', None)
             grade_complete_match_range = getattr(settings, 'GRADEBOOK_GRADE_COMPLETE_PROFORMA_MATCH_RANGE', 0.01)
             course_key = None
-            if view == 'ids':
-                user_ids = User.objects.filter(organizations=pk).values_list('id', flat=True)
-                return Response(user_ids)
-
             if course_id:
                 course_key = get_course_key(course_id)
 
@@ -129,6 +125,11 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
                 enrollments_by_user = {}
                 for enrollment in enrollments:
                     enrollments_by_user[enrollment['user']] = enrollment['total']
+
+            # if we only need ids of users in organization return now
+            if view == 'ids':
+                user_ids = users.values_list('id', flat=True)
+                return Response(user_ids)
 
             response_data = []
             if users:
@@ -176,12 +177,15 @@ class OrganizationsViewSet(viewsets.ModelViewSet):
             group_type = request.QUERY_PARAMS.get('type', None)
             view = request.QUERY_PARAMS.get('view', None)
             groups = Group.objects.filter(organizations=pk)
+
+            if group_type:
+                groups = groups.filter(groupprofile__group_type=group_type)
+
+            # if we only need ids of groups in organization return now
             if view == 'ids':
                 group_ids = groups.values_list('id', flat=True)
                 return Response(group_ids)
 
-            if group_type:
-                groups = groups.filter(groupprofile__group_type=group_type)
             response_data = []
             if groups:
                 for group in groups:


### PR DESCRIPTION
@smagoun this PR supports YONK-281. We are simplifying Organization list and retrieve APIs and creating separate endpoints to get organization user, groups and workgroups.
@mattdrayer could you please review?