### PR TITLE
[BB-430] [MCKIN-8671] Third-party Auth endpoint should return whether user is active

### DIFF
--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -198,7 +198,7 @@ class UserViewAPITests(TpaAPITestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['account_activated'], False)
+        self.assertEqual(response.data['account_activate'], False)
 
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -193,7 +193,7 @@ class UserViewAPITests(TpaAPITestCase):
         self.assertGreater(len(response.data['active']), 0)
 
     def test_get_inactive_user(self):
-        self.client.login(username=STAFF_USERNAME, password=PASSWORD)
+        self.client.login(username=ADMIN_USERNAME, password=PASSWORD)
         url = reverse('third_party_auth_users_api', kwargs={'username': INACTIVE_USERNAME})
 
         response = self.client.get(url)

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -198,7 +198,7 @@ class UserViewAPITests(TpaAPITestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['account_activate'], False)
+        self.assertEqual(response.data['account_active'], False)
 
 
 @override_settings(EDX_API_KEY=VALID_API_KEY)

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -198,7 +198,6 @@ class UserViewAPITests(TpaAPITestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertGreater(len(response.data['active']), 0)
         self.assertEqual(response.data['account_activated'], False)
 
 

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -121,7 +121,8 @@ class UserView(APIView):
         # In the future this can be trivially modified to return the inactive/disconnected providers as well.
 
         return Response({
-            "active": active_providers
+            "active": active_providers,
+            "account_active": user.is_active,
         })
 
     def get_provider_data(self, assoc, is_unprivileged):


### PR DESCRIPTION
/api/third_party_auth/v0/users/{username} also returns if a user is activated or not

New PR because the old one was accidentally closed.