### PR TITLE
YONK-523: avoid creation of draft nodes of document in mongo

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -91,7 +91,9 @@ def preview_handler(request, usage_key_string, handler, suffix=''):
         log.exception("error processing ajax call")
         raise
 
-    modulestore().update_item(descriptor, request.user.id, asides=asides)
+    # Update block only if it has asides
+    if asides:
+        modulestore().update_item(descriptor, request.user.id, asides=asides)
     return webob_to_django_response(resp)
 
 


### PR DESCRIPTION
This PR fixes issue reported in [YONK-523](https://openedx.atlassian.net/browse/YONK-523)
Studio - When course author opens a unit or refreshes the page, publish button gets enabled.