### PR TITLE
[MCKIN-8184] Create an API to list course enrollments by course or a list of users

### DIFF
--- a/common/djangoapps/enrollment/forms.py
+++ b/common/djangoapps/enrollment/forms.py
@@ -37,20 +37,3 @@ class CourseEnrollmentsApiListForm(Form):
                 student_forms.validate_username(username)
             return usernames
         return usernames_csv_string
-
-    def clean(self):
-        """
-        Validate if at least one of course_id or username field is present and return the validated data.
-        """
-
-        cleaned_data = super(CourseEnrollmentsApiListForm, self).clean()
-
-        if not self.errors:
-            course_id = cleaned_data.get('course_id')
-            username = cleaned_data.get('username')
-
-            if not course_id and not username:
-                raise ValidationError(
-                    "At least one of 'course_id', 'username' query string parameters is required."
-                )
-        return cleaned_data

--- a/common/djangoapps/enrollment/forms.py
+++ b/common/djangoapps/enrollment/forms.py
@@ -7,7 +7,7 @@ from opaque_keys.edx.keys import CourseKey
 from student import forms as student_forms
 
 
-class CourseEnrollmentsByUsernameOrCourseIDListForm(Form):
+class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsByUsernameOrCourseIDListView.
     """
@@ -43,7 +43,7 @@ class CourseEnrollmentsByUsernameOrCourseIDListForm(Form):
         Validate if at least one of course_id or username field is present and return the validated data.
         """
 
-        cleaned_data = super(CourseEnrollmentsByUsernameOrCourseIDListForm, self).clean()
+        cleaned_data = super(CourseEnrollmentsApiListForm, self).clean()
 
         if not self.errors:
             course_id = cleaned_data.get('course_id')

--- a/common/djangoapps/enrollment/forms.py
+++ b/common/djangoapps/enrollment/forms.py
@@ -1,0 +1,56 @@
+from django.core.exceptions import ValidationError
+from django.forms import CharField, Form
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from student import forms as student_forms
+
+
+class CourseEnrollmentsByUsernameOrCourseIDListForm(Form):
+    """
+    A form that validates the query string parameters for the CourseEnrollmentsByUsernameOrCourseIDListView.
+    """
+    username = CharField(required=False)
+    course_id = CharField(required=False)
+
+    def clean_course_id(self):
+        """
+        Validate and return a course ID.
+        """
+        course_id = self.cleaned_data.get('course_id')
+        if course_id:
+            try:
+                return CourseKey.from_string(course_id)
+            except InvalidKeyError:
+                raise ValidationError("'{}' is not a valid course id.".format(course_id))
+        return course_id
+
+    def clean_username(self):
+        """
+        Validate a string of comma-separated usernames and return a list of usernames.
+        """
+        usernames_csv_string = self.cleaned_data.get('username')
+        if usernames_csv_string:
+            usernames = usernames_csv_string.split(',')
+            for username in usernames:
+                student_forms.validate_username(username)
+            return usernames
+        return usernames_csv_string
+
+    def clean(self):
+        """
+        Validate if at least one of course_id or username field is present and return the validated data.
+        """
+
+        cleaned_data = super(CourseEnrollmentsByUsernameOrCourseIDListForm, self).clean()
+
+        if not self.errors:
+            course_id = cleaned_data.get('course_id')
+            username = cleaned_data.get('username')
+
+            if not course_id and not username:
+                raise ValidationError(
+                    "At least one of 'course_id', 'username' query string parameters is required."
+                )
+        return cleaned_data

--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -82,6 +82,20 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         lookup_field = 'username'
 
 
+class CourseEnrollmentMinimalDataSerializer(CourseEnrollmentSerializer):
+    """
+    Serializes CourseEnrollment model and returns a subset of fields returned
+    by the CourseEnrollmentSerializer.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(CourseEnrollmentMinimalDataSerializer, self).__init__(*args, **kwargs)
+        self.fields.pop('course_details')
+
+    class Meta(CourseEnrollmentSerializer.Meta):
+        fields = CourseEnrollmentSerializer.Meta.fields + ('course_id', )
+
+
 class ModeSerializer(serializers.Serializer):
     """Serializes a course's 'Mode' tuples
 

--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -82,14 +82,14 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
         lookup_field = 'username'
 
 
-class CourseEnrollmentMinimalDataSerializer(CourseEnrollmentSerializer):
+class CourseEnrollmentsApiListSerializer(CourseEnrollmentSerializer):
     """
     Serializes CourseEnrollment model and returns a subset of fields returned
     by the CourseEnrollmentSerializer.
     """
 
     def __init__(self, *args, **kwargs):
-        super(CourseEnrollmentMinimalDataSerializer, self).__init__(*args, **kwargs)
+        super(CourseEnrollmentsApiListSerializer, self).__init__(*args, **kwargs)
         self.fields.pop('course_details')
 
     class Meta(CourseEnrollmentSerializer.Meta):

--- a/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -102,5 +102,40 @@
             }
         ]
 
+    ],
+    [
+        null,
+        [
+            {
+                "course_id": "e/d/X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1"
+            },
+            {
+                "course_id": "e/d/X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "student3"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "staff"
+            }
+        ]
     ]
 ]

--- a/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -1,0 +1,106 @@
+[
+    [
+        {
+            "course_id": "e/d/X"
+        },
+        [
+            {
+                "course_id": "e/d/X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1"
+            },
+            {
+                "course_id": "e/d/X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            }
+        ]
+    ],
+    [
+        {
+            "course_id": "x/y/Z"
+        },
+        [
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "staff"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "student3"
+            }
+        ]
+    ],
+    [
+        {
+            "course_id": "x/y/Z",
+            "username": "student2,student3"
+        },
+        [
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "student3"
+            }
+        ]
+    ],
+    [
+        {
+            "course_id": "x/y/Z",
+            "username": "student1,student2"
+        },
+        [
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            }
+        ]
+    ],
+    [
+        {
+            "username": "student2,staff"
+        },
+        [
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "verified",
+                "user": "staff"
+            },
+            {
+                "course_id": "e/d/X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            },
+            {
+                "course_id": "x/y/Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2"
+            }
+        ]
+
+    ]
+]

--- a/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/common/djangoapps/enrollment/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -8,13 +8,15 @@
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student1"
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
     ],
@@ -27,19 +29,22 @@
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "staff"
+                "user": "staff",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "student3"
+                "user": "student3",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
     ],
@@ -53,13 +58,15 @@
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "student3"
+                "user": "student3",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
     ],
@@ -73,7 +80,8 @@
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
     ],
@@ -86,19 +94,22 @@
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "staff"
+                "user": "staff",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
 
@@ -110,31 +121,36 @@
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student1"
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "student3"
+                "user": "student3",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
-                "user": "student2"
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
-                "user": "staff"
+                "user": "staff",
+                "created": "2018-01-01T00:00:01Z"
             }
         ]
     ]

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1350,11 +1350,6 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         response = self.client.get(self.url, {'course_id': self.course.id})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_missing_required_query_string_parameters(self):
-        self._login_as_staff()
-        content = self._assert_list_of_enrollments(expected_status=status.HTTP_400_BAD_REQUEST)
-        self.assertIn('developer_message', content)
-
     @ddt.data(
         ({'course_id': '1'}, ['course_id', ]),
         ({'course_id': '1', 'username': 'staff'}, ['course_id', ]),

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1393,10 +1393,5 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         self._login_as_staff()
         content = self._assert_list_of_enrollments(query_params, status.HTTP_200_OK)
         results = content['results']
-        self.assertEqual(len(results), len(expected_results))
-
-        expected_fields = ('course_id', 'user', 'mode', 'created', 'is_active')
-        for item in content['results']:
-            self.assertTrue(any(field in item for field in expected_fields))
 
         self.assertItemsEqual(results, expected_results)

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 from course_modes.models import CourseMode
-from enrollment import api
+from enrollment import api, data
 from enrollment.errors import CourseEnrollmentError
 from enrollment.views import EnrollmentUserThrottle
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -1240,3 +1240,164 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
             HTTP_REFERER=self.REFERER,
             HTTP_X_CSRFTOKEN=csrf_cookie
         )
+
+
+@attr(shard=3)
+@ddt.ddt
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class CourseEnrollmentsByUsernameOrCourseIDListTest(APITestCase, ModuleStoreTestCase):
+    """
+    Test the course enrollments by username or course id endpoint.
+    """
+    def setUp(self):
+        super(CourseEnrollmentsByUsernameOrCourseIDListTest, self).setUp()
+        self.rate_limit_config = RateLimitConfiguration.current()
+        self.rate_limit_config.enabled = False
+        self.rate_limit_config.save()
+
+        throttle = EnrollmentUserThrottle()
+        self.rate_limit, __ = throttle.parse_rate(throttle.rate)
+
+        self.course = CourseFactory.create(org='e', number='d', run='X', emit_signals=True)
+        self.course2 = CourseFactory.create(org='x', number='y', run='Z', emit_signal=True)
+
+        for mode_slug in ('honor', 'verified', 'audit'):
+            CourseModeFactory.create(
+                course_id=self.course.id,
+                mode_slug=mode_slug,
+                mode_display_name=mode_slug
+            )
+
+        self.staff_user = AdminFactory(
+            username='staff',
+            email='staff@example.com',
+            password='edx'
+        )
+
+        self.student1 = UserFactory(
+            username='student1',
+            email='student1@example.com',
+            password='edx'
+        )
+
+        self.student2 = UserFactory(
+            username='student2',
+            email='student2@example.com',
+            password='edx'
+        )
+
+        self.student3 = UserFactory(
+            username='student3',
+            email='student3@example.com',
+            password='edx'
+        )
+
+        data.create_course_enrollment(
+            self.student1.username,
+            unicode(self.course.id),
+            'honor',
+            True
+        )
+        data.create_course_enrollment(
+            self.student2.username,
+            unicode(self.course.id),
+            'honor',
+            True
+        )
+        data.create_course_enrollment(
+            self.student3.username,
+            unicode(self.course2.id),
+            'verified',
+            True
+        )
+        data.create_course_enrollment(
+            self.student2.username,
+            unicode(self.course2.id),
+            'honor',
+            True
+        )
+        data.create_course_enrollment(
+            self.staff_user.username,
+            unicode(self.course2.id),
+            'verified',
+            True
+        )
+        self.url = reverse('courseenrollmentsbyusernameorcourseid')
+
+    def _login_as_staff(self):
+        self.client.login(username=self.staff_user.username, password='edx')
+
+    def _make_request(self, query_params=None):
+        return self.client.get(self.url, query_params)
+
+    def _assert_list_of_enrollments(self, query_params=None, expected_status=status.HTTP_200_OK, error_fields=None):
+        response = self._make_request(query_params)
+        self.assertEqual(response.status_code, expected_status)
+        content = json.loads(response.content)
+        if error_fields is not None:
+            self.assertIn('field_errors', content)
+            for error_field in error_fields:
+                self.assertIn(error_field, content['field_errors'])
+        return content
+
+    def test_user_not_authenticated(self):
+        self.client.logout()
+        response = self.client.get(self.url, {'course_id': self.course.id})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_user_not_authorized(self):
+        self.client.login(username=self.student1.username, password='edx')
+        response = self.client.get(self.url, {'course_id': self.course.id})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_required_query_string_parameters(self):
+        self._login_as_staff()
+        content = self._assert_list_of_enrollments(expected_status=status.HTTP_400_BAD_REQUEST)
+        self.assertIn('developer_message', content)
+
+    @ddt.data(
+        ({'course_id': '1'}, status.HTTP_400_BAD_REQUEST, ['course_id', ]),
+        ({'course_id': '1', 'username': 'staff'}, status.HTTP_400_BAD_REQUEST, ['course_id', ]),
+        ({'username': '1*2'}, status.HTTP_400_BAD_REQUEST, ['username', ]),
+        ({'username': '1*2', 'course_id': 'org.0/course_0/Run_0'}, status.HTTP_400_BAD_REQUEST, ['username', ]),
+        ({'username': '1*2', 'course_id': '1'}, status.HTTP_400_BAD_REQUEST, ['username', 'course_id'])
+    )
+    @ddt.unpack
+    def test_query_string_parameters_invalid_errors(self, query_params, expected_status, error_fields):
+        self._login_as_staff()
+        self._assert_list_of_enrollments(query_params, expected_status, error_fields)
+
+    @ddt.data(
+        # Non-existent user
+        ({'username': 'nobody'}, status.HTTP_200_OK),
+        ({'username': 'nobody', 'course_id': 'e/d/X'}, status.HTTP_200_OK),
+
+        # Non-existent course
+        ({'course_id': 'a/b/c'}, status.HTTP_200_OK),
+        ({'course_id': 'a/b/c', 'username': 'student1'}, status.HTTP_200_OK),
+
+        # Non-existent course and user
+        ({'course_id': 'a/b/c', 'username': 'dummy'}, status.HTTP_200_OK)
+    )
+    @ddt.unpack
+    def test_non_existent_course_user(self, query_params, expected_status):
+        self._login_as_staff()
+        content = self._assert_list_of_enrollments(query_params, expected_status)
+        self.assertEqual(len(content['results']), 0)
+
+    @ddt.data(
+        ({'course_id': 'e/d/X'}, status.HTTP_200_OK, 2),
+        ({'course_id': 'x/y/Z'}, status.HTTP_200_OK, 3),
+        ({'course_id': 'x/y/Z', 'username': 'student2,student3'}, status.HTTP_200_OK, 2),
+        ({'course_id': 'x/y/Z', 'username': 'student1,student2'}, status.HTTP_200_OK, 1),
+        ({'username': 'student2,staff'}, status.HTTP_200_OK, 3)
+    )
+    @ddt.unpack
+    def test_response_valid_queries(self, query_params, expected_status, num_results):
+        self._login_as_staff()
+        content = self._assert_list_of_enrollments(query_params, expected_status)
+        self.assertEqual(len(content['results']), num_results)
+
+        expected_fields = ('course_id', 'user', 'mode', 'created', 'is_active')
+        for item in content['results']:
+            self.assertTrue(any(field in item for field in expected_fields))

--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.conf.urls import patterns, url
 
 from .views import (
-    CourseEnrollmentsByUsernameOrCourseIDListView,
+    CourseEnrollmentsApiListView,
     EnrollmentCourseDetailView,
     EnrollmentListView,
     EnrollmentView,
@@ -28,8 +28,8 @@ urlpatterns = patterns(
     ),
     url(
         r'^enrollments/?$',
-        CourseEnrollmentsByUsernameOrCourseIDListView.as_view(),
-        name='courseenrollmentsbyusernameorcourseid'
+        CourseEnrollmentsApiListView.as_view(),
+        name='courseenrollmentsapilist'
     ),
     url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
     url(

--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -5,7 +5,12 @@ URLs for the Enrollment API
 from django.conf import settings
 from django.conf.urls import patterns, url
 
-from .views import EnrollmentCourseDetailView, EnrollmentListView, EnrollmentView
+from .views import (
+    CourseEnrollmentsByUsernameOrCourseIDListView,
+    EnrollmentCourseDetailView,
+    EnrollmentListView,
+    EnrollmentView,
+)
 
 urlpatterns = patterns(
     'enrollment.views',
@@ -20,6 +25,11 @@ urlpatterns = patterns(
         r'^enrollment/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentView.as_view(),
         name='courseenrollment'
+    ),
+    url(
+        r'^enrollments/?$',
+        CourseEnrollmentsByUsernameOrCourseIDListView.as_view(),
+        name='courseenrollmentsbyusernameorcourseid'
     ),
     url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
     url(

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -772,7 +772,7 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
 
             If the user is not logged in, a 401 error is returned.
 
-            If the user is not course or global staff, a 403 error is returned.
+            If the user is not global staff, a 403 error is returned.
 
             If the specified course_id is not valid or any of the specified usernames
             are not valid, a 400 error is returned.

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -5,19 +5,25 @@ consist primarily of authentication, request validation, and serialization.
 """
 import logging
 
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.decorators import method_decorator
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
+from rest_framework_oauth.authentication import OAuth2Authentication
 
 from course_modes.models import CourseMode
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError
+from enrollment.forms import CourseEnrollmentsByUsernameOrCourseIDListForm
+from enrollment.serializers import CourseEnrollmentMinimalDataSerializer
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.embargo import api as embargo_api
@@ -26,12 +32,13 @@ from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
 )
+from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
 from openedx.features.enterprise_support.api import EnterpriseApiClient, EnterpriseApiException, enterprise_enabled
 from student.auth import user_has_role
-from student.models import User
+from student.models import User, CourseEnrollment
 from student.roles import CourseStaffRole, GlobalStaff
 from util.disable_rate_limit import can_disable_rate_limit
 
@@ -700,3 +707,102 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                     actual_activation=current_enrollment['is_active'] if current_enrollment else None,
                     user_id=user.id
                 )
+
+
+@can_disable_rate_limit
+class CourseEnrollmentsByUsernameOrCourseIDListView(DeveloperErrorViewMixin, ListAPIView, ApiKeyPermissionMixIn):
+    """
+        **Use Cases**
+
+            Get a list of all course enrollments given a course ID or list of usernames.
+
+        **Example Requests**
+
+            GET /api/enrollment/v1/enrollments?course_id={course_id}
+
+            GET /api/enrollment/v1/enrollments?username={username},{username},{username}
+
+            GET /api/enrollment/v1/enrollments?course_id={course_id}&username={username}
+
+        **Query Parameters for GET**
+
+            * course_id: Filters the result to course enrollments for the course corresponding to the
+              given course ID. The value must be URL encoded. Optional. Required if the 'username' parameter
+              is omitted.
+
+            * username: List of comma-separated usernames. Filters the result to the course enrollments
+              of the given users. Optional. Required if the 'course_id' parameter is omitted.
+
+            * page_size: Number of results to return per page.
+
+            * page: Page number to retrieve.
+
+        **Response Values**
+
+            If the request for information about the course enrollments is successful, an HTTP 200 "OK" response
+            is returned.
+
+            The HTTP 200 response has the following values.
+
+            * count: The number of course enrollments matching the request.
+
+            * num_pages: The total number of pages in the result.
+
+            * current_page: The current page number.
+
+            * results: A list of the course enrollments matching the request.
+
+                * created: Date and time when the course enrollment was created.
+
+                * mode: Mode for the course enrollment.
+
+                * is_active: Whether the course enrollment is active or not.
+
+                * user: Username of the user in the course enrollment.
+
+                * course_id: Course ID of the course in the course enrollment.
+
+            * next: The URL to the next page of results, or null if this is the
+              last page.
+
+            * start: The list index of the first item in the response.
+
+            * previous: The URL to the next page of results, or null if this
+              is the first page.
+
+            If the user is not logged in, a 401 error is returned.
+
+            If the user is not course or global staff, a 403 error is returned.
+
+            If the specified course_id is not valid or any of the specified usernames
+            are not valid, a 400 error is returned.
+
+            If the specified course_id does not correspond to a valid course or if all the specified
+            usernames do not correspond to valid users, an HTTP 200 "OK" response is returned with an
+            empty 'results' field.
+    """
+    authentication_classes = (JwtAuthentication, OAuth2Authentication,
+                              SessionAuthentication,)
+    permission_classes = IsAdminUser,
+    throttle_classes = EnrollmentUserThrottle,
+    serializer_class = CourseEnrollmentMinimalDataSerializer
+
+    def get_queryset(self):
+        """
+        Get all the course enrollments for the given course_id and/or given list of usernames.
+        """
+        form = CourseEnrollmentsByUsernameOrCourseIDListForm(self.request.query_params)
+
+        if not form.is_valid():
+            raise ValidationError(form.errors)
+
+        qset = CourseEnrollment.objects.all()
+        course_id = form.cleaned_data.get('course_id')
+        usernames = form.cleaned_data.get('username')
+
+        if course_id:
+            qset = qset.filter(course_id=course_id)
+        if usernames:
+            qset = qset.filter(user__username__in=form.cleaned_data['username'])
+
+        return qset

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -11,13 +11,11 @@ from edx_rest_framework_extensions.authentication import JwtAuthentication
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
-from rest_framework_oauth.authentication import OAuth2Authentication
 
 from course_modes.models import CourseMode
 from enrollment import api
@@ -781,8 +779,11 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
             usernames do not correspond to valid users, an HTTP 200 "OK" response is returned with an
             empty 'results' field.
     """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication,
-                              SessionAuthentication,)
+    authentication_classes = (
+        JwtAuthentication,
+        OAuth2AuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
     permission_classes = IsAdminUser,
     throttle_classes = EnrollmentUserThrottle,
     serializer_class = CourseEnrollmentsApiListSerializer


### PR DESCRIPTION
Creates an enrollment API endpoint to list course enrollments by course or a list of users. 

**Testing instructions**
* Create some test courses and users.
* Enroll some users at random into the created courses.
* Create a staff user (`is_staff` set to `True`).
* Login as the staff user.
* The endpoint is `/api/enrollment/v1/enrollments` with at least of one `course_id`, `username` query string parameters required. The `course_id` field accepts a single URL-encoded course ID and the `username` field accepts a string containing comma-separated usernames, URL encoded if necessary. Refer to the [view docstring](https://github.com/open-craft/edx-platform/blob/MCKIN-8184-api-to-return-list-of-course-enrollments-by-course-or-users/common/djangoapps/enrollment/views.py#L713) for more details.
* Test and verify the endpoint using the following example requests
```
GET /api/enrollment/v1/enrollments?course_id={course_id}

GET /api/enrollment/v1/enrollments?username={username},{username},{username}

GET /api/enrollment/v1/enrollments?course_id={course_id}&username={username}
```

**Reviewers**
- [ ] @pomegranited
- [ ] @xitij2000 