### PR TITLE
update the ooyala xblock version

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -9,7 +9,7 @@
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new
--e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.16#egg=xblock-ooyala==2.0.16
+-e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.18#egg=xblock-ooyala==2.0.18
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-group-project==0.1.1
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@1.5.1#egg=xblock-poll==1.5.1


### PR DESCRIPTION
This PR is updating the Ooyala-xblock version to 2.0.18. 
Tickets: MCKIN-8790