### PR TITLE
Have DiscussionXBlock and DiscussionCourseXBlock take care of loading assets they depend on

### DIFF
--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -1,0 +1,36 @@
+var vendorScript;
+if (typeof MathJax === 'undefined') {
+    vendorScript = document.createElement('script');
+    vendorScript.onload = function() {
+        'use strict';
+        var MathJax = window.MathJax,
+            setMathJaxDisplayDivSettings;
+        MathJax.Hub.Config({
+            tex2jax: {
+                inlineMath: [
+                    ['\\(', '\\)'],
+                    ['[mathjaxinline]', '[/mathjaxinline]']
+                ],
+                displayMath: [
+                    ['\\[', '\\]'],
+                    ['[mathjax]', '[/mathjax]']
+                ]
+            }
+        });
+        MathJax.Hub.signal.Interest(function(message) {
+            if (message[0] === 'End Math') {
+                setMathJaxDisplayDivSettings();
+            }
+        });
+        setMathJaxDisplayDivSettings = function() {
+            $('.MathJax_Display').each(function() {
+                this.setAttribute('tabindex', '0');
+                this.setAttribute('aria-live', 'off');
+                this.removeAttribute('role');
+                this.removeAttribute('aria-readonly');
+            });
+        };
+    };
+    vendorScript.src = 'https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=TeX-MML-AM_SVG';
+    document.body.appendChild(vendorScript);
+}

--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -199,18 +199,16 @@
                 };
             }
 
-            params.beforeSend = function() {
-                if ($elem) {
-                    $elem.prop('disabled', true);
+            if ($elem) {
+                $elem.prop('disabled', true);
+            }
+            if (params.$loading) {
+                if (params.loadingCallback) {
+                    params.loadingCallback.apply(params.$loading);
+                } else {
+                    self.showLoadingIndicator(params.$loading, params.takeFocus);
                 }
-                if (params.$loading) {
-                    if (params.loadingCallback) {
-                        params.loadingCallback.apply(params.$loading);
-                    } else {
-                        self.showLoadingIndicator(params.$loading, params.takeFocus);
-                    }
-                }
-            };
+            }
 
             request = $.ajax(params).always(function() {
                 if ($elem) {

--- a/common/static/common/js/spec/discussion/view/discussion_thread_profile_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_thread_profile_view_spec.js
@@ -18,12 +18,6 @@
                 created_at: '2014-09-09T20:11:08Z'
             };
             this.imageTag = '<img src="https://www.google.com.pk/images/srpr/logo11w.png">';
-            window.MathJax = {
-                Hub: {
-                    Queue: function() {
-                    }
-                }
-            };
         });
         makeView = function(thread) {
             var view;

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -15,6 +15,7 @@ from openedx.core.djangolib.js_utils import (
 <%block name="headextra">
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
+<%static:css group='style-inline-discussion'/>
 <%include file="../discussion/_js_head_dependencies.html" />
 </%block>
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1313,6 +1313,7 @@ dashboard_js = (
     sorted(rooted_glob(PROJECT_ROOT / 'static', 'js/dashboard/**/*.js'))
 )
 discussion_js = (
+    rooted_glob(COMMON_ROOT / 'static', 'common/js/discussion/mathjax_include.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/customwmd.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/mathjax_accessible.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'coffee/src/mathjax_delay_renderer.js') +
@@ -1324,6 +1325,10 @@ discussion_forum_js = [
 ]
 
 discussion_vendor_js = [
+    'js/vendor/edx_ui_toolkit_shim.js',
+    'js/vendor/i18n_shim.js',
+    'js/vendor/URI_shim.js',
+    'js/vendor/leanModal_shim.js',
     'js/Markdown.Converter.js',
     'js/Markdown.Sanitizer.js',
     'js/Markdown.Editor.js',
@@ -1481,6 +1486,18 @@ PIPELINE_CSS = {
             'css/discussion/lms-discussion-main-rtl.css',
         ],
         'output_filename': 'css/discussion/lms-discussion-main-rtl.css',
+    },
+    'style-inline-discussion': {
+        'source_filenames': [
+            'css/discussion/inline-discussion.css',
+        ],
+        'output_filename': 'css/discussion/inline-discussion.css',
+    },
+    'style-inline-discussion-rtl': {
+        'source_filenames': [
+            'css/discussion/inline-discussion-rtl.css',
+        ],
+        'output_filename': 'css/discussion/inline-discussion-rtl.css',
     },
     'style-xmodule-annotations': {
         'source_filenames': [

--- a/lms/static/js/discussion_forum.js
+++ b/lms/static/js/discussion_forum.js
@@ -1,7 +1,7 @@
 /* globals DiscussionApp, DiscussionProfileApp */
 function loadDiscussionApp() {
     $("section.discussion").each(function(index, elem) {
-       DiscussionApp.start(elem);
+        DiscussionApp.start(elem);
     });
     $("section.discussion-user-threads").each(function(index, elem) {
         DiscussionProfileApp.start(elem);

--- a/lms/static/js/vendor/URI_shim.js
+++ b/lms/static/js/vendor/URI_shim.js
@@ -1,0 +1,5 @@
+if (typeof URI === 'undefined') {
+    var vendorScript = document.createElement("script");
+    vendorScript.src = '/static/js/vendor/URI.min.js';
+    document.head.appendChild(vendorScript);
+}

--- a/lms/static/js/vendor/edx_ui_toolkit_shim.js
+++ b/lms/static/js/vendor/edx_ui_toolkit_shim.js
@@ -1,0 +1,18 @@
+if (typeof edx === 'undefined') {
+    var vendorScript,
+        vendorScriptURLs = [
+            '/static/edx-ui-toolkit/js/utils/string-utils.js',
+            '/static/edx-ui-toolkit/js/utils/html-utils.js'
+        ];
+    vendorScript = document.createElement("script");
+    vendorScript.onload = function() {
+        'use strict';
+        vendorScriptURLs.forEach(function(vendorScriptURL) {
+            vendorScript = document.createElement("script");
+            vendorScript.src = vendorScriptURL;
+            document.head.appendChild(vendorScript);
+        });
+    };
+    vendorScript.src = '/static/edx-ui-toolkit/js/utils/global-loader.js';
+    document.head.appendChild(vendorScript);
+}

--- a/lms/static/js/vendor/i18n_shim.js
+++ b/lms/static/js/vendor/i18n_shim.js
@@ -1,0 +1,17 @@
+// Set up gettext in case it isn't available in the client runtime:
+if (typeof gettext === "undefined") {
+    window.gettext = function gettext_stub(string) { return string; };
+    window.ngettext = function ngettext_stub(strA, strB, n) { return n === 1 ? strA : strB; };
+}
+
+// Create interpolate function in case it isn't available in the client runtime:
+if (typeof interpolate === "undefined") {
+    window.interpolate = function(fmt, obj, named) {
+        'use strict';
+        if (named) {
+            return fmt.replace(/%\(\w+\)s/g, function(match) { return String(obj[match.slice(2,-2)]); });
+        } else {
+            return fmt.replace(/%s/g, function() { return String(obj.shift()); });
+        }
+    };
+}

--- a/lms/static/js/vendor/leanModal_shim.js
+++ b/lms/static/js/vendor/leanModal_shim.js
@@ -1,0 +1,5 @@
+if (typeof $.fn.leanModal === 'undefined') {
+    var vendorScript = document.createElement("script");
+    vendorScript.src = '/static/js/vendor/jquery.leanModal.js';
+    document.head.appendChild(vendorScript);
+}

--- a/lms/static/sass/_build-base-v1-rtl.scss
+++ b/lms/static/sass/_build-base-v1-rtl.scss
@@ -1,0 +1,9 @@
+// libs and resets *do not edit*
+@import 'bourbon/bourbon'; // lib - bourbon
+@import 'vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
+@import 'base/variables-rtl';
+
+// base - utilities
+@import 'base/reset';
+@import 'base/variables';
+@import 'base/mixins';

--- a/lms/static/sass/_build-base-v1.scss
+++ b/lms/static/sass/_build-base-v1.scss
@@ -1,0 +1,8 @@
+// libs and resets *do not edit*
+@import 'bourbon/bourbon'; // lib - bourbon
+@import 'vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
+
+// base - utilities
+@import 'base/reset';
+@import 'base/variables';
+@import 'base/mixins';

--- a/lms/static/sass/_build-course.scss
+++ b/lms/static/sass/_build-course.scss
@@ -61,10 +61,6 @@
 // course - ccx_coach
 @import "course/ccx_coach/dashboard";
 
-// discussion
-@import "course/discussion/form-wmd-toolbar";
-@import "course/discussion/form";
-
 // search
 @import 'search/_search';
 

--- a/lms/static/sass/_build-lms-v1.scss
+++ b/lms/static/sass/_build-lms-v1.scss
@@ -61,21 +61,6 @@
 @import 'elements/xseries-certificates';
 @import 'views/api-access';
 
-// app - discussion
-@import "discussion/utilities/variables-v1";
-@import "discussion/mixins";
-@import 'discussion/discussion'; // Process old file after definitions but before everything else, partial is deprecated.
-@import "discussion/elements/actions";
-@import "discussion/elements/editor";
-@import "discussion/elements/labels";
-@import "discussion/elements/navigation";
-@import "discussion/views/home";
-@import "discussion/views/thread";
-@import "discussion/views/create-edit-post";
-@import "discussion/views/response";
-@import 'discussion/utilities/developer';
-@import 'discussion/utilities/shame';
-
 // search
 @import 'search/search';
 

--- a/lms/static/sass/discussion/_build-discussion.scss
+++ b/lms/static/sass/discussion/_build-discussion.scss
@@ -1,0 +1,27 @@
+// ------------------------------
+// Discussions: Shared Build Compile
+
+// About: Sass compile for discussion elements that are shared between LTR and RTL UI. Configuration and vendor specific imports happen before this shared set of imports is compiled in the inline-discussion-*.scss files.
+
+// Set the relative path to the static root
+$static-path: '../..';
+
+// Styles for discussions
+@import "utilities/variables-v1";
+@import "mixins";
+@import 'discussion'; // Process old file after definitions but before everything else, partial is deprecated.
+@import 'discussion-v1'; // Non-Pattern Library styling
+@import "elements/actions";
+@import "elements/editor";
+@import "elements/labels";
+@import "elements/navigation";
+@import "views/home";
+@import "views/thread";
+@import "views/create-edit-post";
+@import "views/response";
+@import 'utilities/developer';
+@import 'utilities/shame';
+
+// Styles for WYSIWYG Markdown editor
+@import "../course/discussion/form-wmd-toolbar";
+@import "../course/discussion/form";

--- a/lms/static/sass/discussion/_discussion-v1.scss
+++ b/lms/static/sass/discussion/_discussion-v1.scss
@@ -1,0 +1,67 @@
+// ------------------------------------------------
+// Styling for non-Pattern Library discussion pages
+// ------------------------------------------------
+
+// Note: replace with globals from common/static/sass/edx-pattern-library-shims when available
+%pattern-library-btn {
+    @include transition(
+        color 0.125s ease-in-out 0s,
+        border-color 0.125s ease-in-out 0s,
+        background 0.125s ease-in-out 0s,
+        box-shadow 0.125s ease-in-out 0s
+    );
+    display: inline-block;
+    border: 1px solid $forum-color-active-thread;
+    border-radius: 3px;
+    margin: 0;
+    background-image: none;
+    box-shadow: none;
+    text-shadow: none;
+    font-size: 14px;
+    font-weight: 600;
+
+    // Display: block, one button per line, full width
+    &.block {
+        display: block;
+        width: 100%;
+    }
+
+    // STATE: is disabled
+    &:disabled,
+    &.is-disabled {
+        pointer-events: none;
+        outline: none;
+        cursor: not-allowed;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+        border-color: $forum-color-hover;
+        background-color: $forum-color-hover;
+        background-image: none;
+        box-shadow: none;
+        color: $forum-color-active-text;
+        text-decoration: none;  // Don't show underlines on links that are styled as buttons
+    }
+}
+
+// Layout control for discussion modules that does not apply to the discussion board
+.discussion-module {
+    .discussion {
+        clear: both;
+        padding-top: ($baseline/2);
+    }
+
+    .btn {
+        @extend %pattern-library-btn;
+        background-color: $forum-color-background;
+        color: $forum-color-active-thread;
+     }
+
+    .btn-brand {
+        @extend %pattern-library-btn;
+        background-color: $forum-color-active-thread;
+        color: $forum-color-active-text;
+    }
+}

--- a/lms/static/sass/discussion/inline-discussion-rtl.scss
+++ b/lms/static/sass/discussion/inline-discussion-rtl.scss
@@ -1,0 +1,15 @@
+// Discussions - CSS application architecture
+// Version 1 styling (pre-Pattern Library)
+// ====================
+
+// Load the RTL version of the edX Pattern Library
+$pattern-library-path: '../edx-pattern-library' !default;
+@import 'edx-pattern-library/pattern-library/sass/edx-pattern-library-rtl';
+
+@import '../build-base-v1-rtl';
+
+// base - elements
+@import '../elements/typography';
+
+// app - discussion
+@import 'build-discussion';

--- a/lms/static/sass/discussion/inline-discussion.scss
+++ b/lms/static/sass/discussion/inline-discussion.scss
@@ -1,0 +1,17 @@
+// Discussions - CSS application architecture
+// Version 1 styling (pre-Pattern Library)
+// ====================
+
+// From lms-discussion-main.scss
+
+// Load the LTR version of the edX Pattern Library
+$pattern-library-path: '../edx-pattern-library' !default;
+@import 'edx-pattern-library/pattern-library/sass/edx-pattern-library-ltr';
+
+@import '../build-base-v1';
+
+// base - elements
+@import '../elements/typography';
+
+// app - discussion
+@import 'build-discussion';

--- a/lms/static/sass/discussion/utilities/_variables-v1.scss
+++ b/lms/static/sass/discussion/utilities/_variables-v1.scss
@@ -3,8 +3,9 @@
 
 // color variables
 $forum-color-background: $white;
-$forum-color-active-thread: $white !default;
-$forum-color-active-text: $base-font-color !default;
+$forum-color-active-thread: $blue !default;
+$forum-color-hover: $action-primary-bg !default;
+$forum-color-active-text: $white !default;
 $forum-color-pinned: $pink !default;
 $forum-color-reported: $pink !default;
 $forum-color-closed: $black !default;
@@ -14,8 +15,21 @@ $forum-color-community-ta: $green-d1 !default;
 $forum-color-marked-answer: $green-d1 !default;
 $forum-color-border: $gray-l3 !default;
 $forum-color-error: $red !default;
+$forum-color-hover-thread: #f6f6f6 !default;
+$forum-color-reading-thread: $gray-d3 !default;
+$forum-color-read-post: $blue !default;
+$forum-color-never-read-post: $gray-d3 !default;
 
 // post images
 $post-image-dimension: ($baseline*3) !default;  // image size  + margin
 $response-image-dimension: ($baseline*2.5) !default; // image size  + margin
 $comment-image-dimension: ($baseline*2) !default; // image size  + margin
+
+// font sizes
+$forum-base-font-size: 14px;
+$forum-x-large-font-size: 21px;
+$forum-large-font-size: 16px;
+$forum-small-font-size: 12px;
+
+// borders
+$forum-border-radius: 3px;

--- a/lms/static/sass/lms-main-v1-rtl.scss
+++ b/lms/static/sass/lms-main-v1-rtl.scss
@@ -2,21 +2,9 @@
 // Version 1 styling (pre-Pattern Library)
 // ====================
 
-// libs and resets *do not edit*
-@import 'bourbon/bourbon'; // lib - bourbon
-@import 'vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
-@import 'base/variables-rtl';
-
-// BASE  *default edX offerings*
-// ====================
-
-// base - utilities
-@import 'base/reset';
-@import 'base/variables';
-@import 'base/mixins';
-
 // This comment is used by preprocess_assets.py to include resources from a
 // theme, for old-style deprecated theming.
 //<THEME-OVERRIDE>
 
+@import 'build-base-v1-rtl';
 @import 'build-lms-v1'; // shared app style assets/rendering

--- a/lms/static/sass/lms-main-v1.scss
+++ b/lms/static/sass/lms-main-v1.scss
@@ -2,20 +2,9 @@
 // Version 1 styling (pre-Pattern Library)
 // ====================
 
-// libs and resets *do not edit*
-@import 'bourbon/bourbon'; // lib - bourbon
-@import 'vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
-
-// BASE  *default edX offerings*
-// ====================
-
-// base - utilities
-@import 'base/reset';
-@import 'base/variables';
-@import 'base/mixins';
-
 // This comment is used by preprocess_assets.py to include resources from a
 // theme, for old-style deprecated theming.
 //<THEME-OVERRIDE>
 
+@import 'build-base-v1';
 @import 'build-lms-v1'; // shared app style assets/rendering

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -40,7 +40,10 @@ ${static.get_page_title_breadcrumbs(course_name())}
 <%static:css group='style-student-notes'/>
 % endif
 
-<%include file="../discussion/_js_head_dependencies.html" />
+<script type="text/javascript" src="${static.url('js/jquery.autocomplete.js')}"></script>
+<script type="text/javascript" src="${static.url('js/src/tooltip_manager.js')}"></script>
+
+<link href="${static.url('css/vendor/jquery.autocomplete.css')}" rel="stylesheet" type="text/css">
   ${HTML(fragment.head_html())}
 </%block>
 
@@ -54,7 +57,7 @@ ${static.get_page_title_breadcrumbs(course_name())}
   <%static:js group='courseware'/>
   <%static:js group='discussion'/>
 
-  <%include file="../discussion/_js_body_dependencies.html" />
+  <%include file="/mathjax_include.html" args="disable_fast_preview=disable_fast_preview"/>
   % if staff_access:
   	<%include file="xqa_interface.html"/>
   % endif

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -61,7 +61,10 @@ ${static.get_page_title_breadcrumbs(course_name())}
 <%static:css group='style-student-notes'/>
 % endif
 
-<%include file="../discussion/_js_head_dependencies.html" />
+<script type="text/javascript" src="${static.url('js/jquery.autocomplete.js')}"></script>
+<script type="text/javascript" src="${static.url('js/src/tooltip_manager.js')}"></script>
+
+<link href="${static.url('css/vendor/jquery.autocomplete.css')}" rel="stylesheet" type="text/css">
   ${HTML(fragment.head_html())}
 </%block>
 
@@ -73,7 +76,8 @@ ${static.get_page_title_breadcrumbs(course_name())}
   <script type="text/javascript" src="${static.url('js/vendor/codemirror-compressed.js')}"></script>
 
   <%static:js group='courseware'/>
-  <%static:js group='discussion'/>
+  <%include file="/mathjax_include.html" args="disable_fast_preview=disable_fast_preview"/>
+
   % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
     <%static:require_module module_name="js/search/course/course_search_factory" class_name="CourseSearchFactory">
         var courseId = $('.courseware-results').data('courseId');
@@ -85,7 +89,6 @@ ${static.get_page_title_breadcrumbs(course_name())}
     CoursewareFactory();
   </%static:require_module>
 
-  <%include file="../discussion/_js_body_dependencies.html" />
   % if staff_access:
   	<%include file="xqa_interface.html"/>
   % endif

--- a/lms/templates/discussion/_discussion_inline.html
+++ b/lms/templates/discussion/_discussion_inline.html
@@ -1,5 +1,7 @@
 <%page expression_filter="h"/>
+
 <%include file="_underscore_templates.html" />
+
 <%!
 from django.utils.translation import ugettext as _
 from json import dumps as json_dumps

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -22,7 +22,11 @@ from openedx.core.lib.xblock_utils import (
     replace_jump_to_id_urls,
     replace_course_urls,
     replace_static_urls,
-    sanitize_html_id
+    sanitize_html_id,
+)
+from openedx.core.lib.xblock_builtin import (
+    get_css_dependencies,
+    get_js_dependencies,
 )
 
 
@@ -181,3 +185,41 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         clean_string = sanitize_html_id(dirty_string)
 
         self.assertEqual(clean_string, 'I_have_un_allowed_characters')
+
+    @ddt.data(
+        (True, ["combined.css"]),
+        (False, ["a.css", "b.css", "c.css"]),
+    )
+    @ddt.unpack
+    def test_get_css_dependencies(self, pipeline_enabled, expected_css_dependencies):
+        """
+        Verify that `get_css_dependencies` returns correct list of files.
+        """
+        pipeline_css = {
+            'style-group': {
+                'source_filenames': ["a.css", "b.css", "c.css"],
+                'output_filename': "combined.css"
+            }
+        }
+        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_CSS=pipeline_css):
+            css_dependencies = get_css_dependencies("style-group")
+            self.assertEqual(css_dependencies, expected_css_dependencies)
+
+    @ddt.data(
+        (True, ["combined.js"]),
+        (False, ["a.js", "b.js", "c.js"]),
+    )
+    @ddt.unpack
+    def test_get_js_dependencies(self, pipeline_enabled, expected_js_dependencies):
+        """
+        Verify that `get_js_dependencies` returns correct list of files.
+        """
+        pipeline_js = {
+            'js-group': {
+                'source_filenames': ["a.js", "b.js", "c.js"],
+                'output_filename': "combined.js"
+            }
+        }
+        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_JS=pipeline_js):
+            js_dependencies = get_js_dependencies("js-group")
+            self.assertEqual(js_dependencies, expected_js_dependencies)

--- a/openedx/core/lib/xblock_builtin/__init__.py
+++ b/openedx/core/lib/xblock_builtin/__init__.py
@@ -1,0 +1,31 @@
+"""
+Helper functions shared by built-in XBlocks.
+
+"""
+
+
+from django.conf import settings
+
+
+def get_css_dependencies(group):
+    """
+    Returns list of CSS dependencies belonging to `group` in settings.PIPELINE_JS.
+
+    Respects `PIPELINE_ENABLED` setting.
+    """
+    if settings.PIPELINE_ENABLED:
+        return [settings.PIPELINE_CSS[group]['output_filename']]
+    else:
+        return settings.PIPELINE_CSS[group]['source_filenames']
+
+
+def get_js_dependencies(group):
+    """
+    Returns list of JS dependencies belonging to `group` in settings.PIPELINE_JS.
+
+    Respects `PIPELINE_ENABLED` setting.
+    """
+    if settings.PIPELINE_ENABLED:
+        return [settings.PIPELINE_JS[group]['output_filename']]
+    else:
+        return settings.PIPELINE_JS[group]['source_filenames']

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -4,12 +4,18 @@ Discussion XBlock
 """
 import logging
 
+from django.templatetags.static import static
+from django.utils.translation import get_language_bidi
+
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 from xblock.core import XBlock
 from xblock.fields import Scope, String, UNIQUE_ID
 from xblock.fragment import Fragment
+
+from openedx.core.lib.xblock_builtin import get_css_dependencies, get_js_dependencies
+
 
 log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)  # pylint: disable=invalid-name
@@ -81,6 +87,56 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin):
             return None
         return user_service._django_user  # pylint: disable=protected-access
 
+    @staticmethod
+    def vendor_js_dependencies():
+        """
+        Returns list of vendor JS files that this XBlock depends on.
+
+        The helper function that it uses to obtain the list of vendor JS files
+        works in conjunction with the Django pipeline to ensure that in development mode
+        the files are loaded individually, but in production just the single bundle is loaded.
+        """
+        return get_js_dependencies('discussion_vendor')
+
+    @staticmethod
+    def js_dependencies():
+        """
+        Returns list of JS files that this XBlock depends on.
+
+        The helper function that it uses to obtain the list of JS files
+        works in conjunction with the Django pipeline to ensure that in development mode
+        the files are loaded individually, but in production just the single bundle is loaded.
+        """
+        return get_js_dependencies('discussion')
+
+    @staticmethod
+    def css_dependencies():
+        """
+        Returns list of CSS files that this XBlock depends on.
+
+        The helper function that it uses to obtain the list of CSS files
+        works in conjunction with the Django pipeline to ensure that in development mode
+        the files are loaded individually, but in production just the single bundle is loaded.
+        """
+        if get_language_bidi():
+            return get_css_dependencies('style-inline-discussion-rtl')
+        else:
+            return get_css_dependencies('style-inline-discussion')
+
+    def add_resource_urls(self, fragment):
+        """
+        Adds URLs for JS and CSS resources that this XBlock depends on to `fragment`.
+        """
+        for vendor_js_file in self.vendor_js_dependencies():
+            fragment.add_resource_url(static(vendor_js_file), "application/javascript", "head")
+
+        for css_file in self.css_dependencies():
+            fragment.add_css_url(static(css_file))
+
+        # Body dependencies
+        for js_file in self.js_dependencies():
+            fragment.add_javascript_url(static(js_file))
+
     def has_permission(self, permission):
         """
         Encapsulates lms specific functionality, as `has_permission` is not
@@ -101,12 +157,11 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin):
         """
         fragment = Fragment()
 
-        course = self.runtime.modulestore.get_course(self.course_key)
+        self.add_resource_urls(fragment)
 
         context = {
             'discussion_id': self.discussion_id,
             'user': self.django_user,
-            'course': course,
             'course_id': self.course_key,
             'can_create_thread': self.has_permission("create_thread"),
             'can_create_comment': self.has_permission("create_comment"),

--- a/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_classes.js
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_classes.js
@@ -1,0 +1,37 @@
+// Add RequireJS definitions for each discussion class
+
+var discussionClasses = [
+    ['Discussion', 'common/js/discussion/discussion'],
+    ['DiscussionModuleView', 'common/js/discussion/discussion_module_view'],
+    ['DiscussionThreadView', 'common/js/discussion/views/discussion_thread_view'],
+    ['DiscussionThreadListView', 'common/js/discussion/views/discussion_thread_list_view'],
+    ['DiscussionThreadProfileView', 'common/js/discussion/views/discussion_thread_profile_view'],
+    ['DiscussionUtil', 'common/js/discussion/utils'],
+    ['NewPostView', 'common/js/discussion/views/new_post_view']
+];
+
+var defineDiscussionClasses = function(define) {
+    'use strict';
+    discussionClasses.forEach(function(discussionClass) {
+        define(
+            discussionClass[1],
+            [],
+            function() {
+                return window[discussionClass[0]];
+            }
+        );
+    });
+};
+
+if (typeof RequireJS === 'undefined') {
+    var vendorScript = document.createElement("script");
+    vendorScript.onload = function() {
+        'use strict';
+        defineDiscussionClasses(define);
+    };
+    vendorScript.src = "/static/js/vendor/requirejs/require.js";
+    document.body.appendChild(vendorScript);
+
+} else {
+    defineDiscussionClasses(RequireJS.define);
+}

--- a/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
@@ -1,14 +1,6 @@
-/* globals DiscussionUtil, DiscussionApp, DiscussionProfileApp */
-var $$course_id = "{{course_id}}";
-
+/* globals DiscussionUtil */
 function DiscussionCourseBlock(runtime, element) {
-    var testUrl = runtime.handlerUrl(element, 'test');
-    if (testUrl.match(/^(http|https):\/\//)) {
-        var hostname = testUrl.match(/^(.*:\/\/[a-z0-9:\-.]+)\//)[1];
-        DiscussionUtil.setBaseUrl(hostname);
-    }
-
+    'use strict';
     DiscussionUtil.force_async = true;
-
     loadDiscussionApp();
 }

--- a/openedx/core/lib/xblock_builtin/xblock_discussion_course/utils.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion_course/utils.py
@@ -1,21 +1,14 @@
 """
-Utils for Discussion XBlock and Course Discussion XBlock
+Utils for DiscussionCourseXBlock
 """
 
 import os
 
-from django.templatetags.static import static
+from django.conf import settings
 
 from mako.template import Template as MakoTemplate
 
 from path import Path as path
-
-
-JS_URLS = [
-    # VENDOR
-    'js/vendor/mustache.js',
-    'js/discussion_forum.js',
-]
 
 
 def _(text):
@@ -23,6 +16,18 @@ def _(text):
     A noop underscore function that marks strings for extraction.
     """
     return text
+
+
+def get_js_dependencies(group):
+    """
+    Returns list of JS dependencies belonging to `group` in settings.PIPELINE_JS.
+
+    Respects `PIPELINE_ENABLED` setting.
+    """
+    if settings.PIPELINE_ENABLED:
+        return [settings.PIPELINE_JS[group]['output_filename']]
+    else:
+        return settings.PIPELINE_JS[group]['source_filenames']
 
 
 def render_mustache_templates():
@@ -54,19 +59,3 @@ def render_mustache_templates():
         for file_name in os.listdir(mustache_dir)
         if is_valid_file_name(file_name)
     )
-
-
-def add_resources_to_fragment(fragment):
-    """
-    Add resources specified in JS_URLS to a given fragment.
-    """
-    for url in JS_URLS:
-        fragment.add_javascript_url(asset_to_static_url(url))
-
-
-def asset_to_static_url(asset_path):
-    """
-    :param str asset_path: path to asset
-    :return: str|unicode url of asset
-    """
-    return static(asset_path)


### PR DESCRIPTION
`DiscussionXBlock` currently relies on courseware to load JS and CSS assets that it depends on. This PR transfers responsibility for loading these assets to the XBlock itself.

`DiscussionCourseXBlock` was already taking care of loading *some* necessary assets. This PR makes sure that the block loads all assets it depends on.

cf. [YONK-382](https://openedx.atlassian.net/browse/YONK-382)

**Related PRs**

- https://github.com/edx/edx-platform/pull/13483

**Dependencies**

<!--
- https://github.com/edx-solutions/edx-platform/pull/743 (commits included here until that PR merges)
-->
- https://github.com/edx-solutions/cs_comments_service/pull/18
- https://github.com/edx-solutions/jquery-xblock/pull/24

<!--
**Relevant commits**

All commits by me. Haven't squashed them yet to keep history transparent. To make it easier to review the changes, I created a separate [branch](https://github.com/open-craft/edx-platform/tree/itsjeyd/discussion-assets-squashed) with a single commit (https://github.com/open-craft/edx-platform/commit/117350e2aad0aacf7e6218b65c0bdab2faf33d38) that combines changes from relevant commits.
-->

<!--
* Commit containing changes prior to internal review: https://github.com/open-craft/edx-platform/commit/a3f1c55ddc09130f194b8b5565aa445e96a8ee8d
* Commit containing changes prior to rebase: https://github.com/open-craft/edx-platform/commit/f3bce6f9eb4b45972b18944be9ccbe1bd658c75f
-->

**Screenshots**

- Adding a post: ![add-a-post](https://cloud.githubusercontent.com/assets/961441/18811656/f111cd80-82b7-11e6-8e48-2f25fbcab7a5.png)

- Expanded discussion: ![post-mathjax-expanded](https://cloud.githubusercontent.com/assets/961441/18811671/6cb8bc50-82b8-11e6-8db3-84a35e435a35.png)

- Responses: ![response-comment-mathjax](https://cloud.githubusercontent.com/assets/961441/18811685/e9c014f0-82b8-11e6-95ba-001df32ad9fb.png)

- Error message: ![post-with-error](https://cloud.githubusercontent.com/assets/961441/18817460/030e2278-8361-11e6-9e9a-f40f7e99d74e.png)

**Setup instructions**

1. Get Studio, LMS, and Apros running on the parent branch (`ziafazal/fix-broken-features`), then checkout this branch. List of commits to use:

    * `edx-platform`: Latest commit on this branch.
    * `cs_comments_service`: https://github.com/edx-solutions/cs_comments_service/commit/10826f6c7b9a597c527bf9752f16567e5025d27e
    * Apros: `master` @ `b7e058b`

2. As `edxapp` user, remove static assets via `git clean -fx`.

3. As `edxapp` user, rebuild assets via `paver update_assets` *or* `paver devstack studio`, `paver devstack lms`.

4. Install changes from https://github.com/edx-solutions/jquery-xblock/pull/24: In Apros repo, replace contents of `static/js/vendor/jquery.xblock.js` with contents of [updated version](https://raw.githubusercontent.com/edx-solutions/jquery-xblock/2037d7411a063124bcc0e10615edfbd8db67c3b2/jquery.xblock.js).

5. As `apros` user, run `./manage.py collectstatic --noinput` and make sure `jquery.xblock.js` is mentioned in the output as one of the files that got updated.

**Test instructions**

1. Add `DiscussionXBlock` to a unit via the main "Discussion" component button.

2. Add `discussion-course` to advanced modules.

3. Create a new section called `DISCUSSION_TAB`.

4. Add a subsection and unit to the `DISCUSSION_TAB` section created in the previous step.

5. Select "Advanced" > "Discussion Course" to add an instance of `DiscussionCourseXBlock` to the unit.

6. Navigate to unit containing `DiscussionXBlock` in the LMS and smoke test discussion functionality.

    For example, make sure that you can perform the following actions as `staff` user:

    * Create a Post, Reply, Comment.
    * Edit a Post, Reply, Comment.
    * Test [MathJax](http://docs.mathjax.org/en/latest/start.html) functionality in Post, Reply, Comment (and Preview), with e.g.
      ```
There are two solutions to \(ax^2 + bx + c = 0\) and they are
$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$

When $a \ne 0$
      ```
    * Delete a Post, Reply, Comment.
    * Follow/unfollow a thread/post.
    * In the "Instructor" panel, add the `staff` user to the `Discussion Admin` or `Discussion Moderator` group. Then you should be able to: 
        * Open/close a thread/post.
        * Pin/unpin a thread/post.
    * Try to create a post without a title. This should cause an error message to be displayed above the controls you used to create the post.

6. Login as a regular student.  You should be able to do the above actions, plus:

    * Report/unreport a post created by the `staff` user.
    * Vote/unvote a thread/post created by the `staff` user.

7. Repeat previous steps for unit containing `DiscussionCourseXBlock`.

8. In Apros, navigate to unit containing `DiscussionXBlock` and repeat previous steps. Performing some of the actions will be a little fiddly because CSS for `DiscussionXBlock` does not match Apros CSS yet (cf. "Author notes" below).

  <!-- Make sure you can "Show discussion", expand and collapse threads, and show/dismiss the form for adding a new post by clicking "Add a Post"/"Cancel". -->

9. In Apros, navigate to (equivalent of) "Discussion" tab and repeat previous steps. The CSS for `DiscussionCourseXBlock` does not match Apros CSS yet (cf. "Author notes" below), so some UI elements will look a little weird.

  <!-- Make sure you can search for posts in the sidebar, view individual threads by selecting them from the sidebar, and show/dismiss the form for adding a new post by clicking "New post"/"Cancel". -->

10. Enable the "Teams" feature:

    * In Studio, replace the contents of "Advanced Settings" > "Teams Configuration" with:

      ```json
{
    "topics": [
        {
            "name": "Sustainability in Corporations",
            "description": "Description for Sustainability in Corporations",
            "id": "Sustain_Corporations"
        },
        {
            "name": "Water Conservation Projects",
            "description": "Description for Water Conservation",
            "id": "Water_Conservation"
        },
        {
            "name": "Sustainability Standards and Reporting",
            "description": "Description for Sustainability Standards",
            "id": "Standards_Reporting"
        }
    ],
    "max_team_size": 5
}
      ```
    * In the LMS, navigate to the "Teams" tab, select one of the topics and add a team to it via "create a new team in this topic".
    * Sanity-check discussion CSS by adding a post, response, and comment.

**Author notes**

- CSS for both `DiscussionXBlock` and `DiscussionCourseXBlock` does not match Apros CSS yet. We have a separate ticket for addressing this: [YONK-383](https://openedx.atlassian.net/browse/YONK-383).

**Reviewers**

- [x] OpenCraft: @pomegranited 
- [ ] Solutions: @ziafazal 