### PR TITLE
MCKIN-5256: Diagnostic feedback version update

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -16,7 +16,7 @@
 -e git+https://github.com/open-craft/xblock-chat.git@4e1ec8b4778377288577fdb4208460a1bbb0cceb#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@d63412e0956f1b77132e4c833c1ad8f0578b816f#egg=xblock-eoc-journal
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
--e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@1df2a4f8de4d947ff2dd67ca716b02373b45e44a#egg=xblock-diagnostic-feedback
+-e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2
 git+https://github.com/edx-solutions/api-integration.git@v1.2.3#egg=api-integration==1.2.3
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.5#egg=organizations-edx-platform-extensions==1.1.5


### PR DESCRIPTION
This PR bumps xblock-diagnosticfeedback version to the latest tagged release [v0.2.2](https://github.com/mckinseyacademy/xblock-diagnosticfeedback/releases/tag/v0.2.2).