### PR TITLE
MCKIN-6708 Bump End of Course Journal Xblock's version.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -449,14 +449,14 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ("level_of_education", "none", u"ȻħȺɍłɇs", u'"ȻħȺɍłɇs" is not a valid choice.'),
         ("country", "GB", "XY", u'"XY" is not a valid choice.'),
         ("year_of_birth", 2009, "not_an_int", u"A valid integer is required."),
-        ("name", "bob", "z" * 256, u"Ensure this value has at most 255 characters (it has 256)."),
+        ("name", "bob", "z" * 256, u"Ensure this field has no more than 255 characters."),
         ("name", u"ȻħȺɍłɇs", "z   ", "The name field must be at least 2 characters long."),
         ("goals", "Smell the roses"),
         ("mailing_address", "Sesame Street"),
         # Note that we store the raw data, so it is up to client to escape the HTML.
         (
             "bio", u"<html>Lacrosse-playing superhero 壓是進界推日不復女</html>",
-            "z" * 3001, u"Ensure this value has at most 3000 characters (it has 3001)."
+            "z" * 3001, u"Ensure this field has no more than 3000 characters."
         ),
         ("account_privacy", ALL_USERS_VISIBILITY),
         ("account_privacy", PRIVATE_VISIBILITY),

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -475,7 +475,7 @@ def get_expected_validation_developer_message(preference_key, preference_value):
         preference_key=preference_key,
         preference_value=preference_value,
         error={
-            "key": [u"Ensure this value has at most 255 characters (it has 256)."]
+            "key": [u"Ensure this field has no more than 255 characters."]
         }
     )
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,9 +35,9 @@ django-statici18n==1.1.5
 django-storages==1.4.1
 django-method-override==0.1.0
 django-user-tasks==0.1.2
-# We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
+# We need a fix to DRF 3.2.x, for now use it from a cherry-picked repo with fixes to https://github.com/encode/django-rest-framework/issues/3354
 #djangorestframework>=3.1,<3.2
-git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
+git+https://github.com/open-craft/django-rest-framework.git@tomaszgy/lazy_strings_included#egg=djangorestframework==3.2.3
 django==1.8.18
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -15,7 +15,7 @@
 -e git+https://github.com/open-craft/problem-builder.git@v2.8.0#egg=xblock-problem-builder==2.8.0
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@038009f7c646be8001998002325efbafe14e2981#egg=xblock-chat
--e git+https://github.com/open-craft/xblock-eoc-journal.git@1d1c5a5ffea4168b690d8922d25da7dfb1fa2fbf#egg=xblock-eoc-journal
+-e git+https://github.com/open-craft/xblock-eoc-journal.git@e1495e855a27514971ca08d87d1a7a2735cd3e31#egg=xblock-eoc-journal
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@v2.0.8#egg=xblock-scorm==2.0.8
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.2#egg=xblock-diagnostic-feedback==0.2.2
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.6#egg=xblock-group-project-v2==0.4.6


### PR DESCRIPTION
## MCKIN-6708
This PR bumps the version of the End of the Course Journal Xblock to include fixes from https://github.com/open-craft/xblock-eoc-journal/pull/10 as a part of MCKIN-6708.

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>