### PR TITLE
[MCKIN-8112] Integrate the openedx-user-manager-api into Ginkgo 

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2262,6 +2262,9 @@ INSTALLED_APPS = (
     # Completion
     'completion',
     'completion_aggregator',
+
+    # User Manager API
+    'user_manager',
 )
 
 ######################### CSRF #########################################

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -144,6 +144,12 @@ urlpatterns += (
     url(r'^api/completion-aggregator/', include('completion_aggregator.urls')),
 )
 
+# USER MANAGER API
+urlpatterns += (
+    url(r'^api/user_manager/', include('user_manager.api.urls', namespace='user-manager-api')),
+)
+
+
 # OPEN EDX USER API
 # mattdrayer: Please note that the user_api declaration must follow
 # the server api declaration.  When declared ahead of the server api

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,3 +30,4 @@ git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#e
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
 openedx-completion-aggregator==1.1
+git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.0#egg=openedx-user-manager-api==1.0.0


### PR DESCRIPTION
Adds the [`openedx-user-manager-api`](https://github.com/mckinseyacademy/openedx-user-manager-api) as an installed django application, and loads its URL endpoints.

**JIRA tickets**: MCKIN-8112

**Dependencies**:
* https://github.com/mckinseyacademy/openedx-user-manager-api/pull/2

**Screenshots**:

![user manager api](https://user-images.githubusercontent.com/7556571/43819512-54d27930-9b22-11e8-8259-4f8b0c6e055f.png)

**Testing instructions**:

1. Run migrations.
1.  No CRUD endpoints exist yet for the user manager API, so data needs to be added via the LMS shell, e.g. 
    ```python
    from user_manager.models import UserManagerRole
    from django.contrib.auth import get_user_model
    User = get_user_model()
    honor = User.objects.get(username='honor')
    staff = User.objects.get(username='staff')
    manager_role = UserManagerRole.objects.create(
        user=honor,
        manager_user=staff,
    )
    ```
1. Authenticate to the LMS as any user.
1. Visit the following URLs to view data from the new endpoints:
   http://lms.mcka.local/api/user_manager/v1/managers/

**Author notes and concerns**:

1. After the Hawthorn rebase, simply installing this django plugin app will be
sufficient to integrate it, and so the URL and `INSTALLED_APPS` changes made here can
be reverted.

**Reviewers**
- [ ] @lgp171188 
- [ ] @xitij2000 -- needed for merge