### PR TITLE
Bump image explorer version to 1.1.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -2,7 +2,7 @@
 
 # When updating a hash of an XBlock that uses xblock-utils, please update its version hash in github.txt.
 -e git+https://github.com/edx-solutions/xblock-mentoring.git@8837eb5d91fed05ec4758dfd9b9e7adc5c906210#egg=xblock-mentoring
--e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.0.1#egg=xblock-image-explorer==1.0.1
+-e git+https://github.com/edx-solutions/xblock-image-explorer.git@v1.1.1#egg=xblock-image-explorer==1.1.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop.git@92ee2055a16899090a073e1df81e35d5293ad767#egg=xblock-drag-and-drop
 # FIXME: temp hash, until a proper solution is findout (ref ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8249)
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@83af3b9b3e9a7e9bb4350bdb5dd813cd6bfd2126#egg=xblock-drag-and-drop-v2==2.2.1


### PR DESCRIPTION
This contains a version bump for xblock-image-explorer.  It resolves the issue with image-explorer blocks being completed to early.  A similar problem for polls and surveys has already been resolved.

**JIRA tickets**: Implements BB-590

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

Install the latest requirements: Create a course that has a poll, survey and image-explorer block. 

In studio (log in as staff w/ password edx): 

1. Go into advanced settings and add {{"poll", "survey", "image-explorer"}} to the list of advanced xblock types.  (Note, the list has to be a valid JSON list: double quotes only, no trailing comma, square brackets around the whole thing).
2. Then go into the course outline, and create a new chapter, section, and unit, and inside the unit add three blocks, one of each type (poll, survey, image explorer).  Go ahead and use the default configuration for each block.
3. Hit publish the course.
4. You might need to update the course start date, so it's already started.

For the next section, I found it helpful to add a print statement to completion/models.py at the beginning of "submit_completion", so you can see exactly when each block gets completed.  Something like:

```python
print("***", user, block_key.block_type, block_key)
```

You can also open up a manage.py lms shell, and do:

```python
>>> from completion.models import BlockCompletion
>>> BlockCompletion.objects.filter(block_type__in=["poll", "survey", "image-explorer"])
```

In the LMS,

1. Navigate to the unit that has your blocks.
2. Verify that no BlockCompletions have been created for your new blocks.
3. Answer the poll
4. Verify that a BlockCompletion was created for the poll.
5. Answer the survey
6. Verify the a BlockCompletion was created for the survey.
7. Click around the image-explorer.
8. Verify that a BlockCompletion was created for the image-explorer.





**Author notes and concerns**:

1. We are aware that there is a glitch affecting the UI for this feature in the following way: ...
   Currently looking for ways to fix it.
2. We tried to optimize for accessibility, but there are still some open questions: ...

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```