### PR TITLE
Version bump to released 1.5.13

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,7 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-#openedx-completion-aggregator==1.5.13
-git+https://github.com/open-craft/openedx-completion-aggregator.git@cliff/root-block#egg=openedx-completion-aggregator==1.5.12.1
-
+openedx-completion-aggregator==1.5.13
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
MCKIN-8817: The previous PR used the branch name for the release target.  This updates it to use the exact same code, but using the released version from PyPI.

(not-urgent follow-up work)

@UmanShahzad 
