### PR TITLE
Bulk course delete management command

### DIFF
--- a/lms/djangoapps/api_manager/management/commands/bulk_delete_courses_with_reference_data.py
+++ b/lms/djangoapps/api_manager/management/commands/bulk_delete_courses_with_reference_data.py
@@ -1,0 +1,110 @@
+"""
+Management command deletes old courses and relevant data from mongo db and mysql db
+"""
+import pytz
+import logging
+from optparse import make_option
+from datetime import datetime, timedelta
+from util.prompt import query_yes_no
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+
+from api_manager.models import CourseGroupRelationship, CourseContentGroupRelationship
+from openedx.core.djangoapps.course_groups.models import CourseCohortsSettings, CourseUserGroup
+from openedx.core.djangoapps.content.course_metadata.models import CourseAggregatedMetaData
+from openedx.core.djangoapps.content.course_structures.models import CourseStructure
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from courseware.models import StudentModule
+from progress.models import CourseModuleCompletion, StudentProgress, StudentProgressHistory
+from gradebook.models import StudentGradebook, StudentGradebookHistory
+from student.models import CourseAccessRole, CourseEnrollment
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Deletes courses based on their age and relevant data of each course
+    """
+    help = 'Deletes courses based on their age and relevant data of each course'
+    option_list = BaseCommand.option_list + (
+        make_option(
+            "-c",
+            "--age",
+            dest="age",
+            help="Age in days",
+            metavar="60"
+        ),
+    )
+    module_store = modulestore()
+    total_courses = 0
+    total_deleted = 0
+
+    @staticmethod
+    def delete_reference_data(course_key):
+        """
+        Deletes reference data for course
+        """
+        print 'removing reference data for course %s' % unicode(course_key)
+        CourseGroupRelationship.objects.filter(course_id=course_key).delete()
+        CourseContentGroupRelationship.objects.filter(course_id=course_key).delete()
+        CourseCohortsSettings.objects.filter(course_id=course_key).delete()
+        CourseUserGroup.objects.filter(course_id=course_key).delete()
+        CourseAggregatedMetaData.objects.filter(id=course_key).delete()
+        CourseStructure.objects.filter(course_id=course_key).delete()
+        CourseOverview.objects.filter(id=course_key).delete()
+        StudentModule.objects.filter(course_id=course_key).delete()
+        CourseModuleCompletion.objects.filter(course_id=course_key).delete()
+        StudentProgressHistory.objects.filter(course_id=course_key).delete()
+        StudentProgress.objects.filter(course_id=course_key).delete()
+        StudentGradebookHistory.objects.filter(course_id=course_key).delete()
+        StudentGradebook.objects.filter(course_id=course_key).delete()
+        CourseAccessRole.objects.filter(course_id=course_key).delete()
+        CourseEnrollment.objects.filter(course_id=course_key).delete()
+
+    def delete_course_from_modulestore(self, course_key):
+        """
+        Deletes course from modulestore
+        """
+        user_id = ModuleStoreEnum.UserID.mgmt_command
+        with self.module_store.bulk_operations(course_key):
+            print 'Removing course %s from modulestore' % unicode(course_key)
+            self.module_store.delete_course(course_key, user_id)
+
+    @transaction.commit_on_success
+    def delete_course_and_data(self, course_key):
+        """
+        Delete course from modulestore and it reference data
+        """
+        Command.delete_reference_data(course_key)
+        self.delete_course_from_modulestore(course_key)
+
+    def handle(self, *args, **options):
+        if not options.get('age'):
+            raise CommandError("bulk_delete_courses_with_reference_data command requires one integer argument: --age")
+
+        age_in_days = int(options.get('age'))
+        if query_yes_no(
+                "Are you sure you want to delete all courses and their reference data having no activity "
+                "in last %s days. This action cannot be undone!" % age_in_days, default="no"
+        ):
+            created_time = datetime.now(pytz.UTC) + timedelta(days=-age_in_days)
+            courses = self.module_store.get_courses()
+
+            for course in courses:
+                if course.edited_on < created_time:
+                    self.total_courses += 1
+                    try:
+                        self.delete_course_and_data(course.id)
+                        self.total_deleted += 1
+                    except Exception as ex:   # pylint: disable=broad-except
+                        log.exception("Exception while deleting course %s", ex.message)
+
+            completion_message = "command completed. Total %s courses deleted out of %s" % (
+                self.total_deleted, self.total_courses
+            )
+            log.info(completion_message)
+            print completion_message

--- a/lms/djangoapps/api_manager/management/commands/tests/test_bulk_delete_courses_with_reference_data.py
+++ b/lms/djangoapps/api_manager/management/commands/tests/test_bulk_delete_courses_with_reference_data.py
@@ -1,0 +1,189 @@
+"""
+Tests to support bulk_delete_courses_with_reference_data django management command
+"""
+import mock
+import pytz
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test.utils import override_settings
+
+from api_manager.models import CourseGroupRelationship
+from gradebook.models import StudentGradebook
+from progress.models import StudentProgress, CourseModuleCompletion
+from student.models import CourseEnrollment, CourseAccessRole
+from openedx.core.djangoapps.content.course_metadata.models import CourseAggregatedMetaData
+from openedx.core.djangoapps.content.course_structures.models import CourseStructure
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from courseware.models import StudentModule
+from student.tests.factories import UserFactory, GroupFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_store_config
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.django import modulestore
+
+MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {}, include_xml=False)
+
+
+@override_settings(MODULESTORE=MODULESTORE_CONFIG)
+class BulkCourseDeleteTests(ModuleStoreTestCase):
+    """
+    Test suite for bulk course delete script
+    """
+    YESNO_PATCH_LOCATION = 'api_manager.management.commands.bulk_delete_courses_with_reference_data.query_yes_no'
+
+    def setUp(self):
+        super(BulkCourseDeleteTests, self).setUp()
+
+    @staticmethod
+    def create_course():
+        """
+        Creates a course with just one chapter inside it
+        """
+        course = CourseFactory.create()
+        ItemFactory.create(
+            category="chapter",
+            parent_location=course.location,
+            display_name="Overview"
+        )
+        return course
+
+    @staticmethod
+    def create_course_reference_data(course_key):
+        """
+        Populates DB with test data
+        """
+        user = UserFactory()
+        group = GroupFactory()
+        CourseGroupRelationship(course_id=course_key, group=group).save()
+        StudentGradebook(
+            user=user,
+            course_id=course_key,
+            grade=0.9,
+            proforma_grade=0.91,
+            progress_summary='test',
+            grade_summary='test',
+            grading_policy='test',
+        ).save()
+        StudentProgress(user=user, course_id=course_key, completions=1).save()
+        CourseModuleCompletion(user=user, course_id=course_key, content_id='test', stage='test').save()
+        CourseEnrollment(user=user, course_id=course_key).save()
+        CourseAccessRole(user=user, course_id=course_key, org='test', role='TA').save()
+        handouts_usage_key = course_key.make_usage_key('course_info', 'handouts')
+        StudentModule(student=user, course_id=course_key, module_state_key=handouts_usage_key).save()
+        CourseAggregatedMetaData(id=course_key, total_assessments=10, total_modules=20).save()
+        CourseStructure(course_id=course_key, structure_json='{"test": true}').save()
+        CourseOverview.get_from_id(course_key)
+
+    def assert_reference_data_exists(self, course_id):
+        """
+        Asserts course reference data exists in DB
+        """
+        self.assertEqual(1, CourseGroupRelationship.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, StudentGradebook.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, StudentProgress.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, CourseModuleCompletion.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, CourseEnrollment.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, CourseAccessRole.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, StudentModule.objects.filter(course_id=course_id).count())
+        self.assertEqual(1, CourseAggregatedMetaData.objects.filter(id=course_id).count())
+        self.assertEqual(1, CourseOverview.objects.filter(id=course_id).count())
+        self.assertEqual(1, CourseStructure.objects.filter(course_id=course_id).count())
+
+        course = modulestore().get_course(course_id)
+        self.assertIsNotNone(course)
+        self.assertEqual(unicode(course_id), unicode(course.id))
+
+    def assert_reference_data_deleted(self, course_id):
+        """
+        Asserts course reference data deleted in DB
+        """
+        self.assertEqual(0, CourseGroupRelationship.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, StudentGradebook.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, StudentProgress.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, CourseModuleCompletion.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, CourseEnrollment.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, CourseAccessRole.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, StudentModule.objects.filter(course_id=course_id).count())
+        self.assertEqual(0, CourseAggregatedMetaData.objects.filter(id=course_id).count())
+        self.assertEqual(0, CourseOverview.objects.filter(id=course_id).count())
+        self.assertEqual(0, CourseStructure.objects.filter(course_id=course_id).count())
+
+        course = modulestore().get_course(course_id)
+        self.assertIsNone(course)
+
+    def setup_course_data(self, number_of_courses=1, days_ago=60):
+        """
+        Creates courses and reference data to test and return list of course ids created
+        """
+        course_ids = []
+        past_datetime = datetime.now(pytz.UTC) + timedelta(days=-days_ago)
+        with freeze_time(past_datetime):
+            while len(course_ids) < number_of_courses:
+                course = BulkCourseDeleteTests.create_course()
+                BulkCourseDeleteTests.create_course_reference_data(course.id)
+                course_ids.append(course.id)
+        return course_ids
+
+    def test_course_bulk_delete(self):
+        """
+        Test bulk course deletion
+        """
+        # Set up courses and data to be deleted
+        course_ids = self.setup_course_data(number_of_courses=4)
+
+        # assert data exists
+        for course_id in course_ids:
+            self.assert_reference_data_exists(course_id)
+
+        with mock.patch(self.YESNO_PATCH_LOCATION) as patched_yes_no:
+            patched_yes_no.return_value = True
+            call_command('bulk_delete_courses_with_reference_data', age=60)
+
+        # assert data deleted
+        for course_id in course_ids:
+            self.assert_reference_data_deleted(course_id)
+
+    def test_course_bulk_delete_with_no_prompt(self):
+        """
+        Test bulk course deletion when user opt to type `No` when prompted
+        """
+        # Set up courses and data to be deleted
+        course_ids = self.setup_course_data()
+
+        with mock.patch(self.YESNO_PATCH_LOCATION) as patched_yes_no:
+            patched_yes_no.return_value = False
+            call_command('bulk_delete_courses_with_reference_data', age=60)
+
+        # assert data still exists
+        for course_id in course_ids:
+            self.assert_reference_data_exists(course_id)
+
+    def test_course_bulk_delete_without_age(self):
+        """
+        Test bulk course deletion when age option is not given
+        """
+        # Set up courses and data to be deleted
+        course_ids = self.setup_course_data()
+
+        with self.assertRaises(SystemExit):
+            call_command('bulk_delete_courses_with_reference_data')
+
+        # assert data still exists
+        for course_id in course_ids:
+            self.assert_reference_data_exists(course_id)
+
+    def test_course_bulk_delete_with_non_int_age(self):
+        """
+        Test bulk course deletion when age option is not an integer
+        """
+        # Set up courses and data to be deleted
+        course_ids = self.setup_course_data()
+
+        with self.assertRaises(ValueError):
+            call_command('bulk_delete_courses_with_reference_data', age='junk')
+
+        # assert data still exists
+        for course_id in course_ids:
+            self.assert_reference_data_exists(course_id)


### PR DESCRIPTION
On McKA QA and McKA Integration environment we need to delete courses in bulk to free disk space. This PR has a new django management command to delete multiples courses where there is no activity by course authors for a certain number of days.
We can run this command on devstack like this
```
./manage.py lms bulk_delete_courses_with_reference_data --age=60  --settings=devstack
```
where `age` option is number of days.
@douglashall would you review this one?