### PR TITLE
YONK-875: No need to send Notification if Channel is None

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -76,8 +76,14 @@ def publish_course_notifications_task(course_id, notification_msg, exclude_user_
                     "api_credentials": mobile_app.get_api_keys()
                 }
                 preferred_channel = mobile_app.get_notification_provider_name()
-                bulk_publish_notification_to_users(user_ids, notification_msg, exclude_user_ids=exclude_user_ids,
-                                                   preferred_channel=preferred_channel, channel_context=channel_context)
+                if preferred_channel:
+                    bulk_publish_notification_to_users(
+                        user_ids,
+                        notification_msg,
+                        exclude_user_ids=exclude_user_ids,
+                        preferred_channel=preferred_channel,
+                        channel_context=channel_context
+                    )
     except Exception, ex:
         # Notifications are never critical, so we don't want to disrupt any
         # other logic processing. So log and continue.


### PR DESCRIPTION
Changes include the addition of a check that ensure no need to send notifications if the channel is none. 
**Issue Fix**: Learners are getting multiple notifications of same announcement.