### PR TITLE
MCKIN-6614: Bump xblock image explorer version to v0.5.0

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,7 +2,7 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.4.3#egg=xblock-image-explorer==0.4.3
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.5.0#egg=xblock-image-explorer==0.5.0
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
 # Temporary new version for A2E course only; installs in parallel with the above version. Aim to remove this and upgrade the above ASAP.


### PR DESCRIPTION
This PR bumps xblock image explorer version to v0.5.0, Which adds feature flag for calculating hotspots in %.