### PR TITLE
Version bump for xblock-eoc-journal

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@
 -e git+https://github.com/open-craft/problem-builder.git@v2.7.1#egg=xblock-problem-builder==2.7.1
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@ad0b7627bfd2d135e1776e19ce208ecf517e50c5#egg=xblock-chat
--e git+https://github.com/open-craft/xblock-eoc-journal.git@d63412e0956f1b77132e4c833c1ad8f0578b816f#egg=xblock-eoc-journal
+-e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2


### PR DESCRIPTION
This is a version bump to pull in https://github.com/open-craft/xblock-eoc-journal/pull/9 , fixing a bug reported on MCKIN-4999 with incorrect engagement metrics.