### PR TITLE
MCKIN-5637, MCKIN-6563 - Merge HTML XBlock student_view_data from Upstream

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime
+from django.conf import settings
 from fs.errors import ResourceNotFoundError
 import logging
 from lxml import etree
@@ -68,6 +69,8 @@ class HtmlBlock(object):
         scope=Scope.settings
     )
 
+    ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA = 'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA'
+
     @XBlock.supports("multi_device")
     def student_view(self, _context):
         """
@@ -77,14 +80,15 @@ class HtmlBlock(object):
 
     def student_view_data(self, context=None):  # pylint: disable=unused-argument
         """
-        Returns a JSON representation of the student_view of this XBlock,
-        retrievable from the Course Block API.
-        Since this data is not user-specific, fields like `html` may contain
-        placeholders like %%USER_ID%%.
+        Return a JSON representation of the student_view of this XBlock.
         """
-        return {
-            'html': self.data
-        }
+        if getattr(settings, 'FEATURES', {}).get(self.ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA, False):
+            return {'enabled': True, 'html': self.get_html()}
+        else:
+            return {
+                'enabled': False,
+                'message': 'To enable, set FEATURES["{}"]'.format(self.ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA)
+            }
 
     def get_html(self):
         """ Returns html required for rendering XModule. """
@@ -98,7 +102,7 @@ class HtmlBlock(object):
         # When we switch this to an XBlock, we can merge this with student_view,
         # but for now the XModule mixin requires that this method be defined.
         # pylint: disable=no-member
-        if self.system.anonymous_student_id:
+        if self.data is not None and getattr(self.system, 'anonymous_student_id', None) is not None:
             return self.data.replace("%%USER_ID%%", self.system.anonymous_student_id)
         return self.data
 

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -4,6 +4,7 @@ Tests for StudentViewTransformer.
 import ddt
 
 # pylint: disable=protected-access
+from django.test.utils import override_settings
 from openedx.core.lib.block_structure.factory import BlockStructureFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
@@ -22,6 +23,9 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
         self.course_usage_key = self.store.make_course_usage_key(self.course_key)
         self.block_structure = BlockStructureFactory.create_from_modulestore(self.course_usage_key, self.store)
 
+    # pylint: disable=fixme
+    # FIXME: See openedx/core/lib/block_structure/block_structure.py FieldData.__delattr__
+    @override_settings(DEBUG=True)
     @ddt.data(
         'video', 'html', ['video', 'html'], [],
     )

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -3,7 +3,6 @@ Tests for StudentViewTransformer.
 """
 
 # pylint: disable=protected-access
-
 from openedx.core.lib.block_structure.factory import BlockStructureFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -1,6 +1,7 @@
 """
 Tests for StudentViewTransformer.
 """
+import ddt
 
 # pylint: disable=protected-access
 from openedx.core.lib.block_structure.factory import BlockStructureFactory
@@ -10,6 +11,7 @@ from xmodule.modulestore.tests.factories import ToyCourseFactory
 from ..student_view import StudentViewTransformer
 
 
+@ddt.ddt
 class TestStudentViewTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for StudentViewTransformer
@@ -20,20 +22,27 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
         self.course_usage_key = self.store.make_course_usage_key(self.course_key)
         self.block_structure = BlockStructureFactory.create_from_modulestore(self.course_usage_key, self.store)
 
-    def test_transform(self):
+    @ddt.data(
+        'video', 'html', ['video', 'html'], [],
+    )
+    def test_transform(self, requested_student_view_data):
         # collect phase
         StudentViewTransformer.collect(self.block_structure)
         self.block_structure._collect_requested_xblock_fields()
 
         # transform phase
-        StudentViewTransformer('video').transform(usage_info=None, block_structure=self.block_structure)
+        StudentViewTransformer(requested_student_view_data).transform(
+            usage_info=None,
+            block_structure=self.block_structure,
+        )
 
-        # verify video data
+        # verify video data returned iff requested
         video_block_key = self.course_key.make_usage_key('video', 'sample_video')
-        self.assertIsNotNone(
+        self.assertEqual(
             self.block_structure.get_transformer_block_field(
                 video_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            )
+            ) is not None,
+            'video' in requested_student_view_data
         )
         self.assertFalse(
             self.block_structure.get_transformer_block_field(
@@ -41,12 +50,13 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
             )
         )
 
-        # verify html data
+        # verify html data returned iff requested
         html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
-        self.assertIsNotNone(
+        self.assertEqual(
             self.block_structure.get_transformer_block_field(
                 html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
-            )
+            ) is not None,
+            'html' in requested_student_view_data
         )
         self.assertTrue(
             self.block_structure.get_transformer_block_field(

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -388,6 +388,9 @@ FEATURES = {
 
     # Allow public account creation
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
+
+    # Whether HTML XBlocks/XModules return HTML content with the Course Blocks API student_view_data
+    'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA': False,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -312,7 +312,7 @@ class FieldData(object):
         if self._is_own_field(field_name):
             return super(FieldData, self).__delattr__(field_name)
         else:
-            delattr(self.fields, field_name)
+            del self.fields[field_name]
 
     def _is_own_field(self, field_name):
         """

--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from functools import partial
 from logging import getLogger
 
+from django.conf import settings
 from openedx.core.lib.graph_traversals import traverse_topologically, traverse_post_order
 
 from .exceptions import TransformerException
@@ -312,7 +313,17 @@ class FieldData(object):
         if self._is_own_field(field_name):
             return super(FieldData, self).__delattr__(field_name)
         else:
-            del self.fields[field_name]
+            # pylint: disable=fixme
+            # FIXME: Bug with Course Blocks API and student_view_data fixed by
+            #  https://github.com/edx/edx-platform/pull/15905/commits/ae15e69a0ad52fec2f146176e418eb2e37f0ecb2
+            # Will be brought in once McKinsey's apps have been updated.
+            # For now, only deployed where DEBUG=True, so QA can test.
+            # See lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+            #   TestStudentViewTransformer.test_transform for affected test.
+            if settings.DEBUG:
+                del self.fields[field_name]
+            else:
+                delattr(self.fields, field_name)
 
     def _is_own_field(self, field_name):
         """


### PR DESCRIPTION
This pull request merges the changes found in upstream [PR #15905.](https://github.com/edx/edx-platform/pull/15905) In addition to the changes, other linked files such as openedx/core/djangoapps/content/block_structure/factory.py have been added.

This encompasses two changes:
1. Need to set settings.FEATURES['ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA'] to continue to see HTML `student_view_data`.
2. A bugfix for the Course Blocks API `student_view_data` parameter has been put in for testing when `settings.DEBUG = True`, because this change may affect the mobile apps using the Course Blocks API.
  Previously, if you put anything in that parameter, then all blocks with student_view_data would return theirs. With this fix enabled, the behavior is in line with [the documentation](http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/blocks.html#query-parameters).

**JIRA tickets**: MCKIN-5637

**Testing instructions**:
The testing instructions are the same as [PR#15905](https://github.com/edx/edx-platform/pull/15905). Please see and use those.

**Reviewers**
- [ ] @pomegranited 
- [ ] TBD
