### PR TITLE
For Mobile API, get earned value from CompletionDataMixin instead of StudentProgress model

### DIFF
--- a/lms/djangoapps/completion_api/models.py
+++ b/lms/djangoapps/completion_api/models.py
@@ -191,13 +191,6 @@ class CourseCompletionFacade(CompletionDataMixin, object):
         return self._inner.course_id
 
     @lazy
-    def earned(self):
-        """
-        Return the number of completions earned by the user.
-        """
-        return self._inner.completions
-
-    @lazy
     def chapter(self):
         """
         Return a list of BlockCompletions for each chapter in the course.


### PR DESCRIPTION
The earned value for student progress retrieved from StudentProgress model is not correct. Until this is corrected, get it from the "earned" property of CompletionDataMixin object.

**Testing instructions**:

1. Import a course and complete some problems in the course.
2. Modify the blocks or delete them.
3. Check that the value in the StudentProgress model still shows the original earned completions, but the value is correctly calculated by the backend.

**Author notes and concerns**:

1. This might be a temporary fix.

**Reviewers**
- [ ] @jcdyer
- [ ] @bradenmacdonald 