### PR TITLE
[MCKIN-8395] Add the missing get users in a cohort endpoint

### DIFF
--- a/openedx/core/djangoapps/course_groups/serializers.py
+++ b/openedx/core/djangoapps/course_groups/serializers.py
@@ -1,0 +1,20 @@
+"""
+Cohorts API serializers.
+"""
+from django.contrib.auth.models import User
+from rest_framework import serializers
+
+
+class CohortUsersAPISerializer(serializers.ModelSerializer):
+    """
+    Serializer for cohort users.
+    """
+    name = serializers.SerializerMethodField('get_full_name')
+
+    def get_full_name(self, model):
+        """Return the full name of the user."""
+        return '{} {}'.format(model.first_name, model.last_name)
+
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'name')


### PR DESCRIPTION
This PR adds the 'get users in a cohort' endpoint accidentally missed in the upstream backport PR #1177. CC @xitij2000.

The testing instructions are the same as on the original PR.