### PR TITLE
YONK-413 Fix DiscussionCourseXBlock URLs

### DIFF
--- a/common/static/common/js/discussion/main.js
+++ b/common/static/common/js/discussion/main.js
@@ -33,16 +33,6 @@
                     course_settings: course_settings
                 });
                 /* jshint +W031*/
-
-                // Avoid re-initializing Backbone.history
-                if (!Backbone.History.started) {
-                    // Changes the current URL to the given root when links
-                    // inside this component are clicked.
-                    Backbone.history.start({
-                        pushState: true,
-                        root: "/courses/" + $$course_id + "/discussion/forum/"
-                    });
-                }
             }
         };
 

--- a/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
@@ -1,6 +1,17 @@
-/* globals DiscussionUtil */
+/* globals window, $$course_id, DiscussionUtil */
 function DiscussionCourseBlock(runtime, element) {
     'use strict';
+    var hasPushState = window.history && window.history.pushState ? true : false;
     DiscussionUtil.force_async = true;
     loadDiscussionApp();
+
+    // Restart the Backbone router to use the discussion root when
+    // links inside this component are clicked.
+    if (Backbone.History.started) {
+        Backbone.history.stop();
+    }
+    Backbone.history.start({
+        pushState: hasPushState,
+        root: "/courses/" + $$course_id + "/discussion/"
+    });
 }

--- a/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion_course/static/js/discussion_course.js
@@ -3,7 +3,6 @@ function DiscussionCourseBlock(runtime, element) {
     'use strict';
     var hasPushState = window.history && window.history.pushState ? true : false;
     DiscussionUtil.force_async = true;
-    loadDiscussionApp();
 
     // Restart the Backbone router to use the discussion root when
     // links inside this component are clicked.


### PR DESCRIPTION
Fixes DiscussionCourseXBlock URLs by resetting the Backbone.History router to use the correct URL root.

Also fixes an issue I noticed with the "All Discussions" button, which wasn't correctly toggling the discussions list.

**JIRA tickets**: Implements YONK-413

**Partner information**: 3rd party-hosted open edX instance, for an edX solutions client

**Merge deadline**:  Fri Oct 21 2016

**Dependencies**:

* https://github.com/edx-solutions/cs_comments_service/pull/18
* [mcka_apros:ziafazal/eucalyptus-modifications](https://github.com/mckinseyacademy/mcka_apros/tree/ziafazal/eucalyptus-modifications) - this takes care of installing the fix from https://github.com/edx-solutions/jquery-xblock/pull/24.

**Setup Instructions**:

1. Get Studio, LMS, and Apros running on the parent branch (`ziafazal/fix-broken-features`), then checkout this branch. List of commits to use:
    * `edx-platform`: Latest commit on this branch.
    * `cs_comments_service`: https://github.com/edx-solutions/cs_comments_service/commit/10826f6c7b9a597c527bf9752f16567e5025d27e
    * `apros` : https://github.com/mckinseyacademy/mcka_apros/commit/1f8071ac5348e9a7889696dfb6a067aca29ea3e3

2. As `edxapp` user, remove static assets via `git clean -fx`.
3. As `edxapp` user, rebuild assets via `paver update_assets` *or* `paver devstack studio`, `paver devstack lms`.
5. As `apros` user, run `./manage.py collectstatic --noinput`, and restart `apros`.

**Testing instructions**:

1. Add `DiscussionXBlock` to a unit via the main "Discussion" component button.
2. Add `discussion-course` to advanced modules.
3. Create a new section called `DISCUSSION_TAB`.
4. Add a subsection and unit to the `DISCUSSION_TAB` section created in the previous step.
5. Select "Advanced" > "Discussion Course" to add an instance of `DiscussionCourseXBlock` to the unit.
6. In Apros LMS, navigate to the Discussion tab.
1. Create a New Post.
1. Refresh the page, and ensure that your new post is still shown.
1. Click on the `All Discussions` button to toggle the full list of discussions with the discussions navigation menu.
1. Smoke test the Discussions tab and inline discussion module to ensure no regressions were introduced.

**Reviewers**
- [ ] @itsjeyd 
- [ ] @ziafazal 