### PR TITLE
bump xblock-poll version to 1.5.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.16#egg=xblock-ooyala==2.0.16
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
--e git+https://github.com/open-craft/xblock-poll.git@v1.5.0#egg=xblock-poll==1.5.0
+-e git+https://github.com/open-craft/xblock-poll.git@1.5.1#egg=xblock-poll==1.5.1
 -e git+https://github.com/edx/edx-notifications.git@0.6.5#egg=edx-notifications==0.6.5
 -e git+https://github.com/open-craft/problem-builder.git@v2.10.5#egg=xblock-problem-builder==2.10.5
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix


### PR DESCRIPTION
This PR bumps xblock-poll version to 1.5.1