### PR TITLE
Increment GPv2 xblock version to 0.4.6

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -18,7 +18,7 @@
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@500eb8b588e731b811d820993a349e676e27e47a#egg=xblock-scorm
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
--e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.5#egg=xblock-group-project-v2==0.4.5
+-e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.6#egg=xblock-group-project-v2==0.4.6
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1#egg=xblock-virtualreality==0.1
 git+https://github.com/edx-solutions/api-integration.git@v1.5.3#egg=api-integration==1.5.3
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.1.6#egg=organizations-edx-platform-extensions==1.1.6


### PR DESCRIPTION
Incorporates the XSS fixes from open-craft/xblock-group-project-v2/pull/118