### PR TITLE
Version bump for xblock-chat

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx/edx-notifications.git@0.6.1#egg=edx-notifications==0.6.1
 -e git+https://github.com/open-craft/problem-builder.git@v2.7.4#egg=xblock-problem-builder==2.7.4
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@ad0b7627bfd2d135e1776e19ce208ecf517e50c5#egg=xblock-chat
+-e git+https://github.com/open-craft/xblock-chat.git@96e8fab2f5bffd7330ffc03b622a80536477808e#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal
 -e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2


### PR DESCRIPTION
This fixes some layout bugs we noticed while working on MCKIN-5274. Details [here](https://github.com/open-craft/xblock-chat/pull/18).