### PR TITLE
Bump version of group project v2

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -19,7 +19,7 @@
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@bd1de6c0c426fff13b09893ef1bfd04b0cc741be#egg=xblock-eoc-journal
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@v2.0.11#egg=xblock-scorm==2.0.11
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
--e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.7#egg=xblock-group-project-v2==0.4.7
+-e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.9#egg=xblock-group-project-v2==0.4.9
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.1#egg=xblock-virtualreality==0.1.1
 git+https://github.com/edx-solutions/api-integration.git@v1.8.4#egg=api-integration==1.8.4
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.1#egg=organizations-edx-platform-extensions==1.2.1


### PR DESCRIPTION
Bumps version of the Group Project v2 XBlock to include bugfix in https://github.com/open-craft/xblock-group-project-v2/pull/121. 