### PR TITLE
[MCKIN-5641] Add upstream-compatible OAuth2 support to XBlock handlers

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -29,7 +29,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from requests.auth import HTTPBasicAuth
 from rest_framework.exceptions import APIException
-from rest_framework.permissions import SAFE_METHODS
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xblock.exceptions import NoSuchHandlerError, NoSuchViewError
@@ -986,7 +985,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
         suffix (str)
 
     Raises:
-        HttpResponseForbidden: If the request method is not in SAFE_METHODS and user is not authenticated.
+        HttpResponseForbidden: If the request method is not `GET` and user is not authenticated.
         Http404: If the course is not found in the modulestore.
     """
     # In this case, we are using Session based authentication, so we need to check CSRF token.
@@ -1011,9 +1010,9 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
                     request.user, _ = user_auth_tuple
                     break
 
-    # NOTE (CCB): Allow anonymous SAFE_METHOD calls (e.g. for transcripts). Modifying this view is simpler than updating
+    # NOTE (CCB): Allow anonymous GET calls (e.g. for transcripts). Modifying this view is simpler than updating
     # the XBlocks to use `handle_xblock_callback_noauth`, which is practically identical to this view.
-    if not (request.method in SAFE_METHODS or request.user and request.user.is_authenticated()):
+    if request.method != 'GET' and not (request.user and request.user.is_authenticated):
         return HttpResponseForbidden()
 
     request.user.known = request.user.is_authenticated()

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1012,7 +1012,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
 
     # NOTE (CCB): Allow anonymous GET calls (e.g. for transcripts). Modifying this view is simpler than updating
     # the XBlocks to use `handle_xblock_callback_noauth`, which is practically identical to this view.
-    if request.method != 'GET' and not (request.user and request.user.is_authenticated):
+    if request.method != 'GET' and not (request.user and request.user.is_authenticated()):
         return HttpResponseForbidden()
 
     request.user.known = request.user.is_authenticated()

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -16,19 +16,20 @@ from completion import waffle as completion_waffle
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
+from django.middleware.csrf import CsrfViewMiddleware
 from django.core.context_processors import csrf
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, HttpResponseForbidden
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from edx_proctoring.services import ProctoringService
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from requests.auth import HTTPBasicAuth
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import APIException
+from rest_framework.permissions import SAFE_METHODS
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
 from xblock.exceptions import NoSuchHandlerError, NoSuchViewError
@@ -971,32 +972,64 @@ def handle_xblock_callback_noauth(request, course_id, usage_id, handler, suffix=
         return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
 
 
-class XblockCallbackView(APIView):
+@csrf_exempt
+@xframe_options_exempt
+def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     """
-    Class-based view for extensions. This is where AJAX calls go.
+    Generic view for extensions. This is where AJAX calls go.
 
-    Return 403 error if the user is not logged in. Raises Http404 if
-    the location and course_id do not identify a valid module, the module is
-    not accessible by the user, or the module raises NotFoundError. If the
-    module raises any other error, it will escape this function.
+    Arguments:
+        request (Request): Django request.
+        course_id (str): Course containing the block
+        usage_id (str)
+        handler (str)
+        suffix (str)
+
+    Raises:
+        HttpResponseForbidden: If the request method is not in SAFE_METHODS and user is not authenticated.
+        Http404: If the course is not found in the modulestore.
     """
-    authentication_classes = (SessionAuthentication, OAuth2AuthenticationAllowInactiveUser)
-    permission_classes = (IsAuthenticated,)
+    # In this case, we are using Session based authentication, so we need to check CSRF token.
+    if request.user and request.user.is_authenticated():
+        error = CsrfViewMiddleware().process_view(request, None, (), {})
+        if error:
+            return error
 
-    def get(self, request, course_id, usage_id, handler, suffix=None):
-        return _get_course_and_invoke_handler(request, course_id, usage_id, handler, suffix)
+    else:
+        authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
+        authenticators = [auth() for auth in authentication_classes]
 
-    def post(self, request, course_id, usage_id, handler, suffix=None):
-        return _get_course_and_invoke_handler(request, course_id, usage_id, handler, suffix)
+        for authenticator in authenticators:
+            try:
+                user_auth_tuple = authenticator.authenticate(request)
+            except APIException:
+                log.exception(
+                    "XBlock handler %r failed to authenticate with %s", handler, authenticator.__class__.__name__
+                )
+            else:
+                if user_auth_tuple is not None:
+                    request.user, _ = user_auth_tuple
+                    break
 
-    def put(self, request, course_id, usage_id, handler, suffix=None):
-        return _get_course_and_invoke_handler(request, course_id, usage_id, handler, suffix)
+    # NOTE (CCB): Allow anonymous SAFE_METHOD calls (e.g. for transcripts). Modifying this view is simpler than updating
+    # the XBlocks to use `handle_xblock_callback_noauth`, which is practically identical to this view.
+    if not (request.method in SAFE_METHODS or request.user and request.user.is_authenticated()):
+        return HttpResponseForbidden()
 
-    def patch(self, request, course_id, usage_id, handler, suffix=None):
-        return _get_course_and_invoke_handler(request, course_id, usage_id, handler, suffix)
+    request.user.known = request.user.is_authenticated()
 
-    def delete(self, request, course_id, usage_id, handler, suffix=None):
-        return _get_course_and_invoke_handler(request, course_id, usage_id, handler, suffix)
+    try:
+        course_key = CourseKey.from_string(course_id)
+    except InvalidKeyError:
+        raise Http404('{} is not a valid course key'.format(course_id))
+
+    with modulestore().bulk_operations(course_key):
+        try:
+            course = modulestore().get_course(course_key)
+        except ItemNotFoundError:
+            raise Http404('{} does not exist in the modulestore'.format(course_id))
+
+        return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
 
 
 def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None):

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -4,6 +4,7 @@ import json
 from functools import partial
 
 import factory
+from django.test.client import RequestFactory
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
@@ -161,3 +162,13 @@ class StudentInfoFactory(DjangoModelFactory):
     field_name = 'existing_field'
     value = json.dumps('old_value')
     student = factory.SubFactory(UserFactory)
+
+
+class RequestFactoryNoCsrf(RequestFactory):
+    """
+    RequestFactory, which disables csrf checks.
+    """
+    def request(self, **kwargs):
+        request = super(RequestFactoryNoCsrf, self).request(**kwargs)
+        setattr(request, '_dont_enforce_csrf_checks', True)
+        return request

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -1,20 +1,9 @@
 """
 Tests use cases related to LMS Entrance Exam behavior, such as gated content access (TOC)
 """
-from mock import patch, Mock
-
-from django.core.urlresolvers import reverse
-from django.test.client import RequestFactory
-from rest_framework.test import APIRequestFactory
-from nose.plugins.attrib import attr
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.model_data import FieldDataCache
-from courseware.module_render import toc_for_course, get_module, XblockCallbackView
-from courseware.tests.factories import UserFactory, InstructorFactory, StaffFactory
-from courseware.tests.helpers import (
-    LoginEnrollmentTestCase,
-)
+
 from courseware.entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,
@@ -22,8 +11,8 @@ from courseware.entrance_exams import (
     user_has_passed_entrance_exam
 )
 from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module, toc_for_course
-from courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory
+from courseware.module_render import get_module, handle_xblock_callback, toc_for_course
+from courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory, RequestFactoryNoCsrf
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from django.core.urlresolvers import reverse
 from milestones.tests.utils import MilestonesTestCaseMixin
@@ -544,15 +533,14 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         """
         Tests entrance exam xblock has `entrance_exam_passed` key in json response.
         """
-        request_factory = APIRequestFactory()
+        request_factory = RequestFactoryNoCsrf()
         data = {'input_{}_2_1'.format(unicode(self.problem_1.location.html_id())): 'choice_2'}
         request = request_factory.post(
             'problem_check',
             data=data
         )
         request.user = self.user
-        view = XblockCallbackView.as_view()
-        response = view(
+        response = handle_xblock_callback(
             request,
             unicode(self.course.id),
             unicode(self.problem_1.location),

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -14,12 +14,11 @@ from bson import ObjectId
 from completion.models import BlockCompletion
 from completion import waffle as completion_waffle
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse
-from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
+from edx_oauth2_provider.tests.factories import AccessTokenFactory, ClientFactory
 from edx_proctoring.api import create_exam, create_exam_attempt, update_attempt_status
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.tests.test_services import MockCreditService
@@ -31,9 +30,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from progress.models import CourseModuleCompletion
 from pyquery import PyQuery
-from rest_framework.test import APIRequestFactory, force_authenticate
-from student.models import anonymous_id_for_user
-from verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from xblock.core import XBlock, XBlockAside
 from xblock.field_data import FieldData
 from xblock.fields import ScopeIds
@@ -47,10 +43,9 @@ from courseware import module_render as render
 from courseware.courses import get_course_info_section, get_course_with_access
 from courseware.field_overrides import OverrideFieldData
 from courseware.model_data import FieldDataCache
-from courseware.module_render import hash_resource, get_module_for_descriptor, XblockCallbackView
 from courseware.models import StudentModule
 from courseware.module_render import get_module_for_descriptor, hash_resource
-from courseware.tests.factories import GlobalStaffFactory, StudentModuleFactory, UserFactory
+from courseware.tests.factories import GlobalStaffFactory, StudentModuleFactory, UserFactory, RequestFactoryNoCsrf
 from courseware.tests.test_submitting_problems import TestSubmittingProblems
 from courseware.tests.tests import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
@@ -182,7 +177,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
         self.mock_user = UserFactory()
         self.mock_user.id = 1
-        self.request_factory = RequestFactory()
+        self.request_factory = RequestFactoryNoCsrf()
 
         # Construct a mock module for the modulestore to return
         self.mock_module = MagicMock()
@@ -290,8 +285,9 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                     self.dispatch
                 )
 
-    def test_anonymous_handle_xblock_callback(self):
-        dispatch_url = reverse(
+    def _get_dispatch_url(self):
+        """Helper to get dispatch URL for testing xblock callback."""
+        return reverse(
             'xblock_handler',
             args=[
                 self.course_key.to_deprecated_string(),
@@ -300,23 +296,40 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                 'goto_position'
             ]
         )
+
+    def test_anonymous_get_xblock_callback(self):
+        """Test that anonymous GET is allowed."""
+        dispatch_url = self._get_dispatch_url()
+        response = self.client.get(dispatch_url)
+        self.assertEquals(200, response.status_code)
+
+    def test_anonymous_post_xblock_callback(self):
+        """Test that anonymous POST is not allowed."""
+        dispatch_url = self._get_dispatch_url()
         response = self.client.post(dispatch_url, {'position': 2})
         self.assertEquals(403, response.status_code)
+
+    def test_session_authentication(self):
+        """ Test that the xblock endpoint supports session authentication."""
+        self.client.login(username=self.mock_user.username, password="test")
+        dispatch_url = self._get_dispatch_url()
+        response = self.client.post(dispatch_url)
+        self.assertEqual(200, response.status_code)
+
+    def test_oauth_authentication(self):
+        """ Test that the xblock endpoint supports OAuth authentication."""
+        dispatch_url = self._get_dispatch_url()
+        access_token = AccessTokenFactory(user=self.mock_user, client=ClientFactory()).token
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + access_token}
+        response = self.client.post(dispatch_url, {}, **headers)
+        self.assertEqual(200, response.status_code)
 
     def test_missing_position_handler(self):
         """
         Test that sending POST request without or invalid position argument don't raise server error
         """
         self.client.login(username=self.mock_user.username, password="test")
-        dispatch_url = reverse(
-            'xblock_handler',
-            args=[
-                self.course_key.to_deprecated_string(),
-                quote_slashes(self.course_key.make_usage_key('videosequence', 'Toy_Videos').to_deprecated_string()),
-                'xmodule_handler',
-                'goto_position'
-            ]
-        )
+        dispatch_url = self._get_dispatch_url()
         response = self.client.post(dispatch_url)
         self.assertEqual(200, response.status_code)
         self.assertEqual(json.loads(response.content), {'success': True})
@@ -439,7 +452,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 @attr(shard=1)
 class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
-    Test the XblockCallbackView function
+    Test the handle_xblock_callback function
     """
 
     @classmethod
@@ -453,8 +466,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
 
         self.location = self.course_key.make_usage_key('chapter', 'Overview')
         self.mock_user = UserFactory.create()
-        self.request_factory = RequestFactory()
-        self.drf_request_factory = APIRequestFactory()
+        self.request_factory = RequestFactoryNoCsrf()
 
         # Construct a mock module for the modulestore to return
         self.mock_module = MagicMock()
@@ -483,27 +495,25 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         return mock_file
 
     def test_invalid_location(self):
-        request = self.drf_request_factory.post('dummy_url', data={'position': 1})
+        request = self.request_factory.post('dummy_url', data={'position': 1})
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        resp = view(
-            request,
-            self.course_key.to_deprecated_string(),
-            'invalid Location',
-            'dummy_handler'
-            'dummy_dispatch'
-        )
-        self.assertEquals(resp.status_code, 404)
+        with self.assertRaises(Http404):
+            render.handle_xblock_callback(
+                request,
+                self.course_key.to_deprecated_string(),
+                'invalid Location',
+                'dummy_handler'
+                'dummy_dispatch'
+            )
 
     def test_too_many_files(self):
-        request = self.drf_request_factory.post(
+        request = self.request_factory.post(
             'dummy_url',
             data={'file_id': (self._mock_file(),) * (settings.MAX_FILEUPLOADS_PER_INPUT + 1)}
         )
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
         self.assertEquals(
-            view(
+            render.handle_xblock_callback(
                 request,
                 self.course_key.to_deprecated_string(),
                 quote_slashes(self.location.to_deprecated_string()),
@@ -517,14 +527,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
 
     def test_too_large_file(self):
         inputfile = self._mock_file(size=1 + settings.STUDENT_FILEUPLOAD_MAX_SIZE)
-        request = self.drf_request_factory.post(
+        request = self.request_factory.post(
             'dummy_url',
             data={'file_id': inputfile}
         )
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
         self.assertEquals(
-            view(
+            render.handle_xblock_callback(
                 request,
                 self.course_key.to_deprecated_string(),
                 quote_slashes(self.location.to_deprecated_string()),
@@ -537,10 +546,9 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         )
 
     def test_xmodule_dispatch(self):
-        request = self.drf_request_factory.post('dummy_url', data={'position': 1})
+        request = self.request_factory.post('dummy_url', data={'position': 1})
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        response = view(
+        response = render.handle_xblock_callback(
             request,
             self.course_key.to_deprecated_string(),
             quote_slashes(self.location.to_deprecated_string()),
@@ -550,36 +558,33 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         self.assertIsInstance(response, HttpResponse)
 
     def test_bad_course_id(self):
-        request = self.drf_request_factory.post('dummy_url')
+        request = self.request_factory.post('dummy_url')
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        resp = view(
-            request,
-            'bad_course_id',
-            quote_slashes(self.location.to_deprecated_string()),
-            'xmodule_handler',
-            'goto_position',
-        )
-        self.assertEquals(resp.status_code, 404)
+        with self.assertRaises(Http404):
+            render.handle_xblock_callback(
+                request,
+                'bad_course_id',
+                quote_slashes(self.location.to_deprecated_string()),
+                'xmodule_handler',
+                'goto_position',
+            )
 
     def test_bad_location(self):
-        request = self.drf_request_factory.post('dummy_url')
+        request = self.request_factory.post('dummy_url')
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        resp = view(
-            request,
-            self.course_key.to_deprecated_string(),
-            quote_slashes(self.course_key.make_usage_key('chapter', 'bad_location').to_deprecated_string()),
-            'xmodule_handler',
-            'goto_position',
-        )
-        self.assertEquals(resp.status_code, 404)
+        with self.assertRaises(Http404):
+            render.handle_xblock_callback(
+                request,
+                self.course_key.to_deprecated_string(),
+                quote_slashes(self.course_key.make_usage_key('chapter', 'bad_location').to_deprecated_string()),
+                'xmodule_handler',
+                'goto_position',
+            )
 
     def test_bad_xmodule_dispatch(self):
-        request = self.drf_request_factory.post('dummy_url')
+        request = self.request_factory.post('dummy_url')
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        resp = view(
+        resp = render.handle_xblock_callback(
             request,
             self.course_key.to_deprecated_string(),
             quote_slashes(self.location.to_deprecated_string()),
@@ -589,10 +594,9 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         self.assertEquals(resp.status_code, 404)
 
     def test_missing_handler(self):
-        request = self.drf_request_factory.post('dummy_url')
+        request = self.request_factory.post('dummy_url')
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        resp = view(
+        resp = render.handle_xblock_callback(
             request,
             self.course_key.to_deprecated_string(),
             quote_slashes(self.location.to_deprecated_string()),
@@ -606,14 +610,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         course = CourseFactory.create()
         block = ItemFactory.create(category='stateless_scorer', parent=course)
 
-        request = self.drf_request_factory.post(
+        request = self.request_factory.post(
             'dummy_url',
             data=json.dumps({"grade": 0.75}),
             content_type='application/json'
         )
         request.user = self.mock_user
-        view = XblockCallbackView.as_view()
-        response = view(
+        response = render.handle_xblock_callback(
             request,
             unicode(course.id),
             quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -633,13 +636,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, False):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({'grade': 0.5}),
                 content_type='application/json',
             )
-            force_authenticate(request, user=self.mock_user)
-            response = render.XblockCallbackView.as_view()(
+            request.user = self.mock_user
+            response = render.handle_xblock_callback(
                 request,
                 unicode(course.id),
                 quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -657,13 +660,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
             with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
                 course = CourseFactory.create()
                 block = ItemFactory.create(category='comp', parent=course)
-                request = self.drf_request_factory.post(
+                request = self.request_factory.post(
                     '/',
                     data=json.dumps({'grade': 0.5}),
                     content_type='application/json',
                 )
-                force_authenticate(request, user=self.mock_user)
-                response = render.XblockCallbackView.as_view()(
+                request.user = self.mock_user
+                response = render.handle_xblock_callback(
                     request,
                     unicode(course.id),
                     quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -679,33 +682,33 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, False):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({'completion': 0.625}),
                 content_type='application/json',
             )
-            force_authenticate(request, user=self.mock_user)
-            response = render.XblockCallbackView.as_view()(
+            request.user = self.mock_user
+            response = render.handle_xblock_callback(
                 request,
                 unicode(course.id),
                 quote_slashes(unicode(block.scope_ids.usage_id)),
                 'complete',
                 '',
             )
-            self.assertEqual(response.status_code, 404)
+            self.assertEquals(response.status_code, 404)
 
     @XBlock.register_temp_plugin(StubCompletableXBlock, identifier='comp')
     def test_completion_event(self):
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({'completion': 0.625}),
                 content_type='application/json',
             )
-            force_authenticate(request, user=self.mock_user)
-            response = render.XblockCallbackView.as_view()(
+            request.user = self.mock_user
+            response = render.handle_xblock_callback(
                 request,
                 unicode(course.id),
                 quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -721,13 +724,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, False):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({}),
                 content_type='application/json',
             )
-            force_authenticate(request, user=self.mock_user)
-            response = render.XblockCallbackView.as_view()(
+            request.user = self.mock_user
+            response = render.handle_xblock_callback(
                 request,
                 unicode(course.id),
                 quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -743,13 +746,13 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({}),
                 content_type='application/json',
             )
-            force_authenticate(request, user=self.mock_user)
-            response = render.XblockCallbackView.as_view()(
+            request.user = self.mock_user
+            response = render.handle_xblock_callback(
                 request,
                 unicode(course.id),
                 quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -765,20 +768,20 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
             course = CourseFactory.create()
             block = ItemFactory.create(category='comp', parent=course)
-            request = self.drf_request_factory.post(
+            request = self.request_factory.post(
                 '/',
                 data=json.dumps({'completion': 0.8}),
                 content_type='application/json',
             )
             self.mock_user.real_user = GlobalStaffFactory.create()
             self.mock_user.real_user.masquerade_settings = CourseMasquerade(course.id, user_name="jem")
-            force_authenticate(request, user=self.mock_user)
+            request.user = self.mock_user
             request.session = {}
             #request.user.real_user = GlobalStaffFactory.create()
             #request.user.real_user.masquerade_settings = CourseMasquerade(course.id, user_name="jem")
             with patch('courseware.module_render.is_masquerading_as_specific_student') as mock_masq:
                 mock_masq.return_value = True
-                response = render.XblockCallbackView.as_view()(
+                response = render.handle_xblock_callback(
                     request,
                     unicode(course.id),
                     quote_slashes(unicode(block.scope_ids.usage_id)),
@@ -827,7 +830,7 @@ class TestTOC(ModuleStoreTestCase):
         self.course_key = ToyCourseFactory.create().id  # pylint: disable=attribute-defined-outside-init
         self.chapter = 'Overview'
         chapter_url = '%s/%s/%s' % ('/courses', self.course_key, self.chapter)
-        factory = RequestFactory()
+        factory = RequestFactoryNoCsrf()
         self.request = factory.get(chapter_url)
         self.request.user = UserFactory()
         self.modulestore = self.store._get_modulestore_for_courselike(
@@ -942,7 +945,7 @@ class TestProctoringRendering(SharedModuleStoreTestCase):
         super(TestProctoringRendering, self).setUp()
         self.chapter = 'Overview'
         chapter_url = '%s/%s/%s' % ('/courses', self.course_key, self.chapter)
-        factory = RequestFactory()
+        factory = RequestFactoryNoCsrf()
         self.request = factory.get(chapter_url)
         self.request.user = UserFactory.create()
         self.user = UserFactory.create()
@@ -1289,7 +1292,7 @@ class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCase
             category='sequential',
             display_name="Gated Sequential"
         )
-        self.request = RequestFactory().get('%s/%s/%s' % ('/courses', self.course.id, self.chapter.display_name))
+        self.request = RequestFactoryNoCsrf().get('%s/%s/%s' % ('/courses', self.course.id, self.chapter.display_name))
         self.request.user = UserFactory()
         self.field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
             self.course.id, self.request.user, self.course, depth=2
@@ -1349,7 +1352,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
     def setUp(self):
         super(TestHtmlModifiers, self).setUp()
         self.course = CourseFactory.create()
-        self.request = RequestFactory().get('/')
+        self.request = RequestFactoryNoCsrf().get('/')
         self.request.user = self.user
         self.request.session = {}
         self.content_string = '<p>This is the content<p>'
@@ -1544,7 +1547,7 @@ class ViewInStudioTest(ModuleStoreTestCase):
         """ Set up the user and request that will be used. """
         super(ViewInStudioTest, self).setUp()
         self.staff_user = GlobalStaffFactory.create()
-        self.request = RequestFactory().get('/')
+        self.request = RequestFactoryNoCsrf().get('/')
         self.request.user = self.staff_user
         self.request.session = {}
         self.module = None
@@ -1665,7 +1668,7 @@ class TestStaffDebugInfo(SharedModuleStoreTestCase):
     def setUp(self):
         super(TestStaffDebugInfo, self).setUp()
         self.user = UserFactory.create()
-        self.request = RequestFactory().get('/')
+        self.request = RequestFactoryNoCsrf().get('/')
         self.request.user = self.user
         self.request.session = {}
 
@@ -1897,7 +1900,7 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
         super(TestModuleTrackingContext, self).setUp()
 
         self.user = UserFactory.create()
-        self.request = RequestFactory().get('/')
+        self.request = RequestFactoryNoCsrf().get('/')
         self.request.user = self.user
         self.request.session = {}
         self.course = CourseFactory.create()
@@ -1957,8 +1960,7 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
 
         descriptor = ItemFactory.create(**descriptor_kwargs)
 
-        view = XblockCallbackView.as_view()
-        view(
+        render.handle_xblock_callback(
             self.request,
             self.course.id.to_deprecated_string(),
             quote_slashes(descriptor.location.to_deprecated_string()),
@@ -2163,7 +2165,7 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
 
         self.mock_user = UserFactory()
         self.mock_user.id = 1
-        self.request_factory = RequestFactory()
+        self.request_factory = RequestFactoryNoCsrf()
 
     @ddt.data('xblock', 'xmodule')
     @XBlock.register_temp_plugin(PureXBlock, identifier='xblock')

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -23,7 +23,7 @@ from course_modes.tests.factories import CourseModeFactory
 from courseware.access_utils import is_course_open_for_learner
 from courseware.model_data import FieldDataCache, set_score
 from courseware.module_render import get_module
-from courseware.tests.factories import GlobalStaffFactory, StudentModuleFactory
+from courseware.tests.factories import GlobalStaffFactory, StudentModuleFactory, RequestFactoryNoCsrf
 from courseware.testutils import RenderXBlockTestMixin
 from courseware.url_helpers import get_redirect_url
 from courseware.user_state_client import DjangoXBlockUserStateClient
@@ -32,7 +32,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.test import TestCase
-from django.test.client import Client, RequestFactory
+from django.test.client import Client
 from django.test.utils import override_settings
 from freezegun import freeze_time
 from lms.djangoapps.commerce.utils import EcommerceService  # pylint: disable=import-error
@@ -1993,7 +1993,7 @@ class VerifyCourseKeyDecoratorTests(TestCase):
     def setUp(self):
         super(VerifyCourseKeyDecoratorTests, self).setUp()
 
-        self.request = RequestFactory().get("foo")
+        self.request = RequestFactoryNoCsrf().get("foo")
         self.valid_course_id = "edX/test/1"
         self.invalid_course_id = "edX/"
 
@@ -2028,7 +2028,7 @@ class IsCoursePassedTests(ModuleStoreTestCase):
             display_name='Verified Course',
             grade_cutoffs={'cutoff': 0.75, 'Pass': self.SUCCESS_CUTOFF}
         )
-        self.request = RequestFactory()
+        self.request = RequestFactoryNoCsrf()
         self.request.user = self.student
 
     def test_user_fails_if_not_clear_exam(self):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -10,7 +10,6 @@ from django.views.generic.base import RedirectView
 from ratelimitbackend import admin
 
 from courseware.views.index import CoursewareIndex
-from courseware.module_render import XblockCallbackView
 from courseware.views.views import CourseTabView, EnrollStaffView, StaticCourseTabView
 from django_comment_common.models import ForumsConfig
 from openedx.core.djangoapps.auth_exchange.views import LoginWithAccessTokenView
@@ -252,7 +251,7 @@ urlpatterns += (
             course_key=settings.COURSE_ID_PATTERN,
             usage_key=settings.USAGE_ID_PATTERN,
         ),
-        XblockCallbackView.as_view(),
+        'courseware.module_render.handle_xblock_callback',
         name='xblock_handler',
     ),
     url(


### PR DESCRIPTION
This PR adds OAuth2 and JWT API to call XBlock handlers. It is an alternative approach to edx#15940 - it reuses some DRF logic to handle this, but does not convert `handle_xblock_callback` to DRF view, which caused issues described in edx/Xblock#383.

It needed some reverts as well, because changes from edx#15940 were needed here.

**Testing instructions**:

1. Run tests: `pytest lms/djangoapps/courseware/tests`.
2. Set up OAuth2 token and make GET and POST requests to xblock endpoint.