### PR TITLE
ziafazal/YONK-309-ignore-verticals: ignore some verticals from progress calculations

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -212,7 +212,6 @@ TENDER_DOMAIN = ENV_TOKENS.get('TENDER_DOMAIN', TENDER_DOMAIN)
 TENDER_SUBDOMAIN = ENV_TOKENS.get('TENDER_SUBDOMAIN', TENDER_SUBDOMAIN)
 
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
 PROGRESS_DETACHED_APPS = ['group_project_v2']
 for app in PROGRESS_DETACHED_APPS:
     try:

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -42,6 +42,7 @@ from lms.envs.common import (
     # technically accessible through the CMS via legacy URLs.
     PROFILE_IMAGE_BACKEND, PROFILE_IMAGE_DEFAULT_FILENAME, PROFILE_IMAGE_DEFAULT_FILE_EXTENSION,
     PROFILE_IMAGE_SECRET_KEY, PROFILE_IMAGE_MIN_BYTES, PROFILE_IMAGE_MAX_BYTES,
+    PROGRESS_DETACHED_VERTICAL_CATEGORIES, PROGRESS_DETACHED_CATEGORIES,
     # The following setting is included as it is used to check whether to
     # display credit eligibility table on the CMS or not.
     ENABLE_CREDIT_ELIGIBILITY, YOUTUBE_API_KEY

--- a/lms/djangoapps/progress/signals.py
+++ b/lms/djangoapps/progress/signals.py
@@ -18,6 +18,7 @@ from edx_notifications.lib.publisher import (
     get_notification_type
 )
 from edx_notifications.data import NotificationMessage
+from openedx.core.djangoapps.content.course_metadata.utils import is_progress_detached_vertical
 
 from progress.models import StudentProgress, StudentProgressHistory, CourseModuleCompletion
 
@@ -38,7 +39,7 @@ def is_valid_progress_module(content_id):
         usage_id = BlockUsageLocator.from_string(content_id)
         module = modulestore().get_item(usage_id)
         if module and module.parent and module.parent.category == "vertical" and \
-                module.category not in detached_categories:
+                module.category not in detached_categories and not is_progress_detached_vertical(module.parent):
             return True
         else:
             return False

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -489,7 +489,6 @@ BROKER_URL = "{0}://{1}:{2}@{3}/{4}".format(CELERY_BROKER_TRANSPORT,
 STUDENT_FILEUPLOAD_MAX_SIZE = ENV_TOKENS.get("STUDENT_FILEUPLOAD_MAX_SIZE", STUDENT_FILEUPLOAD_MAX_SIZE)
 
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
 PROGRESS_DETACHED_APPS = ['group_project_v2']
 for app in PROGRESS_DETACHED_APPS:
     try:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -642,8 +642,10 @@ USAGE_KEY_PATTERN = r'(?P<usage_key_string>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@
 ASSET_KEY_PATTERN = r'(?P<asset_key_string>(?:/?c4x(:/)?/[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
 USAGE_ID_PATTERN = r'(?P<usage_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
 
+# Verticals having children with any of these categories would be excluded from progress calculations
+PROGRESS_DETACHED_VERTICAL_CATEGORIES = ['discussion-course', 'group-project', 'gp-v2-project']
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = ['discussion-course', 'group-project', 'discussion-forum']
+PROGRESS_DETACHED_CATEGORIES = PROGRESS_DETACHED_VERTICAL_CATEGORIES + ['discussion-forum']
 ############################## EVENT TRACKING #################################
 
 # FIXME: Should we be doing this truncation?

--- a/openedx/core/djangoapps/content/course_metadata/utils.py
+++ b/openedx/core/djangoapps/content/course_metadata/utils.py
@@ -16,7 +16,23 @@ def get_course_leaf_nodes(course_key):
     verticals = store.get_items(course_key, qualifiers={'category': 'vertical'})
     orphans = store.get_orphans(course_key)
     for vertical in verticals:
-        if hasattr(vertical, 'children') and vertical.location not in orphans:
+        if hasattr(vertical, 'children') and not is_progress_detached_vertical(vertical) and \
+                vertical.location not in orphans:
             nodes.extend([unit for unit in vertical.children
                           if getattr(unit, 'category') not in detached_categories])
     return nodes
+
+
+def is_progress_detached_vertical(vertical):
+    """
+    Returns boolean indicating if vertical is valid for progress calculations
+    If a vertical has any children belonging to PROGRESS_DETACHED_VERTICAL_CATEGORIES
+    it should be ignored for progress calculation
+    """
+    detached_vertical_categories = getattr(settings, 'PROGRESS_DETACHED_VERTICAL_CATEGORIES', [])
+    if not hasattr(vertical, 'children'):
+        vertical = modulestore().get_item(vertical, 1)
+    for unit in vertical.children:
+        if getattr(unit, 'category') in detached_vertical_categories:
+            return True
+    return False


### PR DESCRIPTION
This  PR further refines code related to user's progress calculations. We have to exclude those `verticals` if they have any unit having these categories `discussion-course, group-project, gp-v2-project`.

@afzaledx would you please review?