### PR TITLE
MCKIN-6170 MCKIN-6121 Version bump for Drag and drop

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.3#egg=xblock-image-explorer==0.4.3
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@v2.1.3#egg=xblock-drag-and-drop-v2==v2.1.3
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@v2.1.4-prerelease#egg=xblock-drag-and-drop-v2==v2.1.4-prerelease
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.11#egg=xblock-ooyala==2.0.11
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure


### PR DESCRIPTION
Version bump to pull in some important bugfixes. This is a pre-release build, since one of the PRs involved is still waiting for final upstream review from edX.

@mtyaka If the build is green, could you please give this a quick sanity check and merge? We'd like to get this onto QA ASAP.

I forgot to update drag-and-drop-v2's setup.py for this prerelease version, but it should still work, and since it's not an official version release, that's probably fine.