### PR TITLE
bump xblock-image-explorer version to v0.4.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,7 +2,7 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.0#egg=xblock-image-explorer==0.4.0
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.1#egg=xblock-image-explorer==0.4.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.10#egg=xblock-ooyala==2.0.10


### PR DESCRIPTION
This PR bumps xblock-image-explorer version to v0.4.1 to include responsive changes.

@wajeeha-khalid can you please review?