### PR TITLE
Allow overriding aggregator sync/async behavior using ansible vars

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -560,3 +560,13 @@ PARENTAL_CONSENT_AGE_LIMIT = ENV_TOKENS.get(
     'PARENTAL_CONSENT_AGE_LIMIT',
     PARENTAL_CONSENT_AGE_LIMIT
 )
+
+########################## Settings for Completion API #####################
+
+# If using openedx-completion-aggregator, large instances may find that
+# updating the aggregated completion data after each XBlock is completed
+# generates too much database activity. In that case, this should be set
+# to True, and a daily/hourly cron job should be set up to update the
+# completion aggregation data asynchronously using the run_aggregator_service
+# management command.
+COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = ENV_TOKENS.get('COMPLETION_AGGREGATOR_ASYNC_AGGREGATION', False)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1168,3 +1168,13 @@ PARENTAL_CONSENT_AGE_LIMIT = ENV_TOKENS.get(
     'PARENTAL_CONSENT_AGE_LIMIT',
     PARENTAL_CONSENT_AGE_LIMIT
 )
+
+########################## Settings for Completion API #####################
+
+# If using openedx-completion-aggregator, large instances may find that
+# updating the aggregated completion data after each XBlock is completed
+# generates too much database activity. In that case, this should be set
+# to True, and a daily/hourly cron job should be set up to update the
+# completion aggregation data asynchronously using the run_aggregator_service
+# management command.
+COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = ENV_TOKENS.get('COMPLETION_AGGREGATOR_ASYNC_AGGREGATION', False)


### PR DESCRIPTION
Simple PR to allow setting `COMPLETION_AGGREGATOR_ASYNC_AGGREGATION` via ansible.

Todo: submit to upstream platform as well.