### PR TITLE
Ziafazal/yonk 494 tests

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -7,7 +7,33 @@ from urlparse import urlparse
 from django.conf import settings
 from django.utils.decorators import available_attrs
 
+from third_party_auth.models import SAMLProviderData
 from third_party_auth.models import LTIProviderConfig
+
+
+def allow_frame_from_whitelisted_url(view_func):  # pylint: disable=invalid-name
+    """
+    Modifies a view function so that it can be rendered in a frame or iframe
+    if parent url is whitelisted and request HTTP referrer is matches one of SAML providers's sso url.
+    """
+
+    def wrapped_view(request, *args, **kwargs):
+        """ Modify the response with the correct X-Frame-Options and . """
+        resp = view_func(request, *args, **kwargs)
+        x_frame_option = 'DENY'
+        content_security_policy = "frame-ancestors 'none'"
+
+        if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
+            referer = request.META.get('HTTP_REFERER')
+            if referer is not None:
+                sso_urls = SAMLProviderData.objects.values_list('sso_url', flat=True)
+                if referer in sso_urls:
+                    x_frame_option = 'ALLOW-FROM %s' % settings.THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL
+                    content_security_policy = "frame-ancestors %s" % settings.THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL
+        resp['X-Frame-Options'] = x_frame_option
+        resp['Content-Security-Policy'] = content_security_policy
+        return resp
+    return wraps(view_func, assigned=available_attrs(view_func))(wrapped_view)
 
 
 def xframe_allow_whitelisted(view_func):

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -3,16 +3,18 @@ Tests for third_party_auth decorators.
 """
 import ddt
 import unittest
+import datetime
 
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import RequestFactory
 
-from third_party_auth.decorators import xframe_allow_whitelisted
+from third_party_auth.decorators import xframe_allow_whitelisted, allow_frame_from_whitelisted_url
 from third_party_auth.tests.testutil import TestCase
 
+SCORM_CLOUD_URL = 'https://cloud.scorm.com'
 
-@xframe_allow_whitelisted
+
 def mock_view(_request):
     """ A test view for testing purposes. """
     return HttpResponse()
@@ -47,7 +49,7 @@ class TestXFrameWhitelistDecorator(TestCase):
     def test_x_frame_options(self, url, expected_result):
         request = self.construct_request(url)
 
-        response = mock_view(request)
+        response = xframe_allow_whitelisted(mock_view)(request)
 
         self.assertEqual(response['X-Frame-Options'], expected_result)
 
@@ -55,5 +57,73 @@ class TestXFrameWhitelistDecorator(TestCase):
     def test_feature_flag_off(self, url):
         with self.settings(FEATURES={'ENABLE_THIRD_PARTY_AUTH': False}):
             request = self.construct_request(url)
-            response = mock_view(request)
+            response = xframe_allow_whitelisted(mock_view)(request)
             self.assertEqual(response['X-Frame-Options'], 'DENY')
+
+
+# remove this decorator once third_party_auth is enabled in CMS
+@unittest.skipIf(
+    'third_party_auth' not in settings.INSTALLED_APPS,
+    'third_party_auth is not currently installed in CMS'
+)
+@ddt.ddt
+class TestXFrameWhitelistDecoratorForSAML(TestCase):
+    """ Test the allow_frame_from_whitelisted_url decorator. """
+
+    def setUp(self):
+        super(TestXFrameWhitelistDecoratorForSAML, self).setUp()
+        self.configure_saml_provider_data(
+            entity_id='https://idp.testshib.org/idp/shibboleth',
+            sso_url='https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO',
+            public_key='testkey',
+            fetched_at=datetime.datetime.now()
+        )
+        self.factory = RequestFactory()
+
+    def construct_request(self, referer):
+        """ Add the given referer to a request and then return it. """
+        request = self.factory.get('/auth/custom_auth_entry')
+        request.META['HTTP_REFERER'] = referer
+        return request
+
+    @ddt.unpack
+    @ddt.data(
+        (
+            'https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO',
+            {
+                'X-Frame-Options': 'ALLOW-FROM %s' % SCORM_CLOUD_URL,
+                'Content-Security-Policy': "frame-ancestors %s" % SCORM_CLOUD_URL,
+
+            }
+        ),
+        (
+            'http://not-a-real-domain.com/SSO',
+            {
+                'X-Frame-Options': 'DENY',
+                'Content-Security-Policy': "frame-ancestors 'none'",
+
+            }
+        ),
+        (
+            None,
+            {
+                'X-Frame-Options': 'DENY',
+                'Content-Security-Policy': "frame-ancestors 'none'",
+
+            }
+        )
+    )
+    def test_x_frame_options(self, url, expected_headers):
+        with self.settings(THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL=SCORM_CLOUD_URL):
+            request = self.construct_request(url)
+            response = allow_frame_from_whitelisted_url(mock_view)(request)
+            for header, value in expected_headers.items():
+                self.assertEqual(response[header], value)
+
+    @ddt.data('https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO', 'http://not-a-real-domain.com/SSO', None)
+    def test_feature_flag_off(self, url):
+        with self.settings(FEATURES={'ENABLE_THIRD_PARTY_AUTH': False}):
+            request = self.construct_request(url)
+            response = allow_frame_from_whitelisted_url(mock_view)(request)
+            self.assertEqual(response['X-Frame-Options'], 'DENY')
+            self.assertEqual(response['Content-Security-Policy'], "frame-ancestors 'none'")

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -19,6 +19,7 @@ from third_party_auth.models import (
     OAuth2ProviderConfig,
     SAMLProviderConfig,
     SAMLConfiguration,
+    SAMLProviderData,
     LTIProviderConfig,
     cache as config_cache,
     ProviderApiPermissions,
@@ -84,6 +85,13 @@ class ThirdPartyAuthTestMixin(object):
         """ Update the settings for a SAML-based third party auth provider """
         self.assertTrue(SAMLConfiguration.is_enabled(), "SAML Provider Configuration only works if SAML is enabled.")
         obj = SAMLProviderConfig(**kwargs)
+        obj.save()
+        return obj
+
+    @staticmethod
+    def configure_saml_provider_data(**kwargs):
+        """ Update the SAML IdP data """
+        obj = SAMLProviderData(**kwargs)
         obj.save()
         return obj
 

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -11,6 +11,7 @@ from social.apps.django_app.views import complete
 from social.apps.django_app.utils import load_strategy, load_backend
 from social.utils import setting_name
 from .models import SAMLConfiguration
+from .decorators import allow_frame_from_whitelisted_url
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
 
@@ -61,6 +62,7 @@ def lti_login_and_complete_view(request, backend, *args, **kwargs):
     return complete(request, backend, *args, **kwargs)
 
 
+@allow_frame_from_whitelisted_url
 def post_to_custom_auth_form(request):
     """
     Redirect to a custom login/register page.

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -702,6 +702,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     # dict with an arbitrary 'secret_key' and a 'url'.
     THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS = AUTH_TOKENS.get('THIRD_PARTY_AUTH_CUSTOM_AUTH_FORMS', {})
 
+    # when SSO is enabled via SCORM shell we need allow frames from SCORM cloud
+    THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL = ENV_TOKENS.get('THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL')
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
     OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1192,6 +1192,7 @@ MIDDLEWARE_CLASSES = (
 
 # Clickjacking protection can be enabled by setting this to 'DENY'
 X_FRAME_OPTIONS = 'ALLOW'
+THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL = ''
 
 # Platform for Privacy Preferences header
 P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'


### PR DESCRIPTION
This PR moves `allow_frame_from_whitelisted_url` decorator to Euclayptus upgrade and adds unit tests for it. [YONK-494](https://openedx.atlassian.net/browse/YONK-494) has the detail about original issue for which we had to write this decorator.

@ayesha-baig would you please review this?.