### PR TITLE
specified default context arg for HtmlBlock get_student_value

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -75,7 +75,7 @@ class HtmlBlock(object):
         """
         return Fragment(self.get_html())
 
-    def student_view_data(self):
+    def student_view_data(self, context=None):  # pylint: disable=unused-argument
         """
         Returns a JSON representation of the student_view of this XBlock,
         retrievable from the Course Block API.


### PR DESCRIPTION
Add default context arg for HtmlBlock's student_view_data to prevent errors

**JIRA tickets**: [OC-2995](https://tasks.opencraft.com/browse/OC-2995)

**Dependencies**: None