### PR TITLE
Bump xblock-chat

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0
 -e git+https://github.com/open-craft/problem-builder.git@934d768ba2dc95d2740d7220669f7f5a659048ea#egg=problem-builder
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@63d1c24e5f0d9654f219065e8bf0b83759abea29#egg=xblock-chat
+-e git+https://github.com/open-craft/xblock-chat.git@d3218cb6c549f953749a2a246952bf7557ed4739#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@e59c67a5c07b75978cad45a2acd5dd1c99a71111#egg=xblock-eoc-journal
 git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.2#egg=xblock-group-project-v2
 git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.1#egg=xblock-diagnostic-feedback==0.2.1


### PR DESCRIPTION
This updates xblock-chat to include fixes from https://github.com/open-craft/xblock-chat/pull/12.

**Testing**:

See https://github.com/open-craft/xblock-chat/pull/12.

**Reviewers**:

- [x] @bdero 