### PR TITLE
Bradmerlin/interim completion api

### DIFF
--- a/lms/djangoapps/completion_api/urls.py
+++ b/lms/djangoapps/completion_api/urls.py
@@ -2,10 +2,15 @@
 URLs for the completion API
 """
 
+from django.conf import settings
 from django.conf.urls import url
 from . import views
 
 urlpatterns = [
     url(r'^course/$', views.CompletionListView.as_view()),
-    url(r'^course/(?P<course_key>.*)/$', views.CompletionDetailView.as_view()),
+    url(r'^course/{}/$'.format(settings.COURSE_ID_PATTERN), views.CompletionDetailView.as_view()),
+    url(r'^course/{}/blocks/{}/$'.format(
+        settings.COURSE_ID_PATTERN,
+        settings.USAGE_ID_PATTERN
+    ), views.CompletionBlockUpdateView.as_view()),
 ]


### PR DESCRIPTION
As an interim solution before [this proposal](https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/162247762/Completion+API) is completed, this PR allows mobile apps to modify completion state of arbitrary blocks.

**JIRA tickets**: Implements [OC-3058](https://tasks.opencraft.com/browse/OC-3058) [MCKIN-5798](https://edx-wiki.atlassian.net/browse/MCKIN-5798)

**Merge deadline**: 2017-09-15

**Testing instructions**:
1. POST request containing `{"completion": 1}` to `/api/completion/v0/course/:course_id/blocks/:block_id/`
1. If the course or block IDs do not exist, or the student is not enrolled in the course, or the block does not belong to the course, see 404
1. If the post data does not contain `{"completion": 1}`, see 400
1. If they both exist, see 201

**Reviewers**
- [ ] @bradenmacdonald 
