### PR TITLE
Version bump openedx-completion-aggregator to 1.4

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.3.1
+openedx-completion-aggregator==1.4
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Bump completion aggregator to 1.4 to stop returning null for percent value.

**JIRA tickets**: [BEBOP-316](https://tasks.opencraft.com/browse/BEBOP-316)

**Discussions**: 

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. Version is bumped
2. aggregator returns 0% for courses not started.

**Author notes and concerns**:

**Reviewers**
- [ ] @xitij2000 

**Settings**
