### PR TITLE
dir tag added in xblock webview template 

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -73,7 +73,7 @@ ${HTML(fragment.foot_html())}
 
 </%block>
 
-<div class="course-wrapper chromeless">
+<div dir="${static.dir_rtl()}" class="course-wrapper chromeless">
         <section class="course-content" id="course-content" \
         % if enable_completion_on_view_service:
           data-enable-completion-on-view-service="true" \


### PR DESCRIPTION
Mcka ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8414

dir tag is missing in this page's body which causes discrepancies in Xblocks webviews for rtl languages. 