### PR TITLE
Update Problem Builder Version

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@copy-change-patch#egg=xblock-poll
 -e git+https://github.com/edx/edx-notifications.git@261b507e0e6b2130286e5a34b9010a419aaa8e3f#egg=edx-notifications
--e git+https://github.com/open-craft/problem-builder.git@c7c0b41ad7788c9228e855f1491105134450fbf1#egg=problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@e620ce768793ac3b51f62a003ffb52b4c5124095#egg=problem-builder
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.1#egg=xblock-diagnostic-feedback==0.2.1


### PR DESCRIPTION
This bumps the version of Problem Builder to include a fix for MCKIN-4700 (UI for MCQ's/MRQ's gets disturbed for lengthy choices).

@ziafazal Is this the correct branch to target?

@maxrothman @fredsmith (not sure who to ping) This version bump happens to pull in https://github.com/open-craft/problem-builder/pull/138 which includes a potentially large data migration. Can you please advise if similar care will need to be taken for deploying this on this fork? (Or is the `problem_builder_answer` table much smaller than edx.org?)