### PR TITLE
[MCKIN-6342] Bump xblock drag and drop v3

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
 # Temporary new version for A2E course only; installs in parallel with the above version. Aim to remove this and upgrade the above ASAP.
--e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@f7ded2f65d49e9e51a9e9b9ec7ccdd46b19d3c5a#egg=xblock-drag-and-drop-v2-new
+-e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@a03a218b3c689e07609d8eb3abf8f18e0cb3dd82#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.12#egg=xblock-ooyala==2.0.12
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure


### PR DESCRIPTION
This bumps the new xblock-drag-and-drop-v2 (installed in parallel with the old version) to include fixes from https://github.com/open-craft/xblock-drag-and-drop-v2/pull/18.