### PR TITLE
[MCKIN-9028] Downgrade `discussion-edx-platform-extensions`

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -22,7 +22,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.10#egg=xblock-group-project-v2==0.4.10
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.1#egg=xblock-virtualreality==0.1.1
-git+https://github.com/edx-solutions/api-integration.git@v2.3.7#egg=api-integration==2.3.7
+git+https://github.com/edx-solutions/api-integration.git@revert/MCKIN-8502#egg=api-integration==2.3.9
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.6#egg=organizations-edx-platform-extensions==1.2.6
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.12#egg=gradebook-edx-platform-extensions==1.1.12
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.1.6#egg=projects-edx-platform-extensions==1.1.6

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -22,7 +22,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.10#egg=xblock-group-project-v2==0.4.10
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.1#egg=xblock-virtualreality==0.1.1
-git+https://github.com/edx-solutions/api-integration.git@revert/MCKIN-8502#egg=api-integration==2.3.9
+git+https://github.com/open-craft/api-integration.git@revert/MCKIN-8502#egg=api-integration==2.3.9
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.6#egg=organizations-edx-platform-extensions==1.2.6
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.12#egg=gradebook-edx-platform-extensions==1.1.12
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.1.6#egg=projects-edx-platform-extensions==1.1.6

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -26,7 +26,7 @@ git+https://github.com/edx-solutions/api-integration.git@v2.3.7#egg=api-integrat
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.6#egg=organizations-edx-platform-extensions==1.2.6
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.12#egg=gradebook-edx-platform-extensions==1.1.12
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.1.6#egg=projects-edx-platform-extensions==1.1.6
-git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2.9#egg=discussion-edx-platform-extensions==1.2.9
+git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2.8#egg=discussion-edx-platform-extensions==1.2.8
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -22,7 +22,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.10#egg=xblock-group-project-v2==0.4.10
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.1#egg=xblock-virtualreality==0.1.1
-git+https://github.com/open-craft/api-integration.git@revert/MCKIN-8502#egg=api-integration==2.3.9
+git+https://github.com/edx-solutions/api-integration.git@v2.3.9#egg=api-integration==2.3.9
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.6#egg=organizations-edx-platform-extensions==1.2.6
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.12#egg=gradebook-edx-platform-extensions==1.1.12
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.1.6#egg=projects-edx-platform-extensions==1.1.6


### PR DESCRIPTION
Optimized `discussion-edx-platform-extensions` is not meant to go to the next prod release, so we should bump it back to v1.2.8 for now.