### PR TITLE
ooyala point to removing bitmovin and bit_wrapper branch

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -9,7 +9,7 @@
 # This is required for A2E courses that were created with the temporary (xblock-drag-and-drop-v2-new) DnDv2 branch to continue to work.
 # FIXME: bump version to 2.1.6 when https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/154 merged and tagged
 -e git+https://github.com/open-craft/xblock-drag-and-drop-v2.git@82c9dc5e16d10793e8b79e60661e1a78893fce25#egg=xblock-drag-and-drop-v2-new
--e git+https://github.com/edx-solutions/xblock-ooyala.git@c5d8946214fef5c6250b3fd85d3e6e358a5c12eb#egg=xblock-ooyala==2.0.19
+-e git+https://github.com/edx-solutions/xblock-ooyala.git@mckin-8725b#egg=xblock-ooyala==2.0.20
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-group-project==0.1.1
 -e git+https://github.com/edx-solutions/xblock-adventure.git@7bdeb62b1055377dc04a7b503f7eea8264f5847b#egg=xblock-adventure
 -e git+https://github.com/open-craft/xblock-poll.git@1.6.1#egg=xblock-poll==1.6.1


### PR DESCRIPTION
This pr is pointing ooyala fix to the branch mckin-8725b