### PR TITLE
MCKIN-7398 Avoid database write that can cause deadlock

### DIFF
--- a/lms/djangoapps/completion_api/models.py
+++ b/lms/djangoapps/completion_api/models.py
@@ -103,7 +103,7 @@ class CourseCompletionFacade(CompletionDataMixin, object):
         """
         The block key for the course.
         """
-        return CourseOverview.load_from_module_store(self.course_key).location
+        return CourseOverview.get_from_id(self.course_key).location
 
     @lazy
     def blocks(self):


### PR DESCRIPTION
This is a possible fix for MCKIN-7398. This changes the code to fetch CourseOverview from the database whenever possible, instead of always fetching it from the ModuleStore and updating the CourseOverview cache.

This should also improve the API performance.