### PR TITLE
[Staging Hotfix] Version bump aggregator to 1.5.4

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.2
+openedx-completion-aggregator==1.5.4
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump openedx-completion-aggregator to include memory usage fix for run_aggregator_service mgt command.  This PR hotfixes the version bump into the release-candidate branch, so it can be run on staging.

**JIRA tickets**: Fixes YONK-1089

**Discussions**: YONK-1089 and edx-mcka-dev slack channel on openedx.slack.com

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Verify that 1.5.4 contains the needed changes, and gets deployed.

**Author notes and concerns**:

This needs to be merged ASAP.

**Reviewers**
- [ ] @bradenmacdonald 

**Settings**
