### PR TITLE
Update problem-builder version to include fix from 2.9.2

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@v1.5.0#egg=xblock-poll==1.5.0
 -e git+https://github.com/edx/edx-notifications.git@0.6.5#egg=edx-notifications==0.6.5
--e git+https://github.com/open-craft/problem-builder.git@v2.9.1#egg=xblock-problem-builder==2.9.1
+-e git+https://github.com/open-craft/problem-builder.git@v2.9.2#egg=xblock-problem-builder==2.9.2
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2#egg=xblock-chat==0.2
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@e1495e855a27514971ca08d87d1a7a2735cd3e31#egg=xblock-eoc-journal


### PR DESCRIPTION
Bump version of Problem Builder XBlock to v2.9.2 which adds ``description`` field in ``student_view_data`` for ``pb-answer-recap``.  Re: open-craft/problem-builder#185

**Dependencies**: open-craft/problem-builder#185

**Reviewers**
- [ ] @afzaledx
