### PR TITLE
MCKIN-6337 Remove 'course' parameter from requested_fields parameter in completion API

### DIFF
--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -31,7 +31,7 @@ class CompletionViewMixin(object):
     Common functionality for completion views.
     """
 
-    _allowed_requested_fields = AGGREGATE_CATEGORIES | {'mean'}
+    _allowed_requested_fields = (AGGREGATE_CATEGORIES - {'course'}) | {'mean'}
 
     authentication_classes = (
         authentication.OAuth2AuthenticationAllowInactiveUser,
@@ -167,9 +167,9 @@ class CompletionListView(CompletionViewMixin, APIView):
 
         requested_fields (optional):
             A comma separated list of extra data to be returned.  This can be
-            one of the block types specified in `AGGREGATE_CATEGORIES`, or any of
-            the other optional fields specified above.  If any invalid fields
-            are requested, a 400 error will be returned.
+            one of the block types specified in `AGGREGATE_CATEGORIES` (except
+            `course`), or any of the other optional fields specified above.
+            If any invalid fields are requested, a 400 error will be returned.
 
     **Returns**
 


### PR DESCRIPTION
This fixes an internal server error when passing `course` in the `requested_fields` API parameter.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**
1. Register with a normal user
2. Advance a little through a course
3. http://localhost:8000/api/completion/v0/course/ should show meaningful data
4. http://localhost:8000/api/completion/v0/course/?requested_fields=course   should show 400 error at the bottom. No more 500 error
5. http://localhost:8000/api/completion/v0/course/?requested_fields=mean should work
6. http://localhost:8000/api/completion/v0/course/?requested_fields=courseeeeee should show 400 error

**Author notes and concerns**: None
**Reviewers**
- [ ] @jcdyer

**Settings**
None