### PR TITLE
Workaround for Step Builder Progress Issues

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -212,7 +212,7 @@ TENDER_DOMAIN = ENV_TOKENS.get('TENDER_DOMAIN', TENDER_DOMAIN)
 TENDER_SUBDOMAIN = ENV_TOKENS.get('TENDER_SUBDOMAIN', TENDER_SUBDOMAIN)
 
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum', 'sb-step']
 PROGRESS_DETACHED_APPS = ['group_project_v2']
 for app in PROGRESS_DETACHED_APPS:
     try:

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -12,6 +12,7 @@ This is the default template for our main set of AWS servers.
 # pylint: disable=invalid-name
 
 import json
+import importlib
 
 from .common import *
 
@@ -210,6 +211,18 @@ STUDIO_SHORT_NAME = ENV_TOKENS.get('STUDIO_SHORT_NAME', 'Studio')
 TENDER_DOMAIN = ENV_TOKENS.get('TENDER_DOMAIN', TENDER_DOMAIN)
 TENDER_SUBDOMAIN = ENV_TOKENS.get('TENDER_SUBDOMAIN', TENDER_SUBDOMAIN)
 
+# Modules having these categories would be excluded from progress calculations
+PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_APPS = ['group_project_v2']
+for app in PROGRESS_DETACHED_APPS:
+    try:
+        app_config = importlib.import_module('.app_config', app)
+    except ImportError:
+        continue
+
+    detached_module_categories = getattr(app_config, 'PROGRESS_DETACHED_CATEGORIES', [])
+    PROGRESS_DETACHED_CATEGORIES.extend(detached_module_categories)
+
 # Event Tracking
 if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
     TRACKING_IGNORE_URL_PATTERNS = ENV_TOKENS.get("TRACKING_IGNORE_URL_PATTERNS")
@@ -226,7 +239,6 @@ if FEATURES.get('AUTH_USE_CAS'):
     MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
-        import importlib
         CAS_USER_DETAILS_RESOLVER = getattr(
             importlib.import_module(CAS_ATTRIBUTE_CALLBACK['module']),
             CAS_ATTRIBUTE_CALLBACK['function']

--- a/lms/djangoapps/progress/signals.py
+++ b/lms/djangoapps/progress/signals.py
@@ -6,6 +6,7 @@ import logging
 
 from django.dispatch import receiver
 from django.db.models.signals import post_save, pre_save
+from django.db.models import F
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from opaque_keys import InvalidKeyError
@@ -52,7 +53,7 @@ def handle_cmc_post_save_signal(sender, instance, created, **kwargs):
     if created and not any(category in content_id for category in detached_categories):
         try:
             progress = StudentProgress.objects.get(user=instance.user, course_id=instance.course_id)
-            progress.completions += 1
+            progress.completions = F('completions') + 1
             progress.save()
         except ObjectDoesNotExist:
             progress = StudentProgress(user=instance.user, course_id=instance.course_id, completions=1)
@@ -67,10 +68,12 @@ def save_history(sender, instance, **kwargs):  # pylint: disable=no-self-argumen
     """
     Event hook for creating progress entry copies
     """
+    # since instance.completions return F() ExpressionNode we have to pull completions from db
+    progress = StudentProgress.objects.get(pk=instance.id)
     history_entry = StudentProgressHistory(
         user=instance.user,
         course_id=instance.course_id,
-        completions=instance.completions
+        completions=progress.completions
     )
     history_entry.save()
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -489,7 +489,7 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(CELERY_BROKER_TRANSPORT,
 STUDENT_FILEUPLOAD_MAX_SIZE = ENV_TOKENS.get("STUDENT_FILEUPLOAD_MAX_SIZE", STUDENT_FILEUPLOAD_MAX_SIZE)
 
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum', 'sb-step']
 PROGRESS_DETACHED_APPS = ['group_project_v2']
 for app in PROGRESS_DETACHED_APPS:
     try:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -643,7 +643,7 @@ ASSET_KEY_PATTERN = r'(?P<asset_key_string>(?:/?c4x(:/)?/[^/]+/[^/]+/[^/]+/[^@]+
 USAGE_ID_PATTERN = r'(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
 
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum', 'sb-step']
 ############################## EVENT TRACKING #################################
 
 # FIXME: Should we be doing this truncation?


### PR DESCRIPTION
When a student views a Step Builder problem in Apros, if the Step Builder steps contain any HTMLModules, the HTML modules will emit `progress` events because of [this code](https://github.com/edx-solutions/edx-platform/commit/6d2c73caebc0a4f227915c7a08ddce6048f7ed55).

Since Apros doesn't see the child XBlocks, this results in discrepancies about the user's total progress. 

@ziafazal requested: "If we can change step-builder xblock in a way it would send only component id of the parent step-builder xblock at time of completion that should fix a scenario where progress returned by edx-platform API exceeds progress calculated by apros."

Unfortunately, Step Builder cannot control whether or not the HTML Module emits a progress event when it renders. However, since [this code](https://github.com/edx-solutions/edx-platform/blob/ziafazal/YONK-309/lms/djangoapps/progress/signals.py#L49-L52) checks the parent block type before processing progress events for HTML modules, we can easily configure the platform to ignore the 'progress' events coming from HTML modules inside Step Builder problems, but adding `sb-step` to `PROGRESS_DETACHED_CATEGORIES`.


Adding `sb-step` to `PROGRESS_DETACHED_CATEGORIES` implements the fix requested by Zia. The overall progress/grade event for the block is unaffected, since a normal Step Builder hierarchy is like this:
* `step-builder` - emits a `grade` event upon final completion; no `progress` or other events
    * `sb-step` - doesn't emit events
       * `html` - emits unwanted `progress` event
       * `mcq/mrq/answer`
    * `sb-step`
       * `html` - emits unwanted `progress` event
       * `mcq/mrq/answer`


Test Instructions:

1. Create a course with a Step Builder component containing two steps, with HTML modules in each step.
1. View the Step Builder unit in Apros, and interact with it.
1. Notice the progress is no longer inconsistent between the "Cohort" page and the home page.