### PR TITLE
revert group work v2 to older commit

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@d63412e0956f1b77132e4c833c1ad8f0578b816f#egg=xblock-eoc-journal
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@1df2a4f8de4d947ff2dd67ca716b02373b45e44a#egg=xblock-diagnostic-feedback
-git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.3#egg=xblock-group-project-v2==0.4.3
+-e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2
 git+https://github.com/edx-solutions/api-integration.git@v1.2.3#egg=api-integration==1.2.3
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.5#egg=organizations-edx-platform-extensions==1.1.5
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.1#egg=gradebook-edx-platform-extensions==1.1.1


### PR DESCRIPTION
Group Work v2 is showing some anomalies after latest changes. 
We are reverting it back to older hash till we identify root cause and fix.
This commit is to make sure that older commit is working fine on QA so we take that to stage.