### PR TITLE
fixed issue with user grades not being computed

### DIFF
--- a/lms/djangoapps/gradebook/receivers.py
+++ b/lms/djangoapps/gradebook/receivers.py
@@ -30,9 +30,9 @@ def on_score_changed(sender, **kwargs):
     """
     Listens for a 'score_changed' signal invoke grade book update task
     """
-    user = kwargs['user']
-    course_key = kwargs['course_key']
-    update_user_gradebook.delay(course_key, user)
+    user_id = kwargs['user'].id
+    course_key = unicode(kwargs['course_key'])
+    update_user_gradebook.delay(course_key, user_id)
 
 
 @receiver(course_deleted)

--- a/lms/djangoapps/gradebook/tasks.py
+++ b/lms/djangoapps/gradebook/tasks.py
@@ -9,6 +9,8 @@ from celery.task import task  # pylint: disable=import-error,no-name-in-module
 from courseware import grades
 from xmodule.modulestore import EdxJSONEncoder
 from util.request import RequestMockWithoutMiddleware
+from django.contrib.auth.models import User
+from opaque_keys.edx.keys import CourseKey
 
 from gradebook.models import StudentGradebook
 
@@ -16,11 +18,16 @@ log = logging.getLogger('edx.celery.task')
 
 
 @task(name=u'lms.djangoapps.gradebook.tasks.update_user_gradebook')
-def update_user_gradebook(course_key, user):
+def update_user_gradebook(course_key, user_id):
     """
     Taks to recalculate user's gradebook entry
     """
+    if not isinstance(course_key, basestring):
+        raise ValueError('course_key must be a string. {} is not acceptable.'.format(type(course_key)))
+
+    course_key = CourseKey.from_string(course_key)
     try:
+        user = User.objects.get(id=user_id)
         _generate_user_gradebook(course_key, user)
     except Exception as ex:
         log.exception('An error occurred while generating gradebook: %s', ex.message)

--- a/lms/djangoapps/gradebook/tests.py
+++ b/lms/djangoapps/gradebook/tests.py
@@ -483,6 +483,18 @@ class GradebookTests(ModuleStoreTestCase):
         history = StudentGradebookHistory.objects.all()
         self.assertEqual(len(history), 0)
 
+    def test_update_user_gradebook_task_arguments(self):
+        """
+        Tests update_user_gradebook task is called with appropriate arguments
+        """
+        self._create_course()
+        user = UserFactory()
+        module = self.get_module_for_user(user, self.course, self.problem)
+        grade_dict = {'value': 0.75, 'max_value': 1, 'user_id': user.id}
+        with patch('gradebook.receivers.update_user_gradebook.delay') as mock_task:
+            module.system.publish(module, 'grade', grade_dict)
+            mock_task.assert_called_with(unicode(self.course.id), user.id)
+
     @patch.dict(settings.FEATURES, {
         'ALLOW_STUDENT_STATE_UPDATES_ON_CLOSED_COURSE': False,
         'SIGNAL_ON_SCORE_CHANGED': True


### PR DESCRIPTION
User grade computations were moved into a Celery task but argument(course_key, user) passed to that celery task were not primitive types and as a result we were getting these errors
```
EncodeError: CourseLocator(....) is not JSON serializable
EncodeError: <User: ..> is not JSON serializable
```
when celery task is executed.
This PR fixes the issue by converting argument passed to celery task into primitive types.

@msaqib52 would you please review this?