### PR TITLE
MathJax: disable "fast preview" mode

### DIFF
--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -1,5 +1,13 @@
-var vendorScript;
+// See common/templates/mathjax_include.html for info on Fast Preview mode.
+var disableFastPreview = true,
+    vendorScript;
 if (typeof MathJax === 'undefined') {
+    if (disableFastPreview) {
+        window.MathJax = {
+            menuSettings: {CHTMLpreview: false}
+        };
+    }
+
     vendorScript = document.createElement('script');
     vendorScript.onload = function() {
         'use strict';
@@ -17,6 +25,9 @@ if (typeof MathJax === 'undefined') {
                 ]
             }
         });
+        if (disableFastPreview) {
+            MathJax.Hub.processSectionDelay = 0;
+        }
         MathJax.Hub.signal.Interest(function(message) {
             if (message[0] === 'End Math') {
                 setMathJaxDisplayDivSettings();

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -57,7 +57,7 @@ ${static.get_page_title_breadcrumbs(course_name())}
   <%static:js group='courseware'/>
   <%static:js group='discussion'/>
 
-  <%include file="/mathjax_include.html" args="disable_fast_preview=disable_fast_preview"/>
+  <%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
   % if staff_access:
   	<%include file="xqa_interface.html"/>
   % endif

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -76,7 +76,7 @@ ${static.get_page_title_breadcrumbs(course_name())}
   <script type="text/javascript" src="${static.url('js/vendor/codemirror-compressed.js')}"></script>
 
   <%static:js group='courseware'/>
-  <%include file="/mathjax_include.html" args="disable_fast_preview=disable_fast_preview"/>
+  <%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
 
   % if settings.FEATURES.get('ENABLE_COURSEWARE_SEARCH'):
     <%static:require_module module_name="js/search/course/course_search_factory" class_name="CourseSearchFactory">


### PR DESCRIPTION
Changes from our previous PR #744 were [merged to `edx:master](https://github.com/edx/edx-platform/pull/13483), but had to be [reverted](https://github.com/edx/edx-platform/pull/13651) due to timing issues introduced into the Courseware lettuce acceptance tests.

Those issues have been fixed by https://github.com/edx/edx-platform/pull/13713.

This PR brings the fixes in https://github.com/edx/edx-platform/pull/13713 across to the `edx-solutions` Eucalyptus rebase.

**JIRA tickets**: Related to [YONK-382](https://openedx.atlassian.net/browse/YONK-382).

**Discussions**: See comments on [PR #13713](https://github.com/edx/edx-platform/pull/13713#issuecomment-252650478) for test results.

**Merge deadline**: Aiming for 17 Oct 2016.

**Testing instructions**:

See PR #744 for test setup instructions, including a sample MathJax snippet.

Run the test instructions for https://github.com/edx/edx-platform/pull/13713 in Apros to ensure the change has taken effect.

**Reviewers**
- [x] @itsjeyd
- [ ] @ziafazal