### PR TITLE
SSO discovery revisited

### DIFF
--- a/common/djangoapps/third_party_auth/api/urls.py
+++ b/common/djangoapps/third_party_auth/api/urls.py
@@ -3,14 +3,13 @@
 from django.conf import settings
 from django.conf.urls import patterns, url
 
-from .views import ProviderView, UserMappingView, UserView
+from .views import UserMappingView, UserView
 
 
 PROVIDER_PATTERN = r'(?P<provider_id>[\w.+-]+)(?:\:(?P<idp_slug>[\w.+-]+))?'
 
 urlpatterns = patterns(
     '',
-    url(r'^v0/users/(?P<identifier>[^/]+)/providers/$', ProviderView.as_view(), name='third_party_auth_providers_api'),
     url(
         r'^v0/users/{username_pattern}$'.format(username_pattern=settings.USERNAME_PATTERN),
         UserView.as_view(),

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -763,6 +763,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     # when SSO is enabled via SCORM shell we need allow frames from SCORM cloud
     THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL = ENV_TOKENS.get('THIRD_PARTY_AUTH_FRAME_ALLOWED_FROM_URL')
 
+    # Whether to allow unprivileged users to discover SSO providers for arbitrary usernames.
+    ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY = ENV_TOKENS.get('ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY', False)
+
 ##### OAUTH2 Provider ##############
 if FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
     OAUTH_OIDC_ISSUER = ENV_TOKENS['OAUTH_OIDC_ISSUER']


### PR DESCRIPTION
Make SSO provider discovery use the same endpoint as the existing request.  Gate unprivileged rquests with a setting.  Revises work done in #1047.


**JIRA tickets**: Fixes OC-4285

**Discussions**: See OC-4285

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ?

**Testing instructions**:

1. Set up a user (username1) with TPA providers. 
2. Enable the ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY setting in lms.env.json.
2. Log in as some other user (username2)
3. Request /api/third_party_auth/v0/users/username1
4. See that the providers were returned, but that remote_id was excluded from the response.

**Author notes and concerns**:

1. This removes the ability to query by email, since that wasn't part of the old endpoint.  It could be added back.
2. It also changes the response format, to match the existing endpoint.

**Reviewers**
- [ ] @xitij2000 

FYI: @bradenmacdonald 

**Settings**
```yaml
ALLOW_UNPRIVILEGED_SSO_PROVIDER_QUERY: true
```