### PR TITLE
[MCKIN-6357] Revert to old DnDv2 version and install new one in parallel.

### DIFF
--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -329,7 +329,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
 
     SCORED_BLOCK_COUNT = 7
-    ACTUAL_TOTAL_POSSIBLE = 17.0
+    ACTUAL_TOTAL_POSSIBLE = 16.0   # change this to 17.0 after upgrading to new DnD version
 
     @classmethod
     def setUpClass(cls):

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,7 +4,9 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.3#egg=xblock-image-explorer==0.4.3
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@v2.1.4-prerelease2#egg=xblock-drag-and-drop-v2==v2.1.4-prerelease2
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
+# Temporary new version for A2E course only; installs in parallel with the above version. Aim to remove this and upgrade the above ASAP.
+-e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@a2c4d52744943d862e2b1449757a5dc316fe2ee7#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.12#egg=xblock-ooyala==2.0.12
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure


### PR DESCRIPTION
This temporarily installs both version 7b05446 and version v2.1.4-prerelease2 of xblock-drag-and-drop-v2 in parallel. This is meant to be used only temporarily for one course, and not to be maintained in the long term.

**Caveats**

- Any existing drag and drop exercises on the server that have been edited with the new version will break.
- The new version and the old version cannot exist within the same subsection, since the JavaScript conflicts.
- For authors, there may be up to four different drag and drop component types available in Studio (v1 CAPA, v1 XBlock, v2, v2-new) which is confusing.
