### PR TITLE
Added missing local_resource_url method to StudioEditModuleRuntime

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -37,7 +37,7 @@ from contentstore.utils import is_self_paced
 from openedx.core.lib.gating import api as gating_api
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
-from openedx.core.lib.xblock_utils import wrap_xblock, request_token
+from openedx.core.lib.xblock_utils import wrap_xblock, request_token, xblock_local_resource_url
 from static_replace import replace_static_urls
 from student.auth import has_studio_write_access, has_studio_read_access
 from util.date_utils import get_default_time_display
@@ -250,6 +250,12 @@ class StudioEditModuleRuntime(object):
             if service_name == "studio_user_permissions":
                 return StudioPermissionsService(self._user)
         return None
+
+    def local_resource_url(self, *args, **kwargs):
+        """
+        Return URL of XBlock local resource.
+        """
+        return xblock_local_resource_url(*args, **kwargs)
 
 
 @require_http_methods(("GET"))

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -85,7 +85,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@857bf365f19c904d7e48364428f6b93ff153fabd#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.8#egg=edx-milestones==0.1.8
-git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1


### PR DESCRIPTION
**Description:** This PR fixes a couple of issues related to XBlocks:
* Added missing `local_resource_url` method to `StudioEditModuleRuntime` used to render XBlock's edit UI.
* Upgraded xblock-utils to 1.0.3 to fix issue with adding singleton nested XBlocks

**JIRA:** 
* [YONK-435](https://openedx.atlassian.net/browse/YONK-435)
* [YONK-436](https://openedx.atlassian.net/browse/YONK-436)

**Testing instructions:**

*YONK-345:*
1. Create a course.
2. Add Drag and Drop v2, Poll, Survey or any other XBlock affected by [YONK-435](https://openedx.atlassian.net/browse/YONK-435) (non-exclusive list available on the ticket) to Advanced problem list in course "Advanced Settings".
3. Create section, subsection and unit.
4. Add a chosen XBlock to the unit.
5. Click "EDIT" on the block. *Expected result:* XBlock edit UI appears in popup. *Failure condition:* error message "Error: 'StudioEditModuleRuntime' object has no attribute 'local_resource_url'"" is shown.

*YONK-346:*
1. Create a course.
2. Add Step Builder XBlock (`step-builder`) to Advanced problem list in course "Advanced Settings".
3. Create section, subsection and unit.
4. Add Step Builder to a unit.
5. Click "VIEW" on the block. 
6. Click "Review Step". *Expected result:* Review step XBlock is added, "Review Step" button becomes disabled. *Failure condition:* Review step XBlock is **not** added, button becomes disabled.

**Reviewers:**
- [x] @itsjeyd 
- [x] @ziafazal 

**Merge deadline:** Nov 2 EOD.