### PR TITLE
Update xblock-chat

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/edx/edx-notifications.git@0.6.0#egg=edx-notifications==0.6.0
 -e git+https://github.com/open-craft/problem-builder.git@v2.7.0#egg=xblock-problem-builder==2.7.0
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@4e1ec8b4778377288577fdb4208460a1bbb0cceb#egg=xblock-chat
+-e git+https://github.com/open-craft/xblock-chat.git@ad0b7627bfd2d135e1776e19ce208ecf517e50c5#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@d63412e0956f1b77132e4c833c1ad8f0578b816f#egg=xblock-eoc-journal
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2


### PR DESCRIPTION
This updates xblock-chat to include fixes from open-craft/xblock-chat#17.

Replaces https://github.com/edx-solutions/edx-platform/pull/841 (which didn't trigger a CircleCI build).

*Testing:*

See open-craft/xblock-chat#17.

*Reviewers:*

- [ ] @carlio