### PR TITLE
MCKIN-7382 Upgrade all DnDv2 blocks to new version.

### DIFF
--- a/lms/djangoapps/grades/tests/test_new.py
+++ b/lms/djangoapps/grades/tests/test_new.py
@@ -453,7 +453,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
 
     SCORED_BLOCK_COUNT = 7
-    ACTUAL_TOTAL_POSSIBLE = 16.0   # change this to 17.0 after upgrading to new DnD version
+    ACTUAL_TOTAL_POSSIBLE = 17.0
 
     @classmethod
     def setUpClass(cls):

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,9 +4,9 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.6.0#egg=xblock-image-explorer==0.6.0
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7b054467159fd2cbe2e0adccf9a0665d36a2a197#egg=xblock-drag-and-drop-v2
-# Temporary new version for A2E course only; installs in parallel with the above version. Aim to remove this and upgrade the above ASAP.
--e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@1167385e492c7a79407db991c68dc3838e62c8ca#egg=xblock-drag-and-drop-v2-new
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@9e017517060ad1c8e6935c24962de1d233a9d3a4#egg=xblock-drag-and-drop-v2
+# This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
+-e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.15#egg=xblock-ooyala==2.0.15
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure


### PR DESCRIPTION
**Description**

This upgrades DnDv2 to the master version for all courses and makes `xblock-drag-and-drop-v2-new` version just an alias for the master version.

**Testing**

1. **Before applying this change** add at least on old DnDv2 block and at least one new DnDv2 block to your test course.
   * The new drag and drop is added by adding `drag-and-drop-v2-new` to the course advanced settings as an advanced module type, then adding the component via "Component > Drag and Drop Problem"
   * The old drag and drop is added by adding Problem > Advanced > Drag and Drop
1. Apply the changes from this PR and (re)install the requirements.
1. Restart LMS/Studio.
1. Verify that the old DnDv2 blocks have been updated to the new version and continue to work correctly.
1. Verify that the new DnDv2 blocks continue to work correctly.