### PR TITLE
DnDv2 version corrected

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -5,7 +5,7 @@
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.1#egg=xblock-image-explorer==1.0.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 # FIXME: temp hash, until a proper solution is findout (ref ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8249)
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@6756362ffdcbaa38bb0becb3f35e739472b0254a#egg=xblock-drag-and-drop-v2==2.2.1
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@83af3b9b3e9a7e9bb4350bdb5dd813cd6bfd2126#egg=xblock-drag-and-drop-v2==2.2.1
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -5,7 +5,7 @@
 -e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.1#egg=xblock-image-explorer==1.0.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 # FIXME: temp hash, until a proper solution is findout (ref ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8249)
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@7c95f906af2f16eb23352b155c77a16466602631#egg=xblock-drag-and-drop-v2==2.2.1
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@6756362ffdcbaa38bb0becb3f35e739472b0254a#egg=xblock-drag-and-drop-v2==2.2.1
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new


### PR DESCRIPTION
Pointed to commit containing the temp image fix https://github.com/edx-solutions/xblock-drag-and-drop-v2/commits/temp-image-fix