### PR TITLE
added roles parameter

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -386,15 +386,15 @@ class UserBasedRole(object):
         return CourseAccessRole.objects.filter(role=self.role, user=self.user)
 
 
-def get_aggregate_exclusion_user_ids(course_key):
+def get_aggregate_exclusion_user_ids(course_key, roles=None):  # pylint: disable=invalid-name
     """
     This helper method will return the list of user ids that are marked in roles
     that can be excluded from certain aggregate queries. The list of roles to exclude
-    can be defined in a AGGREGATION_EXCLUDE_ROLES settings variable
+    can either be passed in roles argument or defined in a AGGREGATION_EXCLUDE_ROLES settings variable
     """
 
     exclude_user_ids = set()
-    exclude_role_list = getattr(settings, 'AGGREGATION_EXCLUDE_ROLES', [CourseObserverRole.ROLE])
+    exclude_role_list = roles or getattr(settings, 'AGGREGATION_EXCLUDE_ROLES', [CourseObserverRole.ROLE])
 
     for role in exclude_role_list:
         users = CourseRole(role, course_key).users_with_role()

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -15,7 +15,7 @@
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@bf09c7e91089d4323655071cb5ab9cd65a4b4f0a#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/edx-solutions/xblock.git@d25a661454da9e6b149d6c559de50ddcd0770857#egg=xblock
-git+https://github.com/edx-solutions/api-integration.git@v1.0.3#egg=api-integration==1.0.3
+git+https://github.com/edx-solutions/api-integration.git@v1.0.4#egg=api-integration==1.0.4
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.1#egg=organizations-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.0.2#egg=gradebook-edx-platform-extensions==1.0.2
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.0.5#egg=projects-edx-platform-extensions==1.0.5


### PR DESCRIPTION
This PR adds a `roles` to `get_aggregate_exclusion_user_ids` method to get user ids of those users having given roles if `roles` parameter is present otherwise it would return user ids for roles in `AGGREGATION_EXCLUDE_ROLES ` setting. It also bumps the version of api-integration.

@msaqib52 please review.