### PR TITLE
YONK-924: Xblock handler added with the older URL

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -10,6 +10,11 @@ from functools import partial
 from datetime import datetime
 from django.utils.timezone import UTC
 
+from rest_framework.views import APIView
+from rest_framework.authentication import SessionAuthentication
+from rest_framework_oauth.authentication import OAuth2Authentication
+from rest_framework.permissions import IsAuthenticated
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -932,6 +937,29 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
             raise Http404("invalid location")
 
         return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
+
+
+# TODO: deprecated (XblockCallbackView is deprecated in favour of handle_xblock_callback as a function based view)
+# Need to be removed soon after all apps shifted to new URL in API Integration.
+class XblockCallbackView(APIView):
+
+    authentication_classes = (SessionAuthentication, OAuth2Authentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, course_id, usage_id, handler, suffix=None):
+        return handle_xblock_callback(request, course_id, usage_id, handler, suffix)
+
+    def post(self, request, course_id, usage_id, handler, suffix=None):
+        return handle_xblock_callback(request, course_id, usage_id, handler, suffix)
+
+    def put(self, request, course_id, usage_id, handler, suffix=None):
+        return handle_xblock_callback(request, course_id, usage_id, handler, suffix)
+
+    def patch(self, request, course_id, usage_id, handler, suffix=None):
+        return handle_xblock_callback(request, course_id, usage_id, handler, suffix)
+
+    def delete(self, request, course_id, usage_id, handler, suffix=None):
+        return handle_xblock_callback(request, course_id, usage_id, handler, suffix)
 
 
 def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -12,6 +12,8 @@ from ratelimitbackend import admin
 from courseware.views.index import CoursewareIndex
 from courseware.views.views import CourseTabView, EnrollStaffView, StaticCourseTabView
 from django_comment_common.models import ForumsConfig
+
+from lms.djangoapps.courseware.module_render import XblockCallbackView
 from openedx.core.djangoapps.auth_exchange.views import LoginWithAccessTokenView
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
@@ -238,7 +240,7 @@ urlpatterns += (
             course_key=settings.COURSE_ID_PATTERN,
             usage_key=settings.USAGE_ID_PATTERN,
         ),
-        'courseware.module_render.handle_xblock_callback',
+        XblockCallbackView.as_view(),
         name='xblock_handler',
     ),
     url(


### PR DESCRIPTION
Changes include addtion of OAuth2Authentication on Xblock handler to allow mobile app use older url.