### PR TITLE
Version bump aggregator MCKIN-8099

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.2
+
+openedx-completion-aggregator==1.5.3
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump PR for open-craft/openedx-completion-aggregator#32  

Configures aggregator to have django admin pages.  

* Design takes into account performance considerations for large relationships: No select box for user model.

**JIRA tickets**: Assists with MCKIN-8099

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: Sooner the better, but not critical.

**Testing instructions**:

Version bump.  See related PR, above.

**Author notes and concerns**:  N/A

**Reviewers**
- [x] @viadanna ?


**Settings**
