### PR TITLE
ziafazal/YONK-339-b: added grade section breakdown and ability to pull additional fields

### DIFF
--- a/lms/djangoapps/api_manager/courses/views.py
+++ b/lms/djangoapps/api_manager/courses/views.py
@@ -1089,7 +1089,23 @@ class CoursesUsersList(SecureListAPIView):
         Extra context provided to the serializer class.
         """
         serializer_context = super(CoursesUsersList, self).get_serializer_context()
-        serializer_context.update({'course_id': self.course_key})
+        default_fields = ",".join([
+            "id",
+            "email",
+            "username",
+            "first_name",
+            "last_name",
+            "created",
+            "is_active",
+            "avatar_url",
+            "city",
+            "title",
+            "country",
+            "full_name",
+            "is_staff",
+            "last_login",
+        ])
+        serializer_context.update({'course_id': self.course_key, 'default_fields': default_fields})
         return serializer_context
 
     def get_queryset(self):


### PR DESCRIPTION
This PR has changes to add `section_breakdown` of users grades to `grades` field of course user list API. Changes in this PR also enable us to get additional fields by add a querystring like this `additional_fields=grades,organizations,roles`.

@msaqib52 would you please review?