### PR TITLE
YONK-1175/MCKIN-8690 version bump aggregator 1.5.9

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.4
+# openedx-completion-aggregator==1.5.6
+git+https://github.com/open-craft/openedx-completion-aggregator@hotfix-1.5.5.1#egg=openedx-completion-aggregator==1.5.5.1
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,6 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-# openedx-completion-aggregator==1.5.6
-git+https://github.com/open-craft/openedx-completion-aggregator@hotfix-1.5.5.1#egg=openedx-completion-aggregator==1.5.5.1
+openedx-completion-aggregator==1.5.9
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump aggregator to 1.5.9

* Make username optional on v0 api. (MCKIN-8690)
* Include console output in long-running migration. (YONK-1175)

**JIRA tickets**: Implements YONK-1175, MCKIN-8690

**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Verify that completion aggregator installs the right version in edx-platform,
2. Verify that the username parameter is optional for non-staff users on the /v0/ api, but required on /v1/
3. Verify that the migration produces output ("Transferred 0 records at <datetime>")

**Author notes and concerns**:

**Reviewers**
- [ ] @xitij2000 

**Settings**
