### PR TITLE
Backport completion event handling.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -29,4 +29,4 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-git+https://github.com/open-craft/openedx-completion-aggregator@cliff/ginkgo-compat#egg=openedx-completion-aggregator==0.1.1
+openedx-completion-aggregator==1.0


### PR DESCRIPTION
This backport brings in the code that handles creating BlockCompletion objects when the following xblock events are published:

1. "grade"  -- scorable blocks are now be completed when an answer is submitted.
2. "completion" -- This is new, and the preferred way for non-scorable blocks to be completed.
3. "progress" -- Legacy mckinsey blocks that still use the progress system will be completed when they submit one of these events.

**JIRA tickets**: Implements OC-4475 (no MCKIN ticket that I know of).

**Discussions**: N/A

**Dependencies**: OC-4474, still in review, but this branch is based on that one.

**Screenshots**: N/A

**Merge deadline**: None

**Testing instructions**:

On a ginkgo solutions devstack:

1. Update installed prereqs.
1. Enable completion tracking waffle flag.
2. Log into a course, and complete a few blocks.  Particularly, this should work with ooyala and scorable blocks.  There's still some work that needs to be done to enable completable-by-viewing blocks (HTML blocks, for instance).
3. Verify that BlockCompletions are created. 
4. Verify that Aggregators are completed from those BlockCompletions.

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @pomegranited 


**Settings**
Enable completion.enable_completion_waffle switch.
