### PR TITLE
ziafazal/YONK-494: added ability to allow frames from a whit listed url

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -1,0 +1,34 @@
+"""
+Decorators that can be used to interact with third_party_auth.
+"""
+from functools import wraps
+
+from django.conf import settings
+from django.utils.decorators import available_attrs
+
+from .models import SAMLProviderData
+
+
+def allow_frame_from_whitelisted_url(view_func):  # pylint: disable=invalid-name
+    """
+    Modifies a view function so that it can be rendered in a frame or iframe
+    if parent url is whitelisted and request HTTP referrer is matches one of SAML providers's sso url.
+    """
+
+    def wrapped_view(request, *args, **kwargs):
+        """ Modify the response with the correct X-Frame-Options and . """
+        resp = view_func(request, *args, **kwargs)
+        x_frame_option = 'DENY'
+        content_security_policy = "frame-ancestors 'none'"
+
+        if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
+            referer = request.META.get('HTTP_REFERER')
+            if referer is not None:
+                sso_urls = SAMLProviderData.objects.values_list('sso_url', flat=True)
+                if referer in sso_urls:
+                    x_frame_option = 'ALLOW-FROM %s' % settings.THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL
+                    content_security_policy = "frame-ancestors %s" % settings.THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL
+        resp['X-Frame-Options'] = x_frame_option
+        resp['Content-Security-Policy'] = content_security_policy
+        return resp
+    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse, HttpResponseServerError, Http404
 from django.shortcuts import redirect, render
 from social.apps.django_app.utils import load_strategy, load_backend
 from .models import SAMLConfiguration
+from .decorators import allow_frame_from_whitelisted_url
 
 
 def inactive_user_view(request):
@@ -38,6 +39,7 @@ def saml_metadata_view(request):
     return HttpResponseServerError(content=', '.join(errors))
 
 
+@allow_frame_from_whitelisted_url
 def post_to_custom_auth_form(request):
     """
     Redirect to a custom login/register page.

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -605,6 +605,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     # dict with an arbitrary 'secret_key' and a 'url'.
     THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = AUTH_TOKENS.get('THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS', {})
 
+    # when SSO is enabled via SCORM shell we need allow frames from SCORM cloud
+    THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL = ENV_TOKENS.get('THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL')
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
     OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1246,6 +1246,7 @@ MIDDLEWARE_CLASSES = (
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'
+THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL = ''
 
 ############################### Pipeline #######################################
 


### PR DESCRIPTION
This PR has added a decorator which can used on any view to allow rendering of that view inside a FRAME or IFRAME if parent is a white listed URL and HTTP REFERER is one of the SAML Idp redirect url. We are adding this new decorator on `auth/custom_auth_entry` view to fix McKA SSO broken flow in case of first time registrations. [YONK-494](https://openedx.atlassian.net/browse/YONK-494) has more detail on McKA issue.

Unit tests to support these changes are added when we cherry pick these in Eucalyptus upgrade branch.

@ayesha-baig could you please review.