### PR TITLE
Add completion mode for discussion block and module.

### DIFF
--- a/common/lib/xmodule/xmodule/discussion_module.py
+++ b/common/lib/xmodule/xmodule/discussion_module.py
@@ -1,16 +1,21 @@
 from pkg_resources import resource_string
-
-from xmodule.x_module import XModule
-from xmodule.raw_module import RawDescriptor
-from xmodule.editing_module import MetadataOnlyEditingDescriptor
-from xblock.fields import String, Scope, UNIQUE_ID
 from uuid import uuid4
+
+from xblock.completable import XBlockCompletionMode
+from xblock.fields import String, Scope, UNIQUE_ID
+
+from xmodule.editing_module import MetadataOnlyEditingDescriptor
+from xmodule.raw_module import RawDescriptor
+from xmodule.x_module import XModule
 
 # Make '_' a no-op so we can scrape strings
 _ = lambda text: text
 
 
 class DiscussionFields(object):
+
+    completion_mode = XBlockCompletionMode.EXCLUDED
+
     discussion_id = String(
         display_name=_("Discussion Id"),
         help=_("The id is a unique identifier for the discussion. It is non editable."),

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -11,6 +11,7 @@ from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xmodule.raw_module import RawDescriptor
 
+from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Scope, String, UNIQUE_ID
 from xblock.fragment import Fragment
@@ -36,6 +37,9 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):
     """
     Provides a discussion forum that is inline with other content in the courseware.
     """
+
+    completion_mode = XBlockCompletionMode.EXCLUDED
+
     discussion_id = String(scope=Scope.settings, default=UNIQUE_ID)
     display_name = String(
         display_name=_("Display Name"),


### PR DESCRIPTION
Adds completion_mode to discussion xblock and discussion module.

**JIRA tickets**: Implements OC-4521

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

1. Enable completion.enable_completion_tracking waffle switch.
2. Verify that interacting with a discussion block does not result in a created BlockCompletion object.
3. Verify that discussion blocks are not considered when calculating total available completions for a given aggregator.

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @pomegranited 


**Settings**
N/A