### PR TITLE
YONK-1177 - Performance related errors on discussion forum and progress page 

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -682,11 +682,13 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             return fragment
         except cc.utils.CommentClientMaintenanceError:
             log.warning('Forum is in maintenance mode')
-            html = render_to_response('discussion/maintenance_fragment.html', {
+            html = render_to_string('discussion/maintenance_fragment.html', {
                 'disable_courseware_js': True,
                 'uses_pattern_library': True,
             })
-            return Fragment(html)
+            fragment = Fragment(html)
+            self.add_fragment_resource_urls(fragment)
+            return fragment
 
     def vendor_js_dependencies(self):
         """


### PR DESCRIPTION
Discussion board AssertionError fixed.

Previously, When forum service is down maintenance page was not loaded as code throws assertion error as fragment gets HTTPResponse object. Fragment now gets a string and maintenance page is rendered successfully.

Also, fragment resources are also added which were not being loaded previously in maintenance error case