### PR TITLE
MCKIN-8752: Revert poll and image-explorer version bumps

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,7 +2,7 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.1.1#egg=xblock-image-explorer==1.1.1
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.1#egg=xblock-image-explorer==1.0.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 # FIXME: temp hash, until a proper solution is findout (ref ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8249)
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@a4dee0689863533948735b4b389493c42b5110f0#egg=xblock-drag-and-drop-v2==2.2.0
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.16#egg=xblock-ooyala==2.0.16
 -e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
--e git+https://github.com/open-craft/xblock-poll.git@1.6.0#egg=xblock-poll==1.6.0
+-e git+https://github.com/open-craft/xblock-poll.git@1.5.1#egg=xblock-poll==1.5.1
 -e git+https://github.com/edx/edx-notifications.git@0.6.5#egg=edx-notifications==0.6.5
 -e git+https://github.com/open-craft/problem-builder.git@v2.11.0#egg=xblock-problem-builder==2.11.0
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix


### PR DESCRIPTION
Without this revert, I get an error when accessing http://apros.mcka.local/courses/edX/PS1/20181029, which is a course that has problem-builder, image-explorer, ooyala-player, poll, and survey xblocks.

I reverted all the changes made since the last successful QA deployment, which included updates to:

* openedx-completion-aggregator (1.5.11 -> 1.5.12
* xblock-image-explorer (1.0.1 -> 1.1.1)
* problem-builder (2.10.5 -> 2.11.0)
* xblock-poll (poll & survey blocks) (1.5.1 -> 1.6.0)

One by one, I re-applied the changes.  Aggregator and problem-builder didn't cause any problems.  The errors showed up again when either image-explorer or xblock-poll was updated.  So this reverts those two changes, and leaves the problem-builder and openedx-completion-aggregator changes in place.