### PR TITLE
Partial filtering by course id on users list API

### DIFF
--- a/lms/djangoapps/api_manager/users/views.py
+++ b/lms/djangoapps/api_manager/users/views.py
@@ -294,6 +294,10 @@ class UsersList(SecureListAPIView):
         if name is not None:
             queryset = queryset.filter(profile__name=name)
 
+        partial_course = self.request.QUERY_PARAMS.get('partial_course', None)
+        if partial_course is not None:
+            queryset = queryset.filter(courseenrollment__course_id__icontains=partial_course).distinct()
+
         queryset = queryset.prefetch_related('organizations')\
             .select_related('courseenrollment_set', 'profile')\
             .annotate(courses_enrolled=Count('courseenrollment'))


### PR DESCRIPTION
@ziafazal 
This is working API with support for partial filtering by course id on users list.
I made additional field 'partial_course' that returns users in courses which have partial matching id.
Example of api call: /api/server/users?partial_course=edX/CS