### PR TITLE
Fix styling problems caused by discussions

### DIFF
--- a/lms/static/sass/_build-base-v1-no-reset.scss
+++ b/lms/static/sass/_build-base-v1-no-reset.scss
@@ -1,0 +1,6 @@
+// libs and resets *do not edit*
+@import 'bourbon/bourbon'; // lib - bourbon
+
+// base - utilities
+@import 'base/variables';
+@import 'base/mixins';

--- a/lms/static/sass/_build-base-v1-rtl.scss
+++ b/lms/static/sass/_build-base-v1-rtl.scss
@@ -1,9 +1,6 @@
 // libs and resets *do not edit*
-@import 'bourbon/bourbon'; // lib - bourbon
 @import 'vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
 @import 'base/variables-rtl';
 
-// base - utilities
-@import 'base/reset';
-@import 'base/variables';
-@import 'base/mixins';
+@import 'base/reset.scss';
+@import 'build-base-v1-no-reset';

--- a/lms/static/sass/_build-base-v1.scss
+++ b/lms/static/sass/_build-base-v1.scss
@@ -1,8 +1,5 @@
 // libs and resets *do not edit*
-@import 'bourbon/bourbon'; // lib - bourbon
 @import 'vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
 
-// base - utilities
-@import 'base/reset';
-@import 'base/variables';
-@import 'base/mixins';
+@import 'base/reset.scss';
+@import 'build-base-v1-no-reset';

--- a/lms/static/sass/discussion/_edx-pattern-library-loader.scss
+++ b/lms/static/sass/discussion/_edx-pattern-library-loader.scss
@@ -1,0 +1,26 @@
+// Discussions - CSS application architecture
+// Version 1 styling (pre-Pattern Library)
+// ====================
+
+// Load edX Pattern Library
+$pattern-library-path: '../../edx-pattern-library' !default;
+
+// We don't need entire pattern library for inline discussion - just the "alerts" part to make alert messages styling
+// consistent with other alert messages.
+// Also, we don't want most of reset and normalization styles - see https://openedx.atlassian.net/browse/YONK-437
+
+// TODO: make edx-pattern-library provide "bodyless" version without actual CSS rules (only SASS mixins, vars etc.)
+@import 'edx-pattern-library/pattern-library/sass/global/lib';                    // third-party libraries
+/* parts of pattern-library/sass/global/core */
+@import 'edx-pattern-library/pattern-library/sass/global/functions';
+@import 'edx-pattern-library/pattern-library/sass/global/settings';
+@import 'edx-pattern-library/pattern-library/sass/global/mixins';
+@import 'edx-pattern-library/pattern-library/sass/global/helpers';
+/* end parts of pattern-library/sass/global/core */
+@import 'edx-pattern-library/pattern-library/sass/patterns/alerts';               // Alerts styling
+
+// SHAME
+// Part of edx-pattern-library _reset.scss, but we don't want entire reset to be here
+* {
+  box-sizing: border-box;
+}

--- a/lms/static/sass/discussion/inline-discussion-rtl.scss
+++ b/lms/static/sass/discussion/inline-discussion-rtl.scss
@@ -1,12 +1,12 @@
 // Discussions - CSS application architecture
 // Version 1 styling (pre-Pattern Library)
 // ====================
+@import 'edx-pattern-library/pattern-library/sass/global/rtl';                    // RTL-specific settings and utilities
+@import 'edx-pattern-library-loader';
 
-// Load the RTL version of the edX Pattern Library
-$pattern-library-path: '../../edx-pattern-library' !default;
-@import 'edx-pattern-library/pattern-library/sass/edx-pattern-library-rtl';
-
-@import '../build-base-v1-rtl';
+@import '../vendor/bi-app/bi-app-rtl'; // set the layout for right to left languages
+@import '../base/variables-rtl';
+@import '../build-base-v1-no-reset';
 
 // base - elements
 @import '../elements/typography';

--- a/lms/static/sass/discussion/inline-discussion.scss
+++ b/lms/static/sass/discussion/inline-discussion.scss
@@ -4,13 +4,13 @@
 
 // From lms-discussion-main.scss
 
-// Load the LTR version of the edX Pattern Library
-$pattern-library-path: '../../edx-pattern-library' !default;
-@import 'edx-pattern-library/pattern-library/sass/edx-pattern-library-ltr';
+@import 'edx-pattern-library/pattern-library/sass/global/ltr';                    // LTR-specific settings and utilities
+@import 'edx-pattern-library-loader';
 
-@import '../build-base-v1';
+@import '../vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
+@import '../base/variables-ltr';
+@import '../build-base-v1-no-reset';
 
-// base - elements
 @import '../elements/typography';
 
 // app - discussion


### PR DESCRIPTION
**Description:** This PR attempts to fix styling problems reported in [YONK-437](https://openedx.atlassian.net/browse/YONK-437). 

**JIRA:** [YONK-437](https://openedx.atlassian.net/browse/YONK-437)

**Testing instructions:**
1. Create a course with GPv2 XBlock ([instructions](https://github.com/open-craft/xblock-group-project-v2/blob/master/README.md), [example course](https://github.com/open-craft/xblock-group-project-v2/tree/master/examples))
2. Configure Group Project in Apros ([instructions](https://github.com/mckinseyacademy/mcka_apros/blob/master/docs/GroupWorkConfiguration.md))
3. Log in into Apros as student enrolled into group project course.
4. Navigate to Group Project part (this button in top-right menu)
![image](https://cloud.githubusercontent.com/assets/3330048/19768280/8333e322-9c5f-11e6-913f-a99dd5dcf8e5.png)
5. Observe that reported styling issues are gone.

**Author concerns:**

This solution is much less elegant than I would like - in short it breaks `build-base` and `edx-pattern-library` abstractions.

**Reviewers:**
- [x] @pomegranited 
- [x] @ziafazal 
