### PR TITLE
Add student_view_data to HTML XBlock

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -75,6 +75,15 @@ class HtmlBlock(object):
         """
         return Fragment(self.get_html())
 
+    def student_view_data(self, context=None):
+        """
+        Returns a JSON representation of the student_view of this XBlock,
+        retrievable from the Course Block API.
+        """
+        return {
+            'html': self.data
+        }
+
     def get_html(self):
         """ Returns html required for rendering XModule. """
 

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -75,10 +75,12 @@ class HtmlBlock(object):
         """
         return Fragment(self.get_html())
 
-    def student_view_data(self, context=None):
+    def student_view_data(self):
         """
         Returns a JSON representation of the student_view of this XBlock,
         retrievable from the Course Block API.
+        Since this data is not user-specific, fields like `html` may contain
+        placeholders like %%USER_ID%%.
         """
         return {
             'html': self.data

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -22,7 +22,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
     Test class for BlocksView
     """
     requested_fields = ['graded', 'format', 'student_view_multi_device', 'children', 'not_a_field', 'due']
-    BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion']
+    BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion', 'html']
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -44,7 +44,7 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
 
         # verify html data
         html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
-        self.assertIsNone(
+        self.assertIsNotNone(
             self.block_structure.get_transformer_block_field(
                 html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
             )


### PR DESCRIPTION
Allow the HTML content of the HtmlBlock to be downloaded via the course blocks API.

**JIRA tickets**: [OC-2995](https://tasks.opencraft.com/browse/OC-2995) [MCKIN-5637](https://edx-wiki.atlassian.net/browse/MCKIN-5637)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Have a course with a Text Html XBlock
2. Navigate to http://localhost:8000/api/courses/v1/blocks/?all_blocks=true&depth=all&requested_fields=student_view_data&course_id=<course_id>
3. See that the block's HTML content is available in the API output as:
```json
"student_view_data": {
  "html": "<h1>HTML Content</h3>"
}
```

**Author notes and concerns**:

1. I'm unsure about whether or not to use `HtmlBlock.get_html()` since the context that `student_view_data` is called in doesn't provide `HtmlBlock.system.anonymous_student_id`.

**Reviewers**
- [ ] @e-kolpakov 
- [ ] TBD