### PR TITLE
MCKIN-8826: Version bump group-project to 0.1.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -10,7 +10,7 @@
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.16#egg=xblock-ooyala==2.0.16
--e git+https://github.com/edx-solutions/xblock-group-project.git@6a68ea09478e49e796ee4c0a985018ec4257b7d7#egg=xblock-group-project
+git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-group-project==0.1.1
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@1.5.1#egg=xblock-poll==1.5.1
 -e git+https://github.com/edx/edx-notifications.git@0.6.6#egg=edx-notifications==0.6.6


### PR DESCRIPTION
@UmanShahzad 
Version bump xblock-group-project to 0.1.1 to exclude from completion aggregation.

**JIRA tickets**: MCKIN-8826

**Discussions**: NA

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

Version bump of already tested code.

**Author notes and concerns**:


**Reviewers**
- [x] @UmanShahzad 

**Settings**
