### PR TITLE
Fix Circle CI to install bundle gem

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,10 @@ general:
     - "test_root/log"
 
 dependencies:
+  pre:
+    - gem install bundler
+    - sudo apt-get update; sudo apt-get install libxmlsec1-dev
+
   override:
     - npm install
     - bundle install


### PR DESCRIPTION
This should fix the CircleCI build which is failing due to https://discuss.circleci.com/t/bundle-command-not-found/3783