### PR TITLE
Install Chat XBlock as a custom package

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,6 +13,7 @@
 -e git+https://github.com/open-craft/problem-builder.git@6cc9169342d40d809a8c9de45608e0f40e896687#egg=problem-builder
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
+-e git+https://github.com/open-craft/xblock-chat.git@56d1f18fff2970d96f2c392ced63f9d0e62d7524#egg=xblock-chat
 git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.1#egg=xblock-diagnostic-feedback==0.2.1
 git+https://github.com/edx-solutions/api-integration.git@v1.1.5#egg=api-integration==1.1.5
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.4#egg=organizations-edx-platform-extensions==1.1.4


### PR DESCRIPTION
This PR installs [OpenCraft's Chat XBlock](https://github.com/open-craft/xblock-chat) as a custom package.

**Testing instructions**:

1. Set up a devstack using this branch.
2. [Enable the Chat XBlock in Studio](https://github.com/open-craft/xblock-chat#enabling-in-studio).
3. Add a new unit and verify that the Chat XBlock is available as an Advanced component. 

**Reviewers**
- [ ] @bradenmacdonald 
