### PR TITLE
MCKIN-6170: revert DnD to old version from stage+prod

### DIFF
--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -329,7 +329,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
 
     SCORED_BLOCK_COUNT = 7
-    ACTUAL_TOTAL_POSSIBLE = 17.0
+    ACTUAL_TOTAL_POSSIBLE = 16.0   # solutions fork is using old version of DnD which does not count
 
     @classmethod
     def setUpClass(cls):

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.3#egg=xblock-image-explorer==0.4.3
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@v2.1.2#egg=xblock-drag-and-drop-v2==v2.1.2
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.11#egg=xblock-ooyala==2.0.11
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure


### PR DESCRIPTION
We have identified a few issues in latest DnD version that was deployed to stage+prod
https://edx-wiki.atlassian.net/browse/MCKIN-6170

This PR is to revert DnD xblock version back to older one only from release branch.