### PR TITLE
Remove throttling from SSO provider view.

### DIFF
--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -83,7 +83,6 @@ class UserView(APIView):
         OAuth2AuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
-    throttle_classes = [ProviderSustainedThrottle, ProviderBurstThrottle]
 
     def get(self, request, username):
         """Create, read, or update enrollment information for a user.


### PR DESCRIPTION
Throttling was intended to limit each user so they could not use this endpoint to scrape a list of all users and their SSO associations.  However, the requests are being made directly by apros, so instead of each user being limited, each app server is limited.

**JIRA tickets**: Fixes 

**Discussions**: On edx-mcka-dev slack channel, 11/07

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP.

**Testing instructions**:

1. Try to log in 

**Author notes and concerns**:

1. We are aware that there is a glitch affecting the UI for this feature in the following way: ...
   Currently looking for ways to fix it.
2. We tried to optimize for accessibility, but there are still some open questions: ...

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```@xitij2000 