### PR TITLE
[Staging Hotfix] YONK-1175: Version bump aggregator to 1.5.10

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.1
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.9
+openedx-completion-aggregator==1.5.10
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump PR to bring in performance improvements to openedx-completion-aggregator migration.

**JIRA tickets**: Implements YONK-1175

**Discussions**: 
**Dependencies**: None

**Screenshots**:

**Sandbox URL**: N/A

**Merge deadline**: ASAP

**Testing instructions**:

N/A

**Author notes and concerns**:

**Reviewers**
- [ ] @feanil 

**Settings**
