### PR TITLE
ziafazal/task-keyerror-fix: renamed task to fix task keyerror

### DIFF
--- a/openedx/core/djangoapps/content/course_metadata/tasks.py
+++ b/openedx/core/djangoapps/content/course_metadata/tasks.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.content.course_metadata.utils import get_course_lea
 log = logging.getLogger('edx.celery.task')
 
 
-@task(name=u'lms.djangoapps.api_manager.tasks.update_course_metadata')
+@task(name=u'openedx.core.djangoapps.content.course_metadata.tasks.update_course_aggregate_metadata')
 def update_course_aggregate_metadata(course_key):  # pylint: disable=invalid-name
     """
     Regenerates and updates the course aggregate metadata (in the database) for the specified course.


### PR DESCRIPTION
We are getting this error on MCKA QA environment when `update_course_aggregate_metadata` task is executed
```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 455, in on_task_received
    strategies[name](message, body,
KeyError: u'lms.djangoapps.api_manager.tasks.update_course_metadata'
```
I believe renaming the task to appropriate module it belongs to should fix it.

@msaqib52 would you please review this change?