### PR TITLE
Update xblock-chat to latest version

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0
 -e git+https://github.com/open-craft/problem-builder.git@6cc9169342d40d809a8c9de45608e0f40e896687#egg=problem-builder
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@d8b58533ba5b42fc294d277d748798be9e4238a3#egg=xblock-chat
+-e git+https://github.com/open-craft/xblock-chat.git@63d1c24e5f0d9654f219065e8bf0b83759abea29#egg=xblock-chat
 git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.2#egg=xblock-group-project-v2
 git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.1#egg=xblock-diagnostic-feedback==0.2.1
 git+https://github.com/edx-solutions/api-integration.git@v1.1.9#egg=api-integration==1.1.9


### PR DESCRIPTION
Make edx-platform use the xblock-chat latest version.

**Review**

Ensure the commit matches [xblock-chat](https://github.com/open-craft/xblock-chat)'s HEAD

**Reviewers**
- [x] @mtyaka  