### PR TITLE
YONK-1150 - Discussions - All response thread is being deleted when learners delete any comment from a response without refreshing discussion post page

### DIFF
--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -523,7 +523,7 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
         if is_comment:
             # If creating a comment, then we don't have the original thread_id
             # so we have to get it from the parent
-            #Parent's comment was required to get parent's user_id to be set to 'replying_to_id'
+            #Parent's comment is required to get parent's user_id to be set to 'replying_to_id'
             parent_comment = cc.Comment.find(parent_id)
             thread_id = parent_comment.thread_id
             replying_to_id = parent_comment.user_id

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -523,7 +523,6 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
         if is_comment:
             # If creating a comment, then we don't have the original thread_id
             # so we have to get it from the parent
-            #Parent's comment is required to get parent's user_id to be set to 'replying_to_id'
             parent_comment = cc.Comment.find(parent_id)
             thread_id = parent_comment.thread_id
             replying_to_id = parent_comment.user_id

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -523,9 +523,10 @@ def _create_comment(request, course_key, thread_id=None, parent_id=None):
         if is_comment:
             # If creating a comment, then we don't have the original thread_id
             # so we have to get it from the parent
-            comment = cc.Comment.find(parent_id)
-            thread_id = comment.thread_id
-            replying_to_id = comment.user_id
+            #Parent's comment was required to get parent's user_id to be set to 'replying_to_id'
+            parent_comment = cc.Comment.find(parent_id)
+            thread_id = parent_comment.thread_id
+            replying_to_id = parent_comment.user_id
 
         thread = cc.Thread.find(thread_id)
 


### PR DESCRIPTION
Fixed comment's reply delete issue. Previously, thread was being deleted when learners delete any comment from a response without refreshing discussion post page