### PR TITLE
MCKIN-8827: Cache block structure (aggregator version bump)

### DIFF
--- a/openedx/tests/completion_aggregator_integration/test_creation.py
+++ b/openedx/tests/completion_aggregator_integration/test_creation.py
@@ -10,7 +10,7 @@ import logging
 from completion.models import BlockCompletion
 from completion.test_utils import CompletionWaffleTestMixin
 from completion_aggregator.models import Aggregator
-from completion_aggregator.tasks.aggregation_tasks import AggregationUpdater
+from completion_aggregator.core import AggregationUpdater
 import ddt
 from django.test.utils import override_settings
 from django.utils import timezone

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,6 +30,6 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.2.2#egg=mobileapps-edx-platform-extensions==1.2.2
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.16
+openedx-completion-aggregator==1.5.17
 
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
Version bump for https://github.com/open-craft/openedx-completion-aggregator/pull/49


**JIRA tickets**: Implements MCKIN-8827

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Step by step manual setup/testing/verification instructions go here.
2. Step 2

**Author notes and concerns**:

1. We are aware that there is a glitch affecting the UI for this feature in the following way: ...
   Currently looking for ways to fix it.
2. We tried to optimize for accessibility, but there are still some open questions: ...

**Reviewers**
- [ ] @xitij2000 

**Settings**
