### PR TITLE
[MCKIN-8184] Create an API to list course enrollments by course or a list of users

### DIFF
--- a/common/djangoapps/enrollment/forms.py
+++ b/common/djangoapps/enrollment/forms.py
@@ -1,3 +1,6 @@
+"""
+Forms for validating user input to the Course Enrollment related views.
+"""
 from django.core.exceptions import ValidationError
 from django.forms import CharField, Form
 
@@ -11,6 +14,7 @@ class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsApiListView.
     """
+    MAX_USERNAME_COUNT = 100
     username = CharField(required=False)
     course_id = CharField(required=False)
 
@@ -33,6 +37,13 @@ class CourseEnrollmentsApiListForm(Form):
         usernames_csv_string = self.cleaned_data.get('username')
         if usernames_csv_string:
             usernames = usernames_csv_string.split(',')
+            if len(usernames) > self.MAX_USERNAME_COUNT:
+                raise ValidationError(
+                    "Too many usernames in a single request - {}. A maximum of {} is allowed".format(
+                        len(usernames),
+                        self.MAX_USERNAME_COUNT,
+                    )
+                )
             for username in usernames:
                 student_forms.validate_username(username)
             return usernames

--- a/common/djangoapps/enrollment/forms.py
+++ b/common/djangoapps/enrollment/forms.py
@@ -14,7 +14,7 @@ class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsApiListView.
     """
-    MAX_USERNAME_COUNT = 100
+    MAX_USERNAME_COUNT = 200
     username = CharField(required=False)
     course_id = CharField(required=False)
 

--- a/common/djangoapps/enrollment/paginators.py
+++ b/common/djangoapps/enrollment/paginators.py
@@ -1,0 +1,11 @@
+"""
+Paginators for the course enrollment related views.
+"""
+from rest_framework.pagination import CursorPagination
+
+
+class CourseEnrollmentsApiListPagination(CursorPagination):
+    """
+    Paginator for the Course enrollments list API.
+    """
+    page_size = 100

--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -87,6 +87,7 @@ class CourseEnrollmentsApiListSerializer(CourseEnrollmentSerializer):
     Serializes CourseEnrollment model and returns a subset of fields returned
     by the CourseEnrollmentSerializer.
     """
+    course_id = serializers.CharField(source='course_overview.id')
 
     def __init__(self, *args, **kwargs):
         super(CourseEnrollmentsApiListSerializer, self).__init__(*args, **kwargs)

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1366,7 +1366,7 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         ({'username': '1*2'}, ['username', ]),
         ({'username': '1*2', 'course_id': 'org.0/course_0/Run_0'}, ['username', ]),
         ({'username': '1*2', 'course_id': '1'}, ['username', 'course_id']),
-        ({'username': ','.join(str(x) for x in range(101))}, ['username', ])
+        ({'username': ','.join(str(x) for x in range(201))}, ['username', ])
     )
     @ddt.unpack
     def test_query_string_parameters_invalid_errors(self, query_params, error_fields):

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1243,13 +1243,13 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
         )
 
 
-@attr(shard=3)
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
     """
     Test the course enrollments api list endpoint.
     """
+    shard = 3
     CREATED_DATA = datetime.datetime(2018, 1, 1, 0, 0, 1, tzinfo=pytz.UTC)
 
     def setUp(self):
@@ -1329,12 +1329,18 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         self.url = reverse('courseenrollmentsapilist')
 
     def _login_as_staff(self):
+        """Login as the staff user."""
         self.client.login(username=self.staff_user.username, password='edx')
 
     def _make_request(self, query_params=None):
+        """Make a request to the course enrollments list endpoint."""
         return self.client.get(self.url, query_params)
 
     def _assert_list_of_enrollments(self, query_params=None, expected_status=status.HTTP_200_OK, error_fields=None):
+        """
+        Make a request to the CourseEnrolllmentApiList endpoint and run assertions on the response
+        using the optional parameters 'query_params', 'expected_status' and 'error_fields'.
+        """
         response = self._make_request(query_params)
         self.assertEqual(response.status_code, expected_status)
         content = json.loads(response.content)
@@ -1359,7 +1365,8 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         ({'course_id': '1', 'username': 'staff'}, ['course_id', ]),
         ({'username': '1*2'}, ['username', ]),
         ({'username': '1*2', 'course_id': 'org.0/course_0/Run_0'}, ['username', ]),
-        ({'username': '1*2', 'course_id': '1'}, ['username', 'course_id'])
+        ({'username': '1*2', 'course_id': '1'}, ['username', 'course_id']),
+        ({'username': ','.join(str(x) for x in range(101))}, ['username', ])
     )
     @ddt.unpack
     def test_query_string_parameters_invalid_errors(self, query_params, error_fields):

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -21,6 +21,7 @@ from course_modes.models import CourseMode
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError
 from enrollment.forms import CourseEnrollmentsApiListForm
+from enrollment.paginators import CourseEnrollmentsApiListPagination
 from enrollment.serializers import CourseEnrollmentsApiListSerializer
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
@@ -36,7 +37,7 @@ from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
 from openedx.features.enterprise_support.api import EnterpriseApiClient, EnterpriseApiException, enterprise_enabled
 from student.auth import user_has_role
-from student.models import User, CourseEnrollment
+from student.models import CourseEnrollment, User
 from student.roles import CourseStaffRole, GlobalStaff
 from util.disable_rate_limit import can_disable_rate_limit
 
@@ -743,12 +744,6 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
 
             The HTTP 200 response has the following values.
 
-            * count: The number of course enrollments matching the request.
-
-            * num_pages: The total number of pages in the result.
-
-            * current_page: The current page number.
-
             * results: A list of the course enrollments matching the request.
 
                 * created: Date and time when the course enrollment was created.
@@ -763,8 +758,6 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
 
             * next: The URL to the next page of results, or null if this is the
               last page.
-
-            * start: The list index of the first item in the response.
 
             * previous: The URL to the next page of results, or null if this
               is the first page.
@@ -785,9 +778,10 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         OAuth2AuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    permission_classes = IsAdminUser,
-    throttle_classes = EnrollmentUserThrottle,
+    permission_classes = (IsAdminUser, )
+    throttle_classes = (EnrollmentUserThrottle, )
     serializer_class = CourseEnrollmentsApiListSerializer
+    pagination_class = CourseEnrollmentsApiListPagination
 
     def get_queryset(self):
         """


### PR DESCRIPTION
**Note: this is a follow-up PR to address the [upstream review comments](https://github.com/edx/edx-platform/pull/18838#issuecomment-417675018) for the changes introduced in https://github.com/edx-solutions/edx-platform/pull/1142.**

Creates an enrollment API endpoint to list course enrollments, optionally filtered by course or a list of users. 

**Testing instructions**
* Create some test courses and users.
* Enroll some users at random into the created courses.
* Create a staff user (`is_staff` set to `True`).
* Login as the staff user.
* The endpoint is `/api/enrollment/v1/enrollments` with `course_id`, `username` as optional query string parameters. The `course_id` field accepts a single URL-encoded course ID and the `username` field accepts a string containing comma-separated usernames, URL encoded if necessary. Refer to the [view docstring](https://github.com/open-craft/edx-platform/blob/MCKIN-8184-api-to-return-list-of-course-enrollments-by-course-or-users/common/djangoapps/enrollment/views.py#L713) for more details.
* Test and verify the endpoint using the following example requests.
* The endpoint uses the DRF `CursorPagination` paginator to implement a cursor-based pagination.
```
GET /api/enrollment/v1/enrollments

GET /api/enrollment/v1/enrollments?course_id={course_id}

GET /api/enrollment/v1/enrollments?username={username},{username},{username}

GET /api/enrollment/v1/enrollments?course_id={course_id}&username={username}
```

**Reviewers**
- [ ] @pomegranited 