### PR TITLE
[MCKIN-6672] McKA Interim Progress API: Allow retrieving only mobile courses

### DIFF
--- a/lms/djangoapps/completion_api/tests/test_views.py
+++ b/lms/djangoapps/completion_api/tests/test_views.py
@@ -440,4 +440,4 @@ class CompletionMobileViewTestCase(SharedModuleStoreTestCase):
             'pagination': {'count': expected_count, 'previous': None, 'num_pages': 1, 'next': None},
             'results': expected_results,
         }
-        self.assertEqual(response.data, expected)
+        self.assertEqual(response.data, expected)  # pylint: disable=no-member

--- a/lms/djangoapps/completion_api/tests/test_views.py
+++ b/lms/djangoapps/completion_api/tests/test_views.py
@@ -379,20 +379,20 @@ class CompletionBlockUpdateViewTestCase(SharedModuleStoreTestCase):
 @ddt.ddt
 class CompletionMobileViewTestCase(SharedModuleStoreTestCase):
     """
-    Test that the CompletionView with mobile courses.
+    Tests the CompletionView with mobile courses.
     """
 
     @classmethod
     def setUpClass(cls):
         super(CompletionMobileViewTestCase, cls).setUpClass()
-        cls.none_mobile_course = ToyCourseFactory.create()
+        cls.non_mobile_course = ToyCourseFactory.create()
         cls.mobile_course = ToyCourseFactory.create(mobile_available=True, course='mobile', run='2018_Spring')
 
     def setUp(self):
         super(CompletionMobileViewTestCase, self).setUp()
         self.test_user = UserFactory.create()
         CourseEnrollment.enroll(self.test_user, self.mobile_course.id)
-        CourseEnrollment.enroll(self.test_user, self.none_mobile_course.id)
+        CourseEnrollment.enroll(self.test_user, self.non_mobile_course.id)
         self.mobile_client = APIClient()
         self.mobile_client.force_authenticate(user=self.test_user)
 
@@ -411,7 +411,7 @@ class CompletionMobileViewTestCase(SharedModuleStoreTestCase):
             ]
         ),
         (
-            2,
+            1,
             [
                 {
                     'course_key': 'edX/mobile/2018_Spring',

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -271,8 +271,8 @@ class CompletionListView(CompletionViewMixin, APIView):
             for course_enrollment in enrollments:
                 course_keys.append(course_enrollment.course_id)
                 course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
-                filtered_course_overview = [overview.id for overview in course_overview_list]
-                enrollments = enrollments.filter(course_id__in=filtered_course_overview)
+            filtered_course_overview = [overview.id for overview in course_overview_list]
+            enrollments = enrollments.filter(course_id__in=filtered_course_overview)
 
         paginated = self.paginator.paginate_queryset(enrollments, self.request, view=self)
 

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -270,7 +270,7 @@ class CompletionListView(CompletionViewMixin, APIView):
             course_keys = []
             for course_enrollment in enrollments:
                 course_keys.append(course_enrollment.course_id)
-                course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
+            course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
             filtered_course_overview = [overview.id for overview in course_overview_list]
             enrollments = enrollments.filter(course_id__in=filtered_course_overview)
 

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -267,14 +267,12 @@ class CompletionListView(CompletionViewMixin, APIView):
             is_active=True).order_by('course_id')
 
         if mobile_only:
-            enrollments = CourseEnrollment.objects.filter(
-                user=self.get_user(),
-                is_active=True,
-                course_id__in=[CourseKey.from_string(key)
-                               for key in CourseOverview.objects.filter(mobile_available=True).values_list('id',
-                                                                                                           flat=True)
-                               ]
-            )
+            course_keys = []
+            for course_enrollment in enrollments:
+                course_keys.append(course_enrollment.course_id)
+                course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
+                filtered_course_overview = [overview.id for overview in course_overview_list]
+                enrollments = enrollments.filter(course_id__in=filtered_course_overview)
 
         paginated = self.paginator.paginate_queryset(enrollments, self.request, view=self)
 

--- a/lms/djangoapps/completion_api/views.py
+++ b/lms/djangoapps/completion_api/views.py
@@ -267,12 +267,14 @@ class CompletionListView(CompletionViewMixin, APIView):
             is_active=True).order_by('course_id')
 
         if mobile_only:
-            course_keys = []
-            for course_enrollment in enrollments:
-                course_keys.append(course_enrollment.course_id)
-            course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
-            filtered_course_overview = [overview.id for overview in course_overview_list]
-            enrollments = enrollments.filter(course_id__in=filtered_course_overview)
+            enrollments = CourseEnrollment.objects.filter(
+                user=self.get_user(),
+                is_active=True,
+                course_id__in=[CourseKey.from_string(key)
+                               for key in CourseOverview.objects.filter(mobile_available=True).values_list('id',
+                                                                                                           flat=True)
+                               ]
+            )
 
         paginated = self.paginator.paginate_queryset(enrollments, self.request, view=self)
 


### PR DESCRIPTION
This pull request adds the ability to query the Completion API and retrieve student progresses only from mobile courses.

**JIRA tickets**: MCKIN-6672

**Testing instructions**:

1. Ensure that a course has the "Mobile Course Available" set to true in Advanced Settings.
2. Visit /api/completion/v0/course/?mobile_only=true
3. Ensure that the course with "Mobile Course Available" is shown.

**Reviewers**
- [x] @jcdyer
- [ ] @pomegranited 