### PR TITLE
Add chromeless class to the wrapper when in chromeless mode.

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -69,7 +69,7 @@ ${HTML(fragment.foot_html())}
 
 </%block>
 
-<div class="course-wrapper">
+<div class="course-wrapper chromeless">
   <section class="course-content" id="course-content">
     ${HTML(fragment.body_html())}
   </section>


### PR DESCRIPTION
This fixes the Android app layout for Xblock-chat – it adds a `.chromeless` class to `div.course-wrapper` that allows xblocks to add CSS tweaks to chromeless views. It is a backport of this [PR](https://github.com/edx/edx-platform/pull/15474) for the edx-solutions fork.

**JIRA Ticket**: [OC-2855](https://tasks.opencraft.com/browse/OC-2855)

**Testing instructions**:
1. Build and install edx-android-app
2. Add an xblock-chat to a course page and use the Android emulator to check that the chat fully expands vertically, instead of occupying only the top half of the screen.