### PR TITLE
MCKIN-5273 Adds eoc-journal to PROGRESS_DETACHED_CATEGORIES

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -632,7 +632,7 @@ USERNAME_PATTERN = r'(?P<username>[\w.@+-]+)'
 # Verticals having children with any of these categories would be excluded from progress calculations
 PROGRESS_DETACHED_VERTICAL_CATEGORIES = ['discussion-course', 'group-project', 'gp-v2-project']
 # Modules having these categories would be excluded from progress calculations
-PROGRESS_DETACHED_CATEGORIES = PROGRESS_DETACHED_VERTICAL_CATEGORIES + ['discussion-forum']
+PROGRESS_DETACHED_CATEGORIES = PROGRESS_DETACHED_VERTICAL_CATEGORIES + ['discussion-forum', 'eoc-journal']
 ############################## EVENT TRACKING #################################
 LMS_SEGMENT_KEY = None
 


### PR DESCRIPTION
Adding `eoc-journal` to `PROGRESS_DETACHED_CATEGORIES` ensures that the End of Course Journal components are excluded from the Apros course Progress calculation.

**JIRA tickets**: Implements MCKIN-5273

**Dependencies**: None

**Screenshots**:

**Partner information**: 3rd Party

**Testing instructions**:

In Studio:
1. Create a new course.
1. Under "Advanced Settings", add `"eoc-journal"`.
1. Add a Subsection, with one or more problems in it.
1. Add a unit containing an EOC Journal component.

In Apros, as the Admin user:
1. Ensure your new Course is added to an [Apros Program](https://github.com/mckinseyacademy/mcka_apros/blob/master/apros_initial_configuration.md#configuring-programs).
1. Enrol a student user in your new Course.

In Apros, as a student user:
1. Navigate to your new Course.
1. Visit *only* the non-EOC Journal units.
1. Go back to the course home page.
1. Note that your course progress is now at 100%.

**Reviewers**
- [ ] OpenCraft TBD