### PR TITLE
Bump aggregator version to 1.5.14

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,7 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-#openedx-completion-aggregator==1.5.13
-git+https://github.com/open-craft/openedx-completion-aggregator.git@cliff/root-block#egg=openedx-completion-aggregator==1.5.12.1
+openedx-completion-aggregator==1.5.14
 
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Bump aggregator version to 1.5.14 to include migrate_progress by id.

**JIRA tickets**: Implements SOL-5, SOL-6.

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**:ASAP

**Testing instructions**:

Verify that aggregator installs the correct version, and can run ./manage.py migrate_progress --ids=100,200,300

**Author notes and concerns**:


**Reviewers**
- [ ] @xitij2000 

**Settings**
