### PR TITLE
Interim Completion API user vs. username inconsistency

### DIFF
--- a/lms/djangoapps/completion_api/tests/test_views.py
+++ b/lms/djangoapps/completion_api/tests/test_views.py
@@ -198,14 +198,16 @@ class CompletionViewTestCase(SharedModuleStoreTestCase):
     def test_wrong_user(self):
         user = UserFactory.create(username='wrong')
         self.client.force_authenticate(user)
-        response = self.client.get('/api/completion/v0/course/?user={}'.format(self.test_user.username))
+        response = self.client.get('/api/completion/v0/course/?username={}'.format(self.test_user.username))
         self.assertEqual(response.status_code, 404)
 
     def test_staff_access(self):
         user = AdminFactory.create(username='staff')
         self.client.force_authenticate(user)
-        response = self.client.get('/api/completion/v0/course/?user={}'.format(self.test_user.username))
+        response = self.client.get('/api/completion/v0/course/?username={}'.format(self.test_user.username))
         self.assertEqual(response.status_code, 200)
+        expected_completion = {'earned': 1.0, 'possible': 12.0, 'ratio': 1 / 12}
+        self.assertEqual(response.data['results'][0]['completion'], expected_completion)  # pylint: disable=no-member
 
 
 class CompletionBlockUpdateViewTestCase(SharedModuleStoreTestCase):

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -45,7 +45,7 @@ class CompletionViewMixin(object):
 
         Usually the requesting user, but a staff user can override this.
         """
-        requested_username = self.request.GET.get('user')
+        requested_username = self.request.GET.get('username')
         if requested_username is None:
             user = self.request.user
         else:


### PR DESCRIPTION
# [OC-3155: Interim Completion API user vs. username inconsistency](https://tasks.opencraft.com/browse/OC-3155)

Change the user parameter to be username instead.

## Reviewers

- [x] @bradenmacdonald 

## Test plan

1. Log in as a student user.
2. Complete some blocks.
3. Try to access /api/completion/v0/course/?user=otherusersname  Expect a regular response, because the user parameter is not recognized
4. Try to access /api/completion/v0/course/?username=otherusersname  Expect a 4xx response, because you can't masquerade as another user
5. Log in as a staff user.
6. Try to access /api/completion/v0/course/?user=otherusersname  Expect a regular response, with the staff user's completions, because the user parameter is not recognized
7. Try to access /api/completion/v0/course/?username=studentuser (from above). Expect a 200 response with the data of the student user.