### PR TITLE
Ziafazal/yonk 309 progress calculation

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -12,6 +12,7 @@ This is the default template for our main set of AWS servers.
 # pylint: disable=invalid-name
 
 import json
+import importlib
 
 from .common import *
 
@@ -210,6 +211,18 @@ STUDIO_SHORT_NAME = ENV_TOKENS.get('STUDIO_SHORT_NAME', 'Studio')
 TENDER_DOMAIN = ENV_TOKENS.get('TENDER_DOMAIN', TENDER_DOMAIN)
 TENDER_SUBDOMAIN = ENV_TOKENS.get('TENDER_SUBDOMAIN', TENDER_SUBDOMAIN)
 
+# Modules having these categories would be excluded from progress calculations
+PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_APPS = ['group_project_v2']
+for app in PROGRESS_DETACHED_APPS:
+    try:
+        app_config = importlib.import_module('.app_config', app)
+    except ImportError:
+        continue
+
+    detached_module_categories = getattr(app_config, 'PROGRESS_DETACHED_CATEGORIES', [])
+    PROGRESS_DETACHED_CATEGORIES.extend(detached_module_categories)
+
 # Event Tracking
 if "TRACKING_IGNORE_URL_PATTERNS" in ENV_TOKENS:
     TRACKING_IGNORE_URL_PATTERNS = ENV_TOKENS.get("TRACKING_IGNORE_URL_PATTERNS")
@@ -226,7 +239,6 @@ if FEATURES.get('AUTH_USE_CAS'):
     MIDDLEWARE_CLASSES += ('django_cas.middleware.CASMiddleware',)
     CAS_ATTRIBUTE_CALLBACK = ENV_TOKENS.get('CAS_ATTRIBUTE_CALLBACK', None)
     if CAS_ATTRIBUTE_CALLBACK:
-        import importlib
         CAS_USER_DETAILS_RESOLVER = getattr(
             importlib.import_module(CAS_ATTRIBUTE_CALLBACK['module']),
             CAS_ATTRIBUTE_CALLBACK['function']

--- a/lms/djangoapps/api_manager/courses/tests.py
+++ b/lms/djangoapps/api_manager/courses/tests.py
@@ -144,13 +144,6 @@ class CoursesApiTests(ModuleStoreTestCase):
             display_name="Group Project2"
         )
 
-        self.course_content = ItemFactory.create(
-            category="videosequence",
-            parent_location=self.chapter.location,
-            data=self.test_data,
-            display_name="Video_Sequence",
-        )
-
         self.course_content2 = ItemFactory.create(
             category="sequential",
             parent_location=self.chapter.location,
@@ -158,18 +151,25 @@ class CoursesApiTests(ModuleStoreTestCase):
             display_name="Sequential",
         )
 
-        self.content_child = ItemFactory.create(
-            category="video",
-            parent_location=self.course_content.location,
-            data=self.test_data,
-            display_name="Video"
-        )
-
         self.content_child2 = ItemFactory.create(
             category="vertical",
             parent_location=self.course_content2.location,
             data=self.test_data,
             display_name="Vertical Sequence"
+        )
+
+        self.course_content = ItemFactory.create(
+            category="videosequence",
+            parent_location=self.content_child2.location,
+            data=self.test_data,
+            display_name="Video_Sequence",
+        )
+
+        self.content_child = ItemFactory.create(
+            category="video",
+            parent_location=self.course_content.location,
+            data=self.test_data,
+            display_name="Video"
         )
 
         self.content_subchild = ItemFactory.create(
@@ -418,12 +418,13 @@ class CoursesApiTests(ModuleStoreTestCase):
         chapter = response.data['content'][0]
         self.assertEqual(chapter['category'], 'chapter')
         self.assertEqual(chapter['name'], 'Overview')
-        self.assertEqual(len(chapter['children']), 6)
+        # we should have 5 children of Overview chapter
+        # 1 sequential, 1 vertical, 1 videosequence and 2 videos
+        self.assertEqual(len(chapter['children']), 5)
 
-        sequence = chapter['children'][0]
-        self.assertEqual(sequence['category'], 'videosequence')
-        self.assertEqual(sequence['name'], 'Video_Sequence')
-        self.assertNotIn('children', sequence)
+        # Make sure one of the children should be a sequential
+        sequential = [child for child in chapter['children'] if child['category'] == 'sequential']
+        self.assertGreater(len(sequential), 0)
 
     def test_courses_tree_get_root(self):
         # query the course tree to quickly get naviation information
@@ -2115,7 +2116,7 @@ class CoursesApiTests(ModuleStoreTestCase):
             local_content_name = 'Video_Sequence{}'.format(i)
             local_content = ItemFactory.create(
                 category="videosequence",
-                parent_location=self.chapter.location,
+                parent_location=self.content_child2.location,
                 data=self.test_data,
                 display_name=local_content_name
             )

--- a/lms/djangoapps/progress/management/commands/recalculate_progress_for_users.py
+++ b/lms/djangoapps/progress/management/commands/recalculate_progress_for_users.py
@@ -1,0 +1,102 @@
+"""
+One-time data migration script -- should not need to run it again
+"""
+import logging
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.db.models import Q
+
+from progress.models import StudentProgress, CourseModuleCompletion
+from progress.signals import is_valid_progress_module
+from student.models import CourseEnrollment
+from xmodule.modulestore.django import modulestore
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Recalculate progress entries for the specified course(s) and/or user(s)
+    """
+    help = 'Recalculate existing users progress per course'
+    option_list = BaseCommand.option_list + (
+        make_option(
+            "-c",
+            "--course_ids",
+            dest="course_ids",
+            help="List of courses for which to Recalculate progress",
+            metavar="first/course/id,second/course/id"
+        ),
+        make_option(
+            "-u",
+            "--user_ids",
+            dest="user_ids",
+            help="List of users for which to Recalculate progress",
+            metavar="1234,2468,3579"
+        ),
+    )
+
+    def handle(self, *args, **options):
+        course_ids = options.get('course_ids')
+        user_ids = options.get('user_ids')
+
+        status_summary = {'skipped': 0, 'updated': 0}
+        total_users_processed = 0
+        detached_categories = getattr(settings, 'PROGRESS_DETACHED_CATEGORIES', [])
+        cat_list = [Q(content_id__contains=item.strip()) for item in detached_categories]
+        cat_list = reduce(lambda a, b: a | b, cat_list)
+
+        # Get the list of courses from the system
+        courses = modulestore().get_courses()
+
+        # If one or more courses were specified by the caller, just use those ones...
+        if course_ids is not None:
+            filtered_courses = []
+            for course in courses:
+                if unicode(course.id) in course_ids.split(','):
+                    filtered_courses.append(course)
+            courses = filtered_courses
+
+        for course in courses:
+            users = CourseEnrollment.objects.users_enrolled_in(course.id)
+            # If one or more users were specified by the caller, just use those ones...
+            if user_ids is not None:
+                filtered_users = []
+                for user in users:
+                    if str(user.id) in user_ids.split(','):
+                        filtered_users.append(user)
+                users = filtered_users
+
+            # For each user...
+            for user in users:
+                total_users_processed += 1
+                status = 'skipped'
+                completions = CourseModuleCompletion.objects.filter(course_id=course.id, user_id=user.id)\
+                    .exclude(cat_list).values_list('content_id', flat=True).distinct()
+
+                num_completions = sum([is_valid_progress_module(content_id=content_id) for content_id in completions])
+                try:
+                    existing_record = StudentProgress.objects.get(user=user, course_id=course.id)
+
+                    if existing_record.completions != num_completions:
+                        existing_record.completions = num_completions
+                        status = 'updated'
+
+                    if status == 'updated':
+                        existing_record.save()
+
+                except StudentProgress.DoesNotExist:
+                    status = "skipped"
+
+                log_msg = 'Progress entry {} -- Course: {}, User: {}  (completions: {})'.format(
+                    status,
+                    course.id,
+                    user.id,
+                    num_completions
+                )
+
+                status_summary[status] += 1
+                log.info(log_msg)
+        print "command completed. Total users processed", total_users_processed, status_summary

--- a/lms/djangoapps/progress/management/commands/tests/test_recalculate_progress_for_users.py
+++ b/lms/djangoapps/progress/management/commands/tests/test_recalculate_progress_for_users.py
@@ -1,36 +1,33 @@
 """
-Run these tests @ Devstack:
-    paver test_system -t lms/djangoapps/progress/management/commands/tests/test_generate_progress_entries.py --fasttest
+Tests for recalculate_progress_for_users.py
 """
 from datetime import datetime
 import uuid
-import time
 
 from django.conf import settings
 from django.test.utils import override_settings
 from django.db.models.signals import post_save
 
 from capa.tests.response_xml_factory import StringResponseXMLFactory
-from progress.management.commands import generate_progress_entries
+from progress.management.commands import recalculate_progress_for_users
 from progress.models import StudentProgress, StudentProgressHistory, CourseModuleCompletion
 from progress.signals import handle_cmc_post_save_signal
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-import progress.signals
 
 MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
 
 
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
-class GenerateProgressEntriesTests(ModuleStoreTestCase):
+class RecalculateProgressEntriesTests(ModuleStoreTestCase):
     """
-    Test suite for progress generation script
+    Test suite for progress recalculation script
     """
 
     def setUp(self):
-        super(GenerateProgressEntriesTests, self).setUp()
-        # Create a couple courses to work with
+        super(RecalculateProgressEntriesTests, self).setUp()
+
         self.course = CourseFactory.create(
             start=datetime(2014, 6, 16, 14, 30),
             end=datetime(2020, 1, 16)
@@ -105,6 +102,11 @@ class GenerateProgressEntriesTests(ModuleStoreTestCase):
             display_name="lab problem 2",
             metadata={'rerandomize': 'always', 'graded': True, 'format': "Lab"}
         )
+        self.non_vertical_problem = ItemFactory.create(
+            parent_location=chapter1.location,
+            category='problem',
+            display_name="non vertical problem",
+        )
 
         # Create some users and enroll them
         self.users = [UserFactory.create(username="testuser" + str(__), profile='test') for __ in xrange(3)]
@@ -122,21 +124,29 @@ class GenerateProgressEntriesTests(ModuleStoreTestCase):
         Clears existing CourseModuleCompletion entries and creates 3 for each user
         """
         CourseModuleCompletion.objects.all().delete()
-        for user in self.users:
-            completion, created = CourseModuleCompletion.objects.get_or_create(user=user,
-                                                                               course_id=self.course.id,
-                                                                               content_id=unicode(self.problem.location),
-                                                                               stage=None)
+        for idx, user in enumerate(self.users):
+            if idx % 2 == 0:
+                StudentProgress.objects.get_or_create(
+                    user_id=user.id, course_id=self.course.id, completions=0
+                )
+            CourseModuleCompletion.objects.get_or_create(user=user,
+                                                         course_id=self.course.id,
+                                                         content_id=unicode(self.problem.location),
+                                                         stage=None)
 
-            completion, created = CourseModuleCompletion.objects.get_or_create(user=user,
-                                                                               course_id=self.course.id,
-                                                                               content_id=unicode(self.problem2.location),
-                                                                               stage=None)
+            CourseModuleCompletion.objects.get_or_create(user=user,
+                                                         course_id=self.course.id,
+                                                         content_id=unicode(self.problem2.location),
+                                                         stage=None)
 
-            completion, created = CourseModuleCompletion.objects.get_or_create(user=user,
-                                                                               course_id=self.course.id,
-                                                                               content_id=unicode(self.problem3.location),
-                                                                               stage=None)
+            CourseModuleCompletion.objects.get_or_create(user=user,
+                                                         course_id=self.course.id,
+                                                         content_id=unicode(self.problem3.location),
+                                                         stage=None)
+            CourseModuleCompletion.objects.get_or_create(user=user,
+                                                         course_id=self.course.id,
+                                                         content_id=unicode(self.non_vertical_problem.location),
+                                                         stage=None)
 
     def test_generate_progress_entries_command(self):
         """
@@ -146,42 +156,40 @@ class GenerateProgressEntriesTests(ModuleStoreTestCase):
         course_ids = '{},bogus/course/id'.format(self.course.id)
         user_ids = '{}'.format(self.users[0].id)
         current_entries = StudentProgress.objects.all()
-        self.assertEqual(len(current_entries), 0)
+        self.assertEqual(len(current_entries), 2)
         current_entries = StudentProgressHistory.objects.all()
-        self.assertEqual(len(current_entries), 0)
+        self.assertEqual(len(current_entries), 2)
 
         # Run the command just for one user
-        generate_progress_entries.Command().handle(user_ids=user_ids)
+        recalculate_progress_for_users.Command().handle(user_ids=user_ids)
 
         # Confirm the progress has been properly updated
         current_entries = StudentProgress.objects.all()
-        self.assertEqual(len(current_entries), 1)
+        self.assertEqual(len(current_entries), 2)
         current_entries = StudentProgressHistory.objects.all()
-        self.assertEqual(len(current_entries), 1)
+        self.assertEqual(len(current_entries), 3)
         user0_entry = StudentProgress.objects.get(user=self.users[0])
         self.assertEqual(user0_entry.completions, 3)
 
-        # The first user will be skipped this next time around because they already have a progress record
-        # and their completions have not changed, and we need to test this valid use case ('skipped')
-        # We also need to test the 'updated' use case, so we'll add a new completion record for the
-        # second user which will alter their count on this next cycle and kick off the update flow
-        completion, created = CourseModuleCompletion.objects.get_or_create(user=self.users[1],
-                                                                           course_id=self.course.id,
-                                                                           content_id=unicode(self.problem4.location),
-                                                                           stage=None)
-
         # Run the command across all users, but just for the specified course
-        generate_progress_entries.Command().handle(course_ids=course_ids)
+        recalculate_progress_for_users.Command().handle(course_ids=course_ids)
+
+        # The first user will be skipped this next time around because they already have a progress record
+        # and their completions have not changed
+        user0_entry = StudentProgress.objects.get(user=self.users[0])
+        self.assertEqual(user0_entry.completions, 3)
 
         # Confirm that the progress has been properly updated
         current_entries = StudentProgress.objects.all()
-        self.assertEqual(len(current_entries), 3)
+        self.assertEqual(len(current_entries), 2)
         current_entries = StudentProgressHistory.objects.all()
         self.assertEqual(len(current_entries), 4)
-        user0_entry = StudentProgress.objects.get(user=self.users[0])
-        self.assertEqual(user0_entry.completions, 3)
-        user1_entry = StudentProgress.objects.get(user=self.users[1])
-        self.assertEqual(user1_entry.completions, 4)
+
+        # second user has no entry in StudentProgress so they should b skipped
+        user1_entry = StudentProgress.objects.filter(user=self.users[1])
+        self.assertEqual(len(user1_entry), 0)
+
+        # third user should have their progress updated
         user2_entry = StudentProgress.objects.get(user=self.users[2])
         self.assertEqual(user2_entry.completions, 3)
 
@@ -194,11 +202,12 @@ class GenerateProgressEntriesTests(ModuleStoreTestCase):
         StudentProgressHistory.objects.all().delete()
         self._generate_course_completion_test_entries()
 
-        #let single bindings to complete their work
-        time.sleep(2)
         current_entries = StudentProgress.objects.all()
         self.assertEqual(len(current_entries), 3)
         current_entries = StudentProgressHistory.objects.all()
-        self.assertEqual(len(current_entries), 9)
+        # StudentProgressHistory should have 11 entries
+        # 9 entries for progress history of 3 users each with 3 completions
+        # and 2 entries for initial progress creation of 2 users
+        self.assertEqual(len(current_entries), 11)
         user0_entry = StudentProgress.objects.get(user=self.users[0])
         self.assertEqual(user0_entry.completions, 3)


### PR DESCRIPTION
@bradenmacdonald, @mattdrayer  This PR has required changes to fix these issues with progress calculation.

1) Race condition
If two Python threads try to update user progress via `StudentProgress` model, one thread could retrieve, increment, and save `completions` field’s value after the other has retrieved it from the database. The value that the second thread saves will be based on the original value; the work of the first thread will simply be lost.

2) Wrong total modules calculation at the time of Course import
We are calculating total number of modules when course_published signal is fired and it fires at the time of course import also and at that case we are calculating wrong number of modules in  course since we don't have `PROGRESS_DETACHED_CATEGORIES` for studio settings.

3) Calculate progress only for those modules which are direct children of `verticals`. In case of step builder or any other XBlocks where we can have other XBlocks as children we should not calculate their children's progress. 

FYI @smagoun 