### PR TITLE
courseware models always imports with lms.djangoapps prefix

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -2,7 +2,7 @@
 Content Library Transformer.
 """
 import json
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from openedx.core.lib.block_structure.transformer import BlockStructureTransformer, FilteringTransformerMixin
 from xmodule.library_content_module import LibraryContentModule
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/courseware/admin.py
+++ b/lms/djangoapps/courseware/admin.py
@@ -2,7 +2,7 @@
 django admin pages for courseware model
 '''
 
-from courseware.models import StudentModule, OfflineComputedGrade, OfflineComputedGradeLog
+from lms.djangoapps.courseware.models import StudentModule, OfflineComputedGrade, OfflineComputedGradeLog
 from ratelimitbackend import admin
 
 admin.site.register(StudentModule)

--- a/lms/djangoapps/courseware/management/commands/fix_student_module_newlines.py
+++ b/lms/djangoapps/courseware/management/commands/fix_student_module_newlines.py
@@ -16,7 +16,7 @@ from django.db import DatabaseError
 from django.db import transaction
 from django.core.management.base import BaseCommand, CommandError
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from util.query import use_read_replica_if_available
 
 log = logging.getLogger("fix_student_module_newlines")

--- a/lms/djangoapps/courseware/management/commands/regrade_partial.py
+++ b/lms/djangoapps/courseware/management/commands/regrade_partial.py
@@ -10,7 +10,7 @@ from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from capa.correctmap import CorrectMap
 
 LOG = logging.getLogger(__name__)

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -9,8 +9,8 @@ from factory.django import DjangoModelFactory
 from student.tests.factories import UserFactory  # Imported to re-export
 
 from student.tests.factories import UserProfileFactory as StudentUserProfileFactory
-from courseware.models import StudentModule, XModuleUserStateSummaryField
-from courseware.models import XModuleStudentInfoField, XModuleStudentPrefsField
+from lms.djangoapps.courseware.models import StudentModule, XModuleUserStateSummaryField
+from lms.djangoapps.courseware.models import XModuleStudentInfoField, XModuleStudentPrefsField
 from student.roles import (
     CourseInstructorRole,
     CourseStaffRole,

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -7,8 +7,8 @@ from nose.plugins.attrib import attr
 from functools import partial
 
 from courseware.model_data import DjangoKeyValueStore, FieldDataCache, InvalidScopeError
-from courseware.models import StudentModule, XModuleUserStateSummaryField
-from courseware.models import XModuleStudentInfoField, XModuleStudentPrefsField
+from lms.djangoapps.courseware.models import StudentModule, XModuleUserStateSummaryField
+from lms.djangoapps.courseware.models import XModuleStudentInfoField, XModuleStudentPrefsField
 
 from student.tests.factories import UserFactory
 from courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory, location, course_id

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -36,7 +36,7 @@ from courseware.courses import get_course_with_access, get_course_info_section
 from courseware.field_overrides import OverrideFieldData
 from courseware.model_data import FieldDataCache
 from courseware.module_render import hash_resource, get_module_for_descriptor, XblockCallbackView
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from courseware.tests.factories import StudentModuleFactory, UserFactory, GlobalStaffFactory
 from courseware.tests.tests import LoginEnrollmentTestCase
 from courseware.tests.test_submitting_problems import TestSubmittingProblems

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -20,7 +20,7 @@ from capa.tests.response_xml_factory import (
     CodeResponseXMLFactory,
 )
 from course_modes.models import CourseMode
-from courseware.models import StudentModule, BaseStudentModuleHistory
+from lms.djangoapps.courseware.models import StudentModule, BaseStudentModuleHistory
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
 from openedx.core.djangoapps.credit.api import (

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -18,7 +18,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from django.db.utils import IntegrityError
 from xblock.fields import Scope
-from courseware.models import StudentModule, BaseStudentModuleHistory
+from lms.djangoapps.courseware.models import StudentModule, BaseStudentModuleHistory
 from edx_user_state_client.interface import XBlockUserStateClient, XBlockUserState
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -67,7 +67,7 @@ from courseware.courses import (
 )
 from courseware.masquerade import setup_masquerade
 from courseware.model_data import FieldDataCache
-from courseware.models import StudentModule, BaseStudentModuleHistory
+from lms.djangoapps.courseware.models import StudentModule, BaseStudentModuleHistory
 from courseware.url_helpers import get_redirect_url, get_redirect_url_for_global_staff
 from courseware.user_state_client import DjangoXBlockUserStateClient
 from edxmako.shortcuts import render_to_response, render_to_string, marketing_link

--- a/lms/djangoapps/coursewarehistoryextended/models.py
+++ b/lms/djangoapps/coursewarehistoryextended/models.py
@@ -17,7 +17,7 @@ from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from coursewarehistoryextended.fields import UnsignedBigIntAutoField
-from courseware.models import StudentModule, BaseStudentModuleHistory
+from lms.djangoapps.courseware.models import StudentModule, BaseStudentModuleHistory
 
 
 class StudentModuleHistoryExtended(BaseStudentModuleHistory):

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from unittest import skipUnless
 from nose.plugins.attrib import attr
 
-from courseware.models import BaseStudentModuleHistory, StudentModuleHistory, StudentModule
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModuleHistory, StudentModule
 
 from courseware.tests.factories import StudentModuleFactory, location, course_id
 

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -17,7 +17,7 @@ from eventtracking import tracker
 import pytz
 
 from course_modes.models import CourseMode
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.grades.signals.signals import PROBLEM_RAW_SCORE_CHANGED
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -28,7 +28,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from course_modes.models import CourseMode
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from edxmako.shortcuts import render_to_string
 from student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
 from track.event_transaction_utils import (

--- a/lms/djangoapps/instructor/services.py
+++ b/lms/djangoapps/instructor/services.py
@@ -7,7 +7,7 @@ import logging
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from commerce.signals import create_zendesk_ticket
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from django.core.exceptions import ObjectDoesNotExist
 import lms.djangoapps.instructor.enrollment as enrollment

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -32,7 +32,7 @@ from xmodule.modulestore import ModuleStoreEnum
 
 from bulk_email.models import BulkEmailFlag
 from course_modes.models import CourseMode
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from courseware.tests.factories import (
     BetaTesterFactory, GlobalStaffFactory, InstructorFactory, StaffFactory, UserProfileFactory
 )
@@ -56,7 +56,7 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, Mo
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.fields import Date
 
-from courseware.models import StudentFieldOverride
+from lms.djangoapps.courseware.models import StudentFieldOverride
 
 import lms.djangoapps.instructor_task.api
 import lms.djangoapps.instructor.views.api

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from ccx_keys.locator import CCXLocator
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from grades.new.subsection_grade import SubsectionGradeFactory
 from grades.tests.utils import answer_problem
 from lms.djangoapps.ccx.tests.factories import CcxFactory

--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -5,7 +5,7 @@ Tests for the InstructorService
 import json
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor.access import allow_access
 from lms.djangoapps.instructor.services import InstructorService
 from lms.djangoapps.instructor.tests.test_tools import msk_from_problem_urlname

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -49,7 +49,7 @@ from django_comment_common.models import (
     FORUM_ROLE_COMMUNITY_TA,
 )
 from edxmako.shortcuts import render_to_string
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from shoppingcart.models import (
     Coupon,
     CourseRegistrationCode,

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseBadRequest
 from django.utils.timezone import utc
 from django.utils.translation import ugettext as _
 
-from courseware.models import StudentFieldOverride
+from lms.djangoapps.courseware.models import StudentFieldOverride
 from courseware.field_overrides import disable_overrides
 from courseware.student_field_overrides import (
     clear_override_for_user,

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -19,7 +19,7 @@ from opaque_keys.edx.keys import UsageKey
 import xmodule.graders as xmgraders
 from student.models import CourseEnrollmentAllowed, CourseEnrollment
 from edx_proctoring.api import get_all_exam_attempts
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from certificates.models import GeneratedCertificate
 from django.db.models import Count
 from certificates.models import CertificateStatuses

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -43,7 +43,7 @@ from courseware.courses import get_course_by_id, get_problems_in_section
 from lms.djangoapps.grades.context import grading_context_for_course
 from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
 from courseware.model_data import DjangoKeyValueStore, FieldDataCache
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from courseware.module_render import get_module_for_descriptor_internal
 from edxmako.shortcuts import render_to_string
 from instructor_analytics.basic import (

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -18,7 +18,7 @@ from functools import partial
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from opaque_keys.edx.locations import i4xEncoder
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from courseware.tests.factories import StudentModuleFactory
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 


### PR DESCRIPTION
As part of [this PR](https://github.com/open-craft/xblock-poll/pull/35), correctly import the Courseware app's models.

**JIRA tickets**: [OC-2981](https://tasks.opencraft.com/browse/OC-2981) [MCKIN-5433](https://edx-wiki.atlassian.net/browse/MCKIN-5433)

**Testing instructions**:

None

**Reviewers**
- [ ] @bradenmacdonald 