### PR TITLE
MCKIN-7023 xblock i18n bump versions

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,10 +2,11 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v0.9.0#egg=xblock-image-explorer==0.9.0
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.0#egg=xblock-image-explorer==1.0.0
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@9e017517060ad1c8e6935c24962de1d233a9d3a4#egg=xblock-drag-and-drop-v2
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
+# FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.15#egg=xblock-ooyala==2.0.15
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -83,8 +83,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-# FIXME -- use tag v1.1.0 when https://github.com/edx/xblock-utils/pull/48 merged and tagged
-git+https://github.com/edx-solutions/xblock-utils.git@ba54084a572a618b9248236403c1200f32d4f889#egg=xblock-utils==1.1.0
+git+https://github.com/edx/xblock-utils.git@v1.1.0#egg=xblock-utils==1.1.0
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5


### PR DESCRIPTION
Cleanup only; no new functionality introduced.

Removes dependencies on temporary branches introduced by https://github.com/edx-solutions/edx-platform/pull/1032.

**JIRA tickets**: [MCKIN-7023](https://edx-wiki.atlassian.net/browse/MCKIN-7023)

**Testing instructions**:

Same as https://github.com/edx-solutions/edx-platform/pull/1032

**Author notes and concerns**:

1. We are waiting for https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 to merge before the [drag-and-drop-v2-new](https://github.com/edx-solutions/edx-platform/blob/5ab79a82767268ac2583055b03081518f550aba5/requirements/edx/custom.txt#L9) revision can be updated too.

**Reviewers**
- [ ] @mtyaka 