### PR TITLE
YONK-825: don't look into course structure if we dont have deprecated_block_types

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -567,6 +567,9 @@ def _deprecated_blocks_info(course_module, deprecated_block_types):
         'advance_settings_url': reverse_course_url('advanced_settings_handler', course_module.id)
     }
 
+    if not deprecated_block_types:
+        return data
+
     try:
         structure_data = api.course_structure(course_module.id, block_types=deprecated_block_types)
     except errors.CourseStructureNotAvailableError:


### PR DESCRIPTION
If course structure is already cached calling `api.course_structure` with empty list of `block_types` returns completed course structure from cache. This check fixes the issue in that scenario. [YONK-825](https://openedx.atlassian.net/browse/YONK-825) has the details of the issue.
