### PR TITLE
Bump Drag and Drop v2 (and XBlock) versions.

### DIFF
--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -329,7 +329,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
 
     SCORED_BLOCK_COUNT = 7
-    ACTUAL_TOTAL_POSSIBLE = 16.0   # solutions fork is using old version of DnD which does not count
+    ACTUAL_TOTAL_POSSIBLE = 17.0
 
     @classmethod
     def setUpClass(cls):

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.3#egg=xblock-image-explorer==0.4.3
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@v2.1.0#egg=xblock-drag-and-drop-v2==v2.1.0
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.11#egg=xblock-ooyala==2.0.11
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -71,7 +71,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 git+https://github.com/edx/lettuce.git@0.2.20.002#egg=lettuce==0.2.20.002
 
 # Our libraries:
-git+https://github.com/edx/XBlock.git@xblock-0.4.13#egg=XBlock==0.4.13
+git+https://github.com/edx/XBlock.git@xblock-0.5.0#egg=XBlock==0.5.0
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail==0.0
 -e git+https://github.com/edx/event-tracking.git@0.2.1#egg=event-tracking==0.2.1
 -e git+https://github.com/edx/django-splash.git@v0.2#egg=django-splash==0.2


### PR DESCRIPTION
This re-adds changes from https://github.com/edx-solutions/edx-platform/pull/886, which somehow either disappeared from master, or never made it to master even though the PR was successfully merged.

This also further bumps the DnDv2 xblock to add some new improvements for mobile.

**Reviewers**:

- [ ] @bradmerlin
- [ ] @bradenmacdonald 