### PR TITLE
bump organizations app version

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -16,7 +16,7 @@
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/edx-solutions/xblock.git@d25a661454da9e6b149d6c559de50ddcd0770857#egg=xblock
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.0#egg=progress-edx-platform-extensions==1.0.0
-git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.0.2#egg=organizations-edx-platform-extensions==1.0.2
+git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.0.4#egg=organizations-edx-platform-extensions==1.0.4
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.0.2#egg=gradebook-edx-platform-extensions==1.0.2
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.0.1#egg=projects-edx-platform-extensions==1.0.1
 git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.0.0#egg=discussion-edx-platform-extensions==1.0.0


### PR DESCRIPTION
This PR updates version number of [organizations](https://github.com/edx-solutions/organizations-edx-platform-extensions/tree/v1.0.4) app, which fixes the enrolled_users attribute to return only id’s of users from this organization and enrolled in this course.

@ziafazal would you please review?

