### PR TITLE
[MCKIN-6965] Newly Added Drag and Drop blocks not loading in Studio

### DIFF
--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -12,7 +12,7 @@
             selector = '.' + blockClass;
         }
         return $(element).immediateDescendents(selector).map(function(idx, elem) {
-            return initializer(elem, requestToken);
+            return initializer($(elem), requestToken);
         }).toArray();
     }
 


### PR DESCRIPTION
This change accompanies fixes to the [drag and drop XBlock](https://github.com/open-craft/xblock-drag-and-drop-v2/pull/24/commits/949dca7b1aa22367bb6c4e2b44056fe10e9c8f21). We intend to submit this fix upstream.

XBlock initialization should be using jQuery wrappers of DOM elements, but descendant blocks were still being passed the plain elements. This corrects that.

**Reviewers**
- [ ] @e-kolpakov 
- [ ] @bradenmacdonald 