### PR TITLE
MCKIN-5415 Fix: Completion API was not working via OAuth2

### DIFF
--- a/lms/djangoapps/completion_api/tests/test_views.py
+++ b/lms/djangoapps/completion_api/tests/test_views.py
@@ -2,8 +2,10 @@
 Test serialization of completion data.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from datetime import datetime, timedelta
 
 from django.test.utils import override_settings
+from oauth2_provider import models as dot_models
 from rest_framework.test import APIClient
 
 from opaque_keys.edx.keys import UsageKey
@@ -12,6 +14,31 @@ from progress import models
 from student.tests.factories import AdminFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
+
+
+def _create_oauth2_token(user):
+    """
+    Create an OAuth2 Access Token for the specified user,
+    to test OAuth2-based API authentication
+
+    Returns the token as a string.
+    """
+    # Use django-oauth-toolkit (DOT) models to create the app and token:
+    dot_app = dot_models.Application.objects.create(
+        name='test app',
+        user=UserFactory.create(),
+        client_type='confidential',
+        authorization_grant_type='authorization-code',
+        redirect_uris='http://none.none'
+    )
+    dot_access_token = dot_models.AccessToken.objects.create(
+        user=user,
+        application=dot_app,
+        expires=datetime.utcnow() + timedelta(weeks=1),
+        scope='read',
+        token='s3cur3t0k3n12345678901234567890'
+    )
+    return dot_access_token.token
 
 
 @override_settings(STUDENT_GRADEBOOK=True)
@@ -67,6 +94,21 @@ class CompletionViewTestCase(SharedModuleStoreTestCase):
         }
         self.assertEqual(response.data, expected)  # pylint: disable=no-member
 
+    def test_list_view_oauth2(self):
+        """
+        Test the list view using OAuth2 Authentication
+        """
+        url = '/api/completion/v0/course/'
+        # Try with no authentication:
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        # Now, try with a valid token header:
+        token = _create_oauth2_token(self.test_user)
+        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {0}".format(token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['results'][0]['completion']['earned'], 1.0)  # pylint: disable=no-member
+
     def test_list_view_with_sequentials(self):
         response = self.client.get('/api/completion/v0/course/?requested_fields=sequential')
         self.assertEqual(response.status_code, 200)
@@ -105,6 +147,21 @@ class CompletionViewTestCase(SharedModuleStoreTestCase):
         }
         self.assertEqual(response.data, expected)  # pylint: disable=no-member
 
+    def test_detail_view_oauth2(self):
+        """
+        Test the detail view using OAuth2 Authentication
+        """
+        url = '/api/completion/v0/course/edX/toy/2012_Fall/'
+        # Try with no authentication:
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+        # Now, try with a valid token header:
+        token = _create_oauth2_token(self.test_user)
+        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {0}".format(token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['completion']['earned'], 1.0)  # pylint: disable=no-member
+
     def test_detail_view_with_sequentials(self):
         response = self.client.get('/api/completion/v0/course/edX/toy/2012_Fall/?requested_fields=sequential')
         self.assertEqual(response.status_code, 200)
@@ -132,9 +189,9 @@ class CompletionViewTestCase(SharedModuleStoreTestCase):
     def test_unauthenticated(self):
         self.client.force_authenticate(None)
         detailresponse = self.client.get('/api/completion/v0/course/edX/toy/2012_Fall/')
-        self.assertEqual(detailresponse.status_code, 403)
+        self.assertEqual(detailresponse.status_code, 401)
         listresponse = self.client.get('/api/completion/v0/course/')
-        self.assertEqual(listresponse.status_code, 403)
+        self.assertEqual(listresponse.status_code, 401)
 
     def test_wrong_user(self):
         user = UserFactory.create(username='wrong')

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -84,7 +84,7 @@ class CompletionViewMixin(object):
         return course_completion_serializer_factory(self.get_requested_fields())
 
 
-class CompletionListView(APIView, CompletionViewMixin):
+class CompletionListView(CompletionViewMixin, APIView):
     """
     API view to render serialized CourseCompletions for a single user
     across all enrolled courses.
@@ -239,7 +239,7 @@ class CompletionListView(APIView, CompletionViewMixin):
         return self.paginator.get_paginated_response(serializer.data)
 
 
-class CompletionDetailView(APIView, CompletionViewMixin):
+class CompletionDetailView(CompletionViewMixin, APIView):
     # pylint: disable=line-too-long
     """
     API view to render a serialized CourseCompletion for a single user in a


### PR DESCRIPTION
The new interim completion API was not working via OAuth2.

The reason due to inheritance order being wrong, so the authentication classes specified for this API were overridden by the base class:

Before:
```
>>> from completion_api.views import CompletionListView
>>> CompletionListView.authentication_classes
[<class 'rest_framework.authentication.SessionAuthentication'>, <class 'rest_framework.authentication.BasicAuthentication'>]
```

After:
```
>>> from completion_api.views import CompletionListView
>>> CompletionListView.authentication_classes
(<class 'openedx.core.lib.api.authentication.OAuth2AuthenticationAllowInactiveUser'>, <class 'openedx.core.lib.api.authentication.SessionAuthenticationAllowInactiveUser'>)
```

*Testing Instructions* (Devstack):
1. (If you need this:) Go to http://localhost:8000/admin/oauth2/client/ and create a new client with user blank, name anything, URL and redirect URL "http://none.none", client type "Public"
1. (If you need this:) Go to http://localhost:8000/admin/oauth2/accesstoken/ and create a new access token for any valid user that you can test the API with, selecting the same client. Set "Expires" to the future and scope to "Read"
1. Try `curl 'http://localhost:8000/api/completion/v0/course/' -H 'Authorization: Bearer TOKEN' -v`, substituting your new token. Make sure you get the expected response(s).