### PR TITLE
[MCKIN-8524] Implement an alternative discussion settings, roles management API

### DIFF
--- a/lms/djangoapps/discussion_api/forms.py
+++ b/lms/djangoapps/discussion_api/forms.py
@@ -1,10 +1,16 @@
 """
 Discussion API forms
 """
+import urllib
+
 from django.core.exceptions import ValidationError
 from django.forms import BooleanField, CharField, ChoiceField, Form, IntegerField
 from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
+
+from courseware.courses import get_course_with_access
+from django_comment_common.models import Role, FORUM_ROLE_MODERATOR, FORUM_ROLE_COMMUNITY_TA
 
 from openedx.core.djangoapps.util.forms import ExtendedNullBooleanField, MultiValueField
 
@@ -119,3 +125,52 @@ class CommentGetForm(_PaginationForm):
     A form to validate query parameters in the comment retrieval endpoint
     """
     requested_fields = MultiValueField(required=False)
+
+
+class CourseDiscussionSettingsForm(Form):
+    """
+    A form to validate the fields in the course discussion settings requests.
+    """
+    course_id = CharField()
+
+    def __init__(self, *args, **kwargs):
+        self.request_user = kwargs.pop('request_user')
+        super(CourseDiscussionSettingsForm, self).__init__(*args, **kwargs)
+
+    def clean_course_id(self):
+        """Validate the 'course_id' value"""
+        course_id = self.cleaned_data['course_id']
+        try:
+            course_key = CourseKey.from_string(course_id)
+            self.cleaned_data['course'] = get_course_with_access(self.request_user, 'staff', course_key)
+            self.cleaned_data['course_key'] = course_key
+            return course_id
+        except InvalidKeyError:
+            raise ValidationError("'{}' is not a valid course key".format(unicode(course_id)))
+
+
+class CourseDiscussionRolesForm(CourseDiscussionSettingsForm):
+    """
+    A form to validate the fields in the course discussion roles requests.
+    """
+    ROLE_CHOICES = (
+        (FORUM_ROLE_MODERATOR, FORUM_ROLE_MODERATOR),
+        (FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR),
+    )
+    rolename = ChoiceField(
+        ROLE_CHOICES,
+        error_messages={"invalid_choice": "Role '%(value)s' does not exist"}
+    )
+
+    def clean_rolename(self):
+        """Validate the 'rolename' value."""
+        rolename = urllib.unquote(self.cleaned_data.get('rolename'))
+        course_id = self.cleaned_data.get('course_key')
+        if course_id and rolename:
+            try:
+                role = Role.objects.get(name=rolename, course_id=course_id)
+            except Role.DoesNotExist:
+                raise ValidationError("Role '{}' does not exist".format(rolename))
+
+            self.cleaned_data['role'] = role
+            return rolename

--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -9,16 +9,23 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from rest_framework import serializers
 
+from discussion.views import get_divided_discussions
 from discussion_api.permissions import NON_UPDATABLE_COMMENT_FIELDS, NON_UPDATABLE_THREAD_FIELDS, get_editable_fields
 from discussion_api.render import render_body
-from django_comment_client.utils import is_comment_too_deep
-from django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_COMMUNITY_TA, FORUM_ROLE_MODERATOR, Role
+from django_comment_client.utils import get_group_id_for_user, get_group_name, is_comment_too_deep
+from django_comment_common.models import (
+    FORUM_ROLE_ADMINISTRATOR,
+    FORUM_ROLE_COMMUNITY_TA,
+    FORUM_ROLE_MODERATOR,
+    Role,
+)
 from django_comment_common.utils import get_course_discussion_settings
 from lms.djangoapps.django_comment_client.utils import course_discussion_division_enabled, get_group_names_by_id
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from lms.lib.comment_client.user import User as CommentClientUser
 from lms.lib.comment_client.utils import CommentClientRequestError
+from student.models import get_user_by_username_or_email
 
 
 def get_context(course, request, thread=None):
@@ -430,6 +437,174 @@ class DiscussionTopicSerializer(serializers.Serializer):
         if not obj.children:
             return []
         return [DiscussionTopicSerializer(child).data for child in obj.children]
+
+    def create(self, validated_data):
+        """
+        Overriden create abstract method
+        """
+        pass
+
+    def update(self, instance, validated_data):
+        """
+        Overriden update abstract method
+        """
+        pass
+
+
+class DiscussionSettingsSerializer(serializers.Serializer):
+    """
+    Serializer for course discussion settings.
+    """
+    divided_course_wide_discussions = serializers.ListField(
+        child=serializers.CharField(),
+    )
+    divided_inline_discussions = serializers.ListField(
+        child=serializers.CharField(),
+    )
+    always_divide_inline_discussions = serializers.BooleanField()
+    division_scheme = serializers.CharField()
+
+    def __init__(self, *args, **kwargs):
+        self.course = kwargs.pop('course')
+        self.discussion_settings = kwargs.pop('discussion_settings')
+        super(DiscussionSettingsSerializer, self).__init__(*args, **kwargs)
+
+    def validate(self, attrs):
+        """
+        Validate the fields in combination.
+        """
+        if not any(field in attrs for field in self.fields):
+            raise ValidationError('Bad request')
+
+        settings_to_change = {}
+        divided_course_wide_discussions, divided_inline_discussions = get_divided_discussions(
+            self.course, self.discussion_settings
+        )
+
+        if any(item in attrs for item in ('divided_course_wide_discussions', 'divided_inline_discussions')):
+            divided_course_wide_discussions = attrs.get(
+                'divided_course_wide_discussions',
+                divided_course_wide_discussions
+            )
+            divided_inline_discussions = attrs.get('divided_inline_discussions', divided_inline_discussions)
+            settings_to_change['divided_discussions'] = divided_course_wide_discussions + divided_inline_discussions
+
+        for item in ('always_divide_inline_discussions', 'division_scheme'):
+            if item in attrs:
+                settings_to_change[item] = attrs[item]
+        attrs['settings_to_change'] = settings_to_change
+        return attrs
+
+    def create(self, validated_data):
+        """
+        Overriden create abstract method
+        """
+        pass
+
+    def update(self, instance, validated_data):
+        """
+        Overriden update abstract method
+        """
+        pass
+
+
+class DiscussionRolesSerializer(serializers.Serializer):
+    """
+    Serializer for course discussion roles.
+    """
+
+    ACTION_CHOICES = (
+        ('allow', 'allow'),
+        ('revoke', 'revoke')
+    )
+    action = serializers.ChoiceField(ACTION_CHOICES)
+    user_id = serializers.CharField()
+
+    def __init__(self, *args, **kwargs):
+        super(DiscussionRolesSerializer, self).__init__(*args, **kwargs)
+        self.user = None
+
+    def validate_user_id(self, user_id):
+        try:
+            self.user = get_user_by_username_or_email(user_id)
+            return user_id
+        except DjangoUser.DoesNotExist:
+            raise ValidationError("'{}' is not a valid student identifier".format(user_id))
+
+    def validate(self, attrs):
+        """Validate the data at an object level."""
+
+        # Store the user object to avoid fetching it again.
+        if hasattr(self, 'user'):
+            attrs['user'] = self.user
+        return attrs
+
+    def create(self, validated_data):
+        """
+        Overriden create abstract method
+        """
+        pass
+
+    def update(self, instance, validated_data):
+        """
+        Overriden update abstract method
+        """
+        pass
+
+
+class DiscussionRolesMemberSerializer(serializers.Serializer):
+    """
+    Serializer for course discussion roles member data.
+    """
+    username = serializers.CharField()
+    email = serializers.EmailField()
+    first_name = serializers.CharField()
+    last_name = serializers.CharField()
+    group_name = serializers.SerializerMethodField()
+
+    def __init__(self, *args, **kwargs):
+        super(DiscussionRolesMemberSerializer, self).__init__(*args, **kwargs)
+        self.course_discussion_settings = self.context['course_discussion_settings']
+
+    def get_group_name(self, instance):
+        """Return the group name of the user."""
+        group_id = get_group_id_for_user(instance, self.course_discussion_settings)
+        group_name = get_group_name(group_id, self.course_discussion_settings)
+        return group_name
+
+    def create(self, validated_data):
+        """
+        Overriden create abstract method
+        """
+        pass
+
+    def update(self, instance, validated_data):
+        """
+        Overriden update abstract method
+        """
+        pass
+
+
+class DiscussionRolesListSerializer(serializers.Serializer):
+    """
+    Serializer for course discussion roles member list.
+    """
+    course_id = serializers.CharField()
+    results = serializers.SerializerMethodField()
+    division_scheme = serializers.SerializerMethodField()
+
+    def get_results(self, obj):
+        """Return the nested serializer data representing a list of member users."""
+        context = {
+            'course_id': obj['course_id'],
+            'course_discussion_settings': self.context['course_discussion_settings']
+        }
+        serializer = DiscussionRolesMemberSerializer(obj['users'], context=context, many=True)
+        return serializer.data
+
+    def get_division_scheme(self, obj):  # pylint: disable=unused-argument
+        """Return the division scheme for the course."""
+        return self.context['course_discussion_settings'].division_scheme
 
     def create(self, validated_data):
         """

--- a/lms/djangoapps/discussion_api/urls.py
+++ b/lms/djangoapps/discussion_api/urls.py
@@ -5,7 +5,14 @@ from django.conf import settings
 from django.conf.urls import include, patterns, url
 from rest_framework.routers import SimpleRouter
 
-from discussion_api.views import CommentViewSet, CourseTopicsView, CourseView, ThreadViewSet
+from discussion_api.views import (
+    CommentViewSet,
+    CourseDiscussionSettingsAPIView,
+    CourseDiscussionRolesAPIView,
+    CourseTopicsView,
+    CourseView,
+    ThreadViewSet,
+)
 
 ROUTER = SimpleRouter()
 ROUTER.register("threads", ThreadViewSet, base_name="thread")
@@ -13,6 +20,20 @@ ROUTER.register("comments", CommentViewSet, base_name="comment")
 
 urlpatterns = patterns(
     "discussion_api",
+    url(
+        r"^v1/courses/{}/settings$".format(
+            settings.COURSE_ID_PATTERN
+        ),
+        CourseDiscussionSettingsAPIView.as_view(),
+        name="discussion_course_settings",
+    ),
+    url(
+        r'^v1/courses/{}/roles/(?P<rolename>[A-Za-z0-9+ _-]+)/?$'.format(
+            settings.COURSE_ID_PATTERN
+        ),
+        CourseDiscussionRolesAPIView.as_view(),
+        name="discussion_course_roles",
+    ),
     url(
         r"^v1/courses/{}".format(settings.COURSE_ID_PATTERN),
         CourseView.as_view(),


### PR DESCRIPTION
This PR implements an alternative cohort discussion settings and cohort discussion roles management API for server-to-server communication. This is related to PR https://github.com/edx/edx-platform/pull/18975 PR which implements a few other API endpoints for managing cohorts. The endpoints support OAuth2 authentication and session authentication and build upon existing API endpoints for the purpose.

**Testing instructions**:
* Log in to the LMS as a staff user.
* Create a test course and enable cohorts for it.
* Create some test users.
* Create a few cohorts and enroll the test users at random in the test course into the created cohorts.
* Enable the 'Course Discussions' feature for the course.
* Test and verify the course discussion settings endpoints using the format of the following example requests. More details are available in the view docstring for these endpoints.

        # Get the discussion settings for the given course.
        GET /api/discussion/v1/courses/{course_id}/settings

        # Example response
        {
            "always_divide_inline_discussions": false,
            "divided_inline_discussions": [],
            "divided_course_wide_discussions": [],
            "id": 1,
            "division_scheme": "cohort",
            "available_division_schemes": ["cohort"]
        }

        # Update the discussion settings for the given course.
        PATCH /api/discussion/v1/courses/{course_id}/settings
        {
            "always_divide_inline_discussions": true,
        }
        # Example response
        {
            "always_divide_inline_discussions": true,
            "divided_inline_discussions": [],
            "divided_course_wide_discussions": [],
            "id": 1,
            "division_scheme": "cohort",
            "available_division_schemes": ["cohort"]
        }

        # Get the member users for a given course and discussion role (URL encoded if necessary) - moderator, group moderator or community TA.
        GET /api/discussion/v1/courses/{course_id}/roles/{discussion rolename}

        # Example response
        {
            "results": [
                {
                    "username": "user1",
                    "email": "user1@example.com",
                    "first_name" "first name",
                    "last_name": "last name",
                    "group_name": "cohort1"
                },
                {
                    "username": "user2",
                    "email": "user2@example.com",
                    "first_name" "first name",
                    "last_name": "last name",
                    "group_name": "cohort2"
                }
            ]
        }

       # Update the discussion role membership of a user in the given course.
        POST /api/discussion/v1/courses/{course_id}/roles/{discussion rolename}

        {
            "user_id": "user1",
            "action": "revoke"
        }

        # Example response
        {
            "results": [
                {
                    "username": "user2",
                    "email": "user2@example.com",
                    "first_name" "first name",
                    "last_name": "last name",
                    "group_name": "cohort2"
                }
            ]
        }

**Author notes/concerns**:
* This is an exact backport of the corresponding upstream PR except for the fixes to the various imports and removal of the 'Group moderator' role which is not available in this fork at the moment.