### PR TITLE
MCKIN-8666: bump xblock problem builder version to 2.11.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@1.5.1#egg=xblock-poll==1.5.1
 -e git+https://github.com/edx/edx-notifications.git@0.6.5#egg=edx-notifications==0.6.5
--e git+https://github.com/open-craft/problem-builder.git@v2.11.0#egg=xblock-problem-builder==2.11.0
+-e git+https://github.com/open-craft/problem-builder.git@2.11.1#egg=xblock-problem-builder==2.11.1
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.3#egg=xblock-chat==0.2.3
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@2490351747eb9cc72b01cacfe0c9cc383c3fd6db#egg=xblock-eoc-journal


### PR DESCRIPTION
This PR bumps xblock problem builder version to 2.11.1