### PR TITLE
added preview_view to inline disucssion

### DIFF
--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -177,6 +177,19 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin):
         """
         Renders author view for Studio.
         """
+        return self.studio_view_fragment()
+
+    def preview_view(self, context=None):  # pylint: disable=unused-argument
+        """
+        Renders preview inside Studio. This is used when DiscussionXBlock is embedded
+        by another XBlock.
+        """
+        return self.studio_view_fragment()
+
+    def studio_view_fragment(self):
+        """
+        Returns a fragment for rendering this block in Studio.
+        """
         fragment = Fragment()
         fragment.add_content(self.runtime.render_template(
             'discussion/_discussion_inline_studio.html',


### PR DESCRIPTION
While testing eucalyptus upgrade on integration environment we found inline discussions does not render in studio when added inside a group project v2. It was trying to render student view and since discussion JS are not setup in asset pipeline of studio it was not able to pull `discussion_vendor` asset group. To fix this issue we need inline discussion xblock to override `preview_view` method. This [story](https://openedx.atlassian.net/browse/YONK-426) has more details to reproduce error.
@pomegranited would you please review this one?

