### PR TITLE
Fix problem-builder egg name in custom requirements.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@copy-change-patch#egg=xblock-poll
 -e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0
--e git+https://github.com/open-craft/problem-builder.git@d312e9a587e4376b9afadb982f5fc28e4a9061fc#egg=problem-builder
+-e git+https://github.com/open-craft/problem-builder.git@d312e9a587e4376b9afadb982f5fc28e4a9061fc#egg=xblock-problem-builder
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@d3218cb6c549f953749a2a246952bf7557ed4739#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@f2749cf50adf1ed053d71d907357e1d3e76e9e37#egg=xblock-eoc-journal


### PR DESCRIPTION
The [actual name of the package is xblock-problem-builder](https://github.com/open-craft/problem-builder/blob/d312e9a587e4376b9afadb982f5fc28e4a9061fc/setup.py#L73), even though the repository is named problem-builder.