### PR TITLE
MCKIN-5641: When user is logged out due to session invalidation, submitting a problem should redirect to login page

### DIFF
--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -1,5 +1,5 @@
 $(document).ajaxError(function(event, jXHR) {
-    if (jXHR.status === 403 && jXHR.responseText === 'Unauthenticated') {
+    if (jXHR.status === 403) {
         var message = gettext(
             'You have been logged out of your edX account. ' +
             'Click Okay to log in again now. ' +


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/edx-solutions/edx-platform/pull/856.
When a user submitting a problem is logged out due to session invalidation, they should be prompted to log back in and then once logged in, should be redirected to the same problem page.

This was broken by the above PR. When the user session is invalidated, clicking on the "Submit" button was doing nothing. This PR fixes it.

Should be merged ASAP.

**Reviewers**
- [x] @mtyaka 
