### PR TITLE
Better fix for missing local_resource_url

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -251,12 +251,6 @@ class StudioEditModuleRuntime(object):
                 return StudioPermissionsService(self._user)
         return None
 
-    def local_resource_url(self, *args, **kwargs):
-        """
-        Return URL of XBlock local resource.
-        """
-        return xblock_local_resource_url(*args, **kwargs)
-
 
 @require_http_methods(("GET"))
 @login_required

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1469,29 +1469,21 @@ class DescriptorSystem(MetricsMixin, ConfigurableFragmentWrapper, Runtime):
         return result
 
     def handler_url(self, block, handler_name, suffix='', query='', thirdparty=False):
-        xmodule_runtime = getattr(block, 'xmodule_runtime', None)
-        if xmodule_runtime is not None:
-            return xmodule_runtime.handler_url(block, handler_name, suffix, query, thirdparty)
-        else:
-            # Currently, Modulestore is responsible for instantiating DescriptorSystems
-            # This means that LMS/CMS don't have a way to define a subclass of DescriptorSystem
-            # that implements the correct handler url. So, for now, instead, we will reference a
-            # global function that the application can override.
-            return descriptor_global_handler_url(block, handler_name, suffix, query, thirdparty)
+        # Currently, Modulestore is responsible for instantiating DescriptorSystems
+        # This means that LMS/CMS don't have a way to define a subclass of DescriptorSystem
+        # that implements the correct handler url. So, for now, instead, we will reference a
+        # global function that the application can override.
+        return descriptor_global_handler_url(block, handler_name, suffix, query, thirdparty)
 
     def local_resource_url(self, block, uri):
         """
         See :meth:`xblock.runtime.Runtime:local_resource_url` for documentation.
         """
-        xmodule_runtime = getattr(block, 'xmodule_runtime', None)
-        if xmodule_runtime is not None:
-            return xmodule_runtime.local_resource_url(block, uri)
-        else:
-            # Currently, Modulestore is responsible for instantiating DescriptorSystems
-            # This means that LMS/CMS don't have a way to define a subclass of DescriptorSystem
-            # that implements the correct local_resource_url. So, for now, instead, we will reference a
-            # global function that the application can override.
-            return descriptor_global_local_resource_url(block, uri)
+        # Currently, Modulestore is responsible for instantiating DescriptorSystems
+        # This means that LMS/CMS don't have a way to define a subclass of DescriptorSystem
+        # that implements the correct local_resource_url. So, for now, instead, we will reference a
+        # global function that the application can override.
+        return descriptor_global_local_resource_url(block, uri)
 
     def applicable_aside_types(self, block):
         """


### PR DESCRIPTION
**Description:** This PR fixes "missing local_resource_url" bug using a better approach (closer to upstream)

**Details:** The bug was caused by the lack of `local_resource_url` in `StudioEditModuleSystem`. However, (investigation showed that) upstream was not affected by this. Further investigation revealed that a [part of the code](https://github.com/edx-solutions/edx-platform/blob/ziafazal/fix-broken-features/common/lib/xmodule/xmodule/x_module.py#L1486-L1488) causes `DescriptorSystem` to unconditionally use `local_resource_url` from `xmodule_runtime` if it is set on an XBlock. This part of code was [long removed from usptream](https://github.com/edx/edx-platform/commit/2faff29a211c1ec5f2a2dcdd08af2ca9598f166f#diff-936697469ba38db0e821ff2f2196c449L1301)

**JIRA:** 
- [YONK-435](https://openedx.atlassian.net/browse/YONK-435)

**Testing instructions:**

1. Create a course.
2. Add Drag and Drop v2, Poll, Survey or any other XBlock affected by [YONK-435](https://openedx.atlassian.net/browse/YONK-435) (non-exclusive list available on the ticket) to Advanced problem list in course "Advanced Settings".
3. Create section, subsection and unit.
4. Add a chosen XBlock to the unit.
5. Click "EDIT" on the block. _Expected result:_ XBlock edit UI appears in popup. _Failure condition:_ error message "Error: 'StudioEditModuleRuntime' object has no attribute 'local_resource_url'"" is shown.

**Author Concerns:** This PR brings the code closer to upstream, but at a cost of having two commits modifying the same place, while ideally it should be picked from [upstream commit](https://github.com/edx/edx-platform/commit/2faff29a211c1ec5f2a2dcdd08af2ca9598f166f).