### PR TITLE
add ooyala player support to problem builder

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,8 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@v1.5.0#egg=xblock-poll==1.5.0
 -e git+https://github.com/edx/edx-notifications.git@0.6.5#egg=edx-notifications==0.6.5
--e git+https://github.com/open-craft/problem-builder.git@v2.9.3#egg=xblock-problem-builder==2.9.3
+# We are changing problem-builder hash for testing purposes in integration branch, do not take to other environments.
+-e git+https://github.com/msaqib52/problem-builder.git@mckin-7282#egg=xblock-problem-builder==7282
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2#egg=xblock-chat==0.2
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@e1495e855a27514971ca08d87d1a7a2735cd3e31#egg=xblock-eoc-journal


### PR DESCRIPTION
This PR adds ooyala player support to problem builder.
Note: We are changing problem-builder hash for testing purposes in integration branch, do not push this change to other environments.

@naeem91 please review