### PR TITLE
YONK-1081: User Identifier is wrong when using name_id for SSO 

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
 social-auth-app-django==1.2.0
-social-auth-core==1.4.0
+social-auth-core==1.7.0
 pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.12


### PR DESCRIPTION
'social-auth-core' version updated from 1.4.0 to 1.7.0