### PR TITLE
YONK-1173: Update xblock version to match aggregator's requirements

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_validation.py
+++ b/common/lib/xmodule/xmodule/tests/test_validation.py
@@ -3,7 +3,8 @@ Test xblock/validation.py
 """
 
 import unittest
-from xblock.test.tools import assert_raises
+
+from nose.tools import assert_raises
 
 from xmodule.validation import StudioValidationMessage, StudioValidation
 from xblock.validation import Validation, ValidationMessage

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -210,7 +210,7 @@ py2neo==3.1.2
 
 # Support for plugins
 web-fragments==0.2.2
-xblock==1.2.0
+xblock>=1.2.2,<1.3
 
 # Third Party XBlocks
 edx-sga==0.6.2

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.4
+openedx-completion-aggregator>=1.5.4,<1.6
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Hotfix to update required XBlock, because the new completion_aggregator depends on it to run aggregator service.

Fixes YONK-1173.

## Notes

* XBlock diff from currently installed version: https://github.com/edx/XBlock/compare/xblock-1.2.0...xblock-1.2.2?expand=1
* This change is already applied on QA, so no update needs to happen there.
