### PR TITLE
[MCKIN-5151] Bump xblock-eoc-journal.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -16,7 +16,7 @@
 -e git+https://github.com/open-craft/problem-builder.git@v2.9.3#egg=xblock-problem-builder==2.9.3
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2#egg=xblock-chat==0.2
--e git+https://github.com/open-craft/xblock-eoc-journal.git@e1495e855a27514971ca08d87d1a7a2735cd3e31#egg=xblock-eoc-journal
+-e git+https://github.com/open-craft/xblock-eoc-journal.git@da43d156270bf47d19c38f06d3be1f66178c19e7#egg=xblock-eoc-journal
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@v2.0.11#egg=xblock-scorm==2.0.11
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.3#egg=xblock-diagnostic-feedback==0.2.3
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.7#egg=xblock-group-project-v2==0.4.7


### PR DESCRIPTION
The new version includes ability to export student's own answers to freeform questions in PDF form, implemented in https://github.com/open-craft/xblock-eoc-journal/pull/12.