### PR TITLE
YONK-1175: Version bump aggregator 1.5.7

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.4
+# openedx-completion-aggregator==1.5.6
+git+https://github.com/open-craft/openedx-completion-aggregator@hotfix-1.5.5.1#egg=openedx-completion-aggregator==1.5.5.1
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,6 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-# openedx-completion-aggregator==1.5.6
-git+https://github.com/open-craft/openedx-completion-aggregator@hotfix-1.5.5.1#egg=openedx-completion-aggregator==1.5.5.1
+openedx-completion-aggregator==1.5.7
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump.  Done in 2 commits to hopefully avoid merge pain when merging into release-candidate, which has a cherry-pick of the first commit applied already.
