### PR TITLE
MCKIN-7601 Bump version of xblock-drag-and-drop-v2 to include native API changes

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.1#egg=xblock-image-explorer==1.0.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@4cc813c02b1fe259d3da7192f706a6fce5548d3a#egg=xblock-drag-and-drop-v2==2.1.7
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@a35f8bfb1315522c3a9d3786d94673d06ebfff3b#egg=xblock-drag-and-drop-v2==2.2.0
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new


### PR DESCRIPTION
Bumps version of xblock-drag-and-drop-v2 to include changes from https://github.com/edx-solutions/xblock-drag-and-drop-v2/commit/a35f8bfb1315522c3a9d3786d94673d06ebfff3b