### PR TITLE
support legacy inline discussion forum name in filters

### DIFF
--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -68,10 +68,10 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
             start=self.now,
         )
 
-        # Create a scheduled discussion xblock
+        # Create a scheduled discussion xblock with legacy category name
         ItemFactory.create(
             parent=parent,
-            category='discussion',
+            category='discussion-forum',
             display_name='scheduled',
             start=self.future,
         )

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -132,7 +132,9 @@ def get_accessible_discussion_xblocks(course, user, include_all=False):  # pylin
     Return a list of all valid discussion xblocks in this course that
     are accessible to the given user.
     """
-    all_xblocks = modulestore().get_items(course.id, qualifiers={'category': 'discussion'}, include_orphans=False)
+    all_xblocks = modulestore().get_items(course.id, qualifiers={
+        'category': ['discussion', 'discussion-forum']
+    }, include_orphans=False)
 
     return [
         xblock for xblock in all_xblocks

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime
 import logging
 import string
+import re
 from django.conf import settings
 
 import pytz
@@ -133,7 +134,7 @@ def get_accessible_discussion_xblocks(course, user, include_all=False):  # pylin
     are accessible to the given user.
     """
     all_xblocks = modulestore().get_items(course.id, qualifiers={
-        'category': ['discussion', 'discussion-forum']
+        'category': re.compile(r'discussion|discussion-forum')
     }, include_orphans=False)
 
     return [


### PR DESCRIPTION
We have renamed inline discussion xblock from `disucssion-forum` to `discussion`. This PR filters inline discussion xblocks with their legacy names also to support loading of discussion threads for old courses.
This fixes YONK-428 and YONK-430.

@antoviaque can some one from your team review this?