### PR TITLE
Problem Builder version bump to 2.7.3

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -10,7 +10,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@v1.3.1#egg=xblock-poll
 -e git+https://github.com/edx/edx-notifications.git@0.6.1#egg=edx-notifications==0.6.1
--e git+https://github.com/open-craft/problem-builder.git@v2.7.2#egg=xblock-problem-builder==2.7.2
+-e git+https://github.com/open-craft/problem-builder.git@v2.7.3#egg=xblock-problem-builder==2.7.3
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@ad0b7627bfd2d135e1776e19ce208ecf517e50c5#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal


### PR DESCRIPTION
This bumps problem builder to version 2.7.3 to pull in some minor API improvements: https://github.com/open-craft/problem-builder/pull/162/files?short_path=0159ad6#diff-0159ad6c3a1f1beb62bf08c385f28573

This work is follow-up to MCKIN-5253.