### PR TITLE
[MCKIN-7179] Bump version of xblock-image-explorer.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,8 +2,7 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
-# FIXME -- use tag v1.1.0 when https://github.com/edx-solutions/xblock-image-explorer/pull/37 merged and tagged
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@c09b90e86ed05519d3a09e857a3c4fce4ede1c71#egg=xblock-image-explorer==0.8.0
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.9.0#egg=xblock-image-explorer==0.9.0
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@9e017517060ad1c8e6935c24962de1d233a9d3a4#egg=xblock-drag-and-drop-v2
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.


### PR DESCRIPTION
This PR bumps version of xblock-image-explorer to apply changes from https://github.com/edx-solutions/xblock-image-explorer/pull/43.

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>