### PR TITLE
MCKIN-5434 api-integration version bump

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@500eb8b588e731b811d820993a349e676e27e47a#egg=xblock-scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.3#egg=xblock-group-project-v2==0.4.3
-git+https://github.com/edx-solutions/api-integration.git@v1.3.8#egg=api-integration==1.3.8
+git+https://github.com/edx-solutions/api-integration.git@v1.3.9#egg=api-integration==1.3.9
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.5#egg=organizations-edx-platform-extensions==1.1.5
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.1#egg=gradebook-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.0.9#egg=projects-edx-platform-extensions==1.0.9


### PR DESCRIPTION
This bumps the `api-integration` version to pull in https://github.com/edx-solutions/api-integration/pull/71 which is required to use staff-only courseware sections via the solutions api.

@ziafazal  This would also pull in your version 1.3.8 with https://github.com/edx-solutions/api-integration/pull/83 - is that OK?