### PR TITLE
[MCKIN-6576] Disable the student_view_data bugfix using a feature flag

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -2,9 +2,10 @@
 Tests for StudentViewTransformer.
 """
 import ddt
+from mock import patch
+from django.conf import settings
 
 # pylint: disable=protected-access
-from django.test.utils import override_settings
 from openedx.core.lib.block_structure.factory import BlockStructureFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
@@ -25,7 +26,40 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
 
     # pylint: disable=fixme
     # FIXME: See openedx/core/lib/block_structure/block_structure.py FieldData.__delattr__
-    @override_settings(DEBUG=True)
+    # This test demonstrates that the student_view_data bug is present by default.
+    # This test can be removed entirely once the bug fix is enabled.
+    @ddt.data(
+        'video', 'html', ['video', 'html'], [],
+    )
+    def test_transform_bug_enabled_by_default(self, requested_student_view_data):
+        # collect phase
+        StudentViewTransformer.collect(self.block_structure)
+        self.block_structure._collect_requested_xblock_fields()
+
+        # transform phase
+        StudentViewTransformer(requested_student_view_data).transform(
+            usage_info=None,
+            block_structure=self.block_structure,
+        )
+
+        # verify both video and html data are always returned
+        video_block_key = self.course_key.make_usage_key('video', 'sample_video')
+        self.assertIsNotNone(
+            self.block_structure.get_transformer_block_field(
+                video_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
+            )
+        )
+        html_block_key = self.course_key.make_usage_key('html', 'toyhtml')
+        self.assertIsNotNone(
+            self.block_structure.get_transformer_block_field(
+                html_block_key, StudentViewTransformer, StudentViewTransformer.STUDENT_VIEW_DATA,
+            )
+        )
+
+    # pylint: disable=fixme
+    # FIXME: See openedx/core/lib/block_structure/block_structure.py FieldData.__delattr__
+    # Remove this patch once the student_view_data bug is fixed for good.
+    @patch.dict(settings.FEATURES, {'ENABLE_STUDENT_VIEW_DATA_BUGFIX': True})
     @ddt.data(
         'video', 'html', ['video', 'html'], [],
     )

--- a/openedx/core/lib/block_structure/block_structure.py
+++ b/openedx/core/lib/block_structure/block_structure.py
@@ -317,10 +317,10 @@ class FieldData(object):
             # FIXME: Bug with Course Blocks API and student_view_data fixed by
             #  https://github.com/edx/edx-platform/pull/15905/commits/ae15e69a0ad52fec2f146176e418eb2e37f0ecb2
             # Will be brought in once McKinsey's apps have been updated.
-            # For now, only deployed where DEBUG=True, so QA can test.
+            # For now, only deployed where settings.FEATURES['ENABLE_STUDENT_VIEW_DATA_BUGFIX']=True, so QA can test.
             # See lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
-            #   TestStudentViewTransformer.test_transform for affected test.
-            if settings.DEBUG:
+            #   TestStudentViewTransformer for affected tests.
+            if settings.FEATURES.get('ENABLE_STUDENT_VIEW_DATA_BUGFIX', False):
                 del self.fields[field_name]
             else:
                 delattr(self.fields, field_name)


### PR DESCRIPTION
https://github.com/edx-solutions/edx-platform/pull/969 disabled the `student_view_data` bugfix using `settings.DEBUG`, which may or may not be enabled in QA.

This change uses a feature flag to enable the bugfix instead.  The bugfix is disabled by default to allow affected apps to be fixed prior to release.

**Testing instructions**
* Run this branch on a solutions devstack
* Login using a user enrolled in the Demo course, e.g. honor@example.com
* Navigate to the Course Blocks API, and request `student_view_data=html`, e.g. 
  http://localhost:8000/api/courses/v1/blocks/?course_id=course-v1%3aedX%2bDemoX%2bDemo_Course&depth=all&student_view_data=html&username=honor
  Note that the returned data shows `student_view_data` blocks for all types of blocks, including `html`, `discussion`, and `video`.
* In `lms.env.json`, under `FEATURES`, add: 
   ```javascript
   "fix_student_view_data_bug": true,
   ```
   and restart the LMS.
* Refresh the Course Blocks API request above, and note that `student_view_data` is now only returned for `html` blocks, and no longer appears for `discussion` and `video` blocks.
* Add `discussion` to the list of requested `student_view_data` blocks, e.g. 
  http://localhost:8000/api/courses/v1/blocks/?course_id=course-v1%3aedX%2bDemoX%2bDemo_Course&depth=all&student_view_data=html,discussion&username=honor
  Note that you can now see `student_view_data` for both `html` and `discussion` blocks. 

**Reviewers**
- [ ] @mtyaka or @bradenmacdonald 

CC @wajeeha-khalid 
  