### PR TITLE
Update xblock-chat to latest version.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0
 -e git+https://github.com/open-craft/problem-builder.git@d312e9a587e4376b9afadb982f5fc28e4a9061fc#egg=problem-builder
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@d3218cb6c549f953749a2a246952bf7557ed4739#egg=xblock-chat
+-e git+https://github.com/open-craft/xblock-chat.git@4e1ec8b4778377288577fdb4208460a1bbb0cceb#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@f2749cf50adf1ed053d71d907357e1d3e76e9e37#egg=xblock-eoc-journal
 git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.2#egg=xblock-group-project-v2
 git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.1#egg=xblock-diagnostic-feedback==0.2.1


### PR DESCRIPTION
This updates xblock-chat to include IE fixes from https://github.com/open-craft/xblock-chat/pull/11.
It also includes changes from https://github.com/open-craft/xblock-chat/pull/14

**Testing**:

Verify that the xblock now loads in IE 10 & 11.

**Notes and concerns**:

While the xblock now loads in IE 10, the layout is rather broken. This is because IE 10 implements an outdated version of the flexbox spec. This will be fixed in a separate story/PR.