### PR TITLE
update git reference of scorm xblock to point to mcka repo

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -15,7 +15,6 @@
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@ad0b7627bfd2d135e1776e19ce208ecf517e50c5#egg=xblock-chat
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal
--e git+https://github.com/raccoongang/edx_xblock_scorm.git#egg=edx_xblock_scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@39771899e30700d3083daedc6464611c1ce9427a#egg=xblock-group-project-v2
 git+https://github.com/edx-solutions/api-integration.git@ziafazal/YONK-705
@@ -25,4 +24,4 @@ git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.0.9
 git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@ziafazal/YONK-705
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.0.3#egg=course-edx-platform-extensions==1.0.3
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.4#egg=progress-edx-platform-extensions==1.0.4
-git+https://github.com/appsembler/edx_xblock_scorm@use_ssla_player#egg=scormxblock
+git+https://github.com/mckinseyacademy/xblock-scorm.git@562f5ec07d1890413ed92e75e665ebb925148ce7


### PR DESCRIPTION
We have received a zip code base of scorm xblock from appsembler team as their latest changes (required by us to run SCORM xblock) are not yet available from their github repo.
This PR is to point git reference for SCORM xblock to mcka github repo with that code base instead of appsembler.