### PR TITLE
[MCKIN-7023] Improve XBlock i18n by allowing template translations

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,11 +2,12 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.6.0#egg=xblock-image-explorer==0.6.0
+# FIXME -- use tag v1.1.0 when https://github.com/edx-solutions/xblock-image-explorer/pull/37 merged and tagged
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@06b5aeb7d998b1193257e581b2648d9a82b881ed#egg=xblock-image-explorer==0.7.0
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
 # Temporary new version for A2E course only; installs in parallel with the above version. Aim to remove this and upgrade the above ASAP.
--e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@1167385e492c7a79407db991c68dc3838e62c8ca#egg=xblock-drag-and-drop-v2-new
+-e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@c98fd76eabbf9e2be85dad519acf1f8918960d03#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.15#egg=xblock-ooyala==2.0.15
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -83,7 +83,8 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
+# FIXME -- use tag v1.1.0 when https://github.com/edx/xblock-utils/pull/48 merged and tagged
+git+https://github.com/edx-solutions/xblock-utils.git@ba54084a572a618b9248236403c1200f32d4f889#egg=xblock-utils==1.1.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5


### PR DESCRIPTION
Uses temporary branches for XBlock, xblock-utils, and DnDv2-new to provide fixes for XBlock template translations.

**JIRA tickets**: [MCKIN-7023](https://edx-wiki.atlassian.net/browse/MCKIN-7023)

**Discussions**: [WL-230](https://openedx.atlassian.net/browse/WL-230), [YONK-879](https://openedx.atlassian.net/browse/YONK-879?focusedCommentId=307771&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-307771)

**Dependencies**:

* https://github.com/edx/xblock-utils/pull/48
* https://github.com/edx-solutions/xblock-image-explorer/pull/37
* https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154
* https://github.com/open-craft/xblock-drag-and-drop-v2/pull/25

**Screenshots**: See https://github.com/edx-solutions/xblock-image-explorer/pull/37 and https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 for before and after screenshots using dummy translations.

**Merge deadline**: ASAP

**Testing instructions**:

See https://github.com/edx-solutions/xblock-image-explorer/pull/37 for test instructions.

**Author notes and concerns**:

1. When the dependent PRs merge, we'll submit a follow-up PR to use the newly tagged versions of the dependent libraries.

**Reviewers**
- [x] @mtyaka 