### PR TITLE
YONK-318: Update organizations list API to return number of courses

### DIFF
--- a/lms/djangoapps/api_manager/permissions.py
+++ b/lms/djangoapps/api_manager/permissions.py
@@ -4,7 +4,7 @@ import logging
 from django.conf import settings
 
 from api_manager.utils import get_client_ip_address, address_exists_in_network
-from rest_framework import permissions, generics, filters, pagination, serializers
+from rest_framework import permissions, generics, filters, pagination, serializers, viewsets
 from rest_framework.views import APIView
 
 from api_manager.utils import str2bool
@@ -169,3 +169,18 @@ class SecureListAPIView(PermissionMixin,
             return None
         else:
             return super(SecureListAPIView, self).get_paginate_by()
+
+
+class APIModelViewSet(PaginationMixin, viewsets.ModelViewSet):
+    """
+    ModelViewSet used for pagination
+    """
+    def get_paginate_by(self):  # pylint: disable=W0221
+        """
+        Override to return size of pages, if page_size parameter in request is zero don't paginate
+        """
+        page_size = self.request.QUERY_PARAMS.get('page_size')
+        if page_size and int(page_size) == 0:
+            return None
+        else:
+            return super(APIModelViewSet, self).get_paginate_by()

--- a/lms/djangoapps/organizations/serializers.py
+++ b/lms/djangoapps/organizations/serializers.py
@@ -26,3 +26,14 @@ class BasicOrganizationSerializer(serializers.ModelSerializer):
         fields = ('url', 'id', 'name', 'display_name', 'contact_name', 'contact_email', 'contact_phone',
                   'logo_url', 'created', 'modified')
         read_only = ('url', 'id', 'created',)
+
+
+class OrganizationWithCourseCountSerializer(BasicOrganizationSerializer):
+    """ Serializer for Organization fields with number of courses """
+    number_of_courses = serializers.IntegerField(source='number_of_courses')
+
+    class Meta(object):
+        """ Serializer/field specification """
+        model = Organization
+        fields = ('url', 'id', 'name', 'display_name', 'number_of_courses', 'contact_name', 'contact_email',
+                  'contact_phone', 'logo_url', 'created', 'modified')


### PR DESCRIPTION
This PR Updates organizations list API to return number of courses as an additional field and also enables pagination on this API.

@ziafazal please review.