### PR TITLE
MCKIN-8827: Version bump aggregator to 1.5.16

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,6 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.15
+openedx-completion-aggregator==1.5.16
 
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump aggregator to improve performance of single-user single-course endpoint.

**JIRA tickets**: MCKIN-8827

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD -Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up. sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

Tested on open-craft/openedx-completion-aggregator#47

**Author notes and concerns**:

**Reviewers**
- [ ] @xitij2000 

**Settings**
