### PR TITLE
YONK-938: Signal added for cohorted discussions

### DIFF
--- a/common/djangoapps/django_comment_common/signals.py
+++ b/common/djangoapps/django_comment_common/signals.py
@@ -2,6 +2,12 @@
 """Signals related to the comments service."""
 
 from django.dispatch import Signal
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from openedx.core.djangoapps.course_groups.models import CourseCohortsSettings
+
+from .utils import set_course_discussion_settings
 
 thread_created = Signal(providing_args=['user', 'post'])
 thread_edited = Signal(providing_args=['user', 'post'])
@@ -14,3 +20,11 @@ comment_edited = Signal(providing_args=['user', 'post'])
 comment_voted = Signal(providing_args=['user', 'post'])
 comment_deleted = Signal(providing_args=['user', 'post', 'involved_users'])
 comment_endorsed = Signal(providing_args=['user', 'post'])
+
+
+@receiver(post_save, sender=CourseCohortsSettings)
+def update_cohorted_discussions(sender, instance, **kwargs):
+    set_course_discussion_settings(
+        course_key=instance.course_id,
+        divided_discussions=instance.cohorted_discussions,
+    )

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -90,7 +90,6 @@ class TestCourseHomePage(SharedModuleStoreTestCase):
         """
         remove_course_updates(self.user, self.course)
         url = course_home_url(self.course)
-        # from nose.tools import set_trace; set_trace()
         response = self.client.get(url)
         self.assertNotContains(response, TEST_COURSE_UPDATES_TOOL, status_code=200)
 


### PR DESCRIPTION
Changes include addition of a signal to update CourseDiscussionSettings with CourseChortsSettings.