### PR TITLE
[MCKIN-9301] BB-728 - Modify LMS APIs to enable OAuth access to problem response reports

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -1,0 +1,25 @@
+"""
+Instructor permissions for class based views
+"""
+
+from django.http import Http404
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys import InvalidKeyError
+from rest_framework import permissions
+
+from courseware.access import has_access
+from courseware.courses import get_course_by_id
+
+
+class IsCourseStaff(permissions.BasePermission):
+    """
+    Check if the requesting user is a course's staff member
+    """
+    def has_permission(self, request, view):
+        try:
+            course_key = CourseKey.from_string(view.kwargs.get('course_id'))
+        except InvalidKeyError:
+            raise Http404()
+
+        course = get_course_by_id(course_key)
+        return has_access(request.user, 'staff', course)

--- a/lms/djangoapps/instructor/urls.py
+++ b/lms/djangoapps/instructor/urls.py
@@ -1,0 +1,33 @@
+"""
+Instructor API endpoint new urls.
+"""
+
+from django.conf import settings
+from django.conf.urls import url
+
+import lms.djangoapps.instructor.views.api
+
+
+urlpatterns = [
+    url(
+        r'^v1/course/{}/tasks$'.format(
+            settings.COURSE_ID_PATTERN,
+        ),
+        lms.djangoapps.instructor.views.api.InstructorTasks.as_view(),
+        name='list_instructor_tasks',
+    ),
+    url(
+        r'^v1/course/{}/reports$'.format(
+            settings.COURSE_ID_PATTERN,
+        ),
+        lms.djangoapps.instructor.views.api.ReportDownloadsList.as_view(),
+        name='list_report_downloads',
+    ),
+    url(
+        r'^v1/course/{}/reports/problem_responses$'.format(
+            settings.COURSE_ID_PATTERN,
+        ),
+        lms.djangoapps.instructor.views.api.ProblemResponseReport.as_view(),
+        name='get_problem_responses',
+    ),
+]

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -64,6 +64,7 @@ from lms.djangoapps.instructor.enrollment import (
     send_mail_to_student,
     unenroll_email
 )
+from lms.djangoapps.instructor.permissions import IsCourseStaff
 from lms.djangoapps.instructor.views import INVOICE_KEY
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
@@ -953,51 +954,66 @@ def list_course_role_members(request, course_id):
     return JsonResponse(response_payload)
 
 
-@transaction.non_atomic_requests
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_level('staff')
-def get_problem_responses(request, course_id):
+class ProblemResponseReport(DeveloperErrorViewMixin, APIView):
     """
-    Initiate generation of a CSV file containing all student answers
-    to a given problem.
-
-    Responds with JSON
-        {"status": "... status message ..."}
-
-    if initiation is successful (or generation task is already running).
-
-    Responds with BadRequest if problem location is faulty.
+    **Use Cases**
+        Initiate generation of a CSV file containing all student answers
+        to a given problem.
+    **Example Requests**:
+        POST /api/instructor/v1/course/{}/reports
+    **Response Values**
+        {
+            "task_id": "task_id"
+            "status": "... status message ..."
+        }
+        Responds with BadRequest if problem location is faulty.
     """
-    course_key = CourseKey.from_string(course_id)
-    problem_location = request.POST.get('problem_location', '')
+    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, IsCourseStaff)
 
-    try:
-        problem_key = UsageKey.from_string(problem_location)
-        # Are we dealing with an "old-style" problem location?
-        run = problem_key.run
-        if not run:
-            problem_key = course_key.make_usage_key_from_deprecated_string(problem_location)
-        if problem_key.course_key != course_key:
-            raise InvalidKeyError(type(problem_key), problem_key)
-    except InvalidKeyError:
-        return JsonResponseBadRequest(_("Could not find problem with this location."))
+    # The non-atomic decorator is required because this view calls a celery
+    # task which uses the 'outer_atomic' context manager.
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, *args, **kwargs):  # pylint: disable=W0221
+        return super(ProblemResponseReport, self).dispatch(*args, **kwargs)
 
-    try:
-        lms.djangoapps.instructor_task.api.submit_calculate_problem_responses_csv(request, course_key, problem_location)
-        success_status = _(
-            "The problem responses report is being created."
-            " To view the status of the report, see Pending Tasks below."
-        )
-        return JsonResponse({"status": success_status})
-    except AlreadyRunningError:
-        already_running_status = _(
-            "A problem responses report generation task is already in progress. "
-            "Check the 'Pending Tasks' table for the status of the task. "
-            "When completed, the report will be available for download in the table below."
-        )
-        return JsonResponse({"status": already_running_status})
+    @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+    def post(self, request, course_id):
+        """
+        Initiate generation of a CSV file containing all student answers
+        to a given problem.
+        """
+        course_key = CourseKey.from_string(course_id)
+        problem_location = request.POST.get('problem_location', '')
+        report_type = _('problem responses')
+
+        try:
+            problem_key = UsageKey.from_string(problem_location)
+            # Are we dealing with an "old-style" problem location?
+            run = problem_key.run
+            if not run:
+                problem_key = UsageKey.from_string(problem_location).map_into_course(course_key)
+            if problem_key.course_key != course_key:
+                raise InvalidKeyError(type(problem_key), problem_key)
+        except InvalidKeyError:
+            return JsonResponseBadRequest(_("Could not find problem with this location."))
+
+        try:
+            lms.djangoapps.instructor_task.api.submit_calculate_problem_responses_csv(
+                request, course_key, problem_location
+            )
+            success_status = _(
+                "The problem responses report is being created."
+                " To view the status of the report, see Pending Tasks below."
+            )
+            return JsonResponse({"status": success_status})
+        except AlreadyRunningError:
+            already_running_status = _(
+                "A problem responses report generation task is already in progress. "
+                "Check the 'Pending Tasks' table for the status of the task. "
+                "When completed, the report will be available for download in the table below."
+            )
+            return JsonResponse({"status": already_running_status})
 
 
 @require_POST
@@ -2297,50 +2313,79 @@ def list_email_content(request, course_id):  # pylint: disable=unused-argument
     return JsonResponse(response_payload)
 
 
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_level('staff')
-def list_instructor_tasks(request, course_id):
+class InstructorTasks(DeveloperErrorViewMixin, APIView):
     """
-    List instructor tasks.
-
-    Takes optional query paremeters.
+    **Use Cases**
+        Lists currently running instructor tasks
+    **Parameters**
         - With no arguments, lists running tasks.
         - `problem_location_str` lists task history for problem
         - `problem_location_str` and `unique_student_identifier` lists task
             history for problem AND student (intersection)
+    **Example Requests**:
+        POST /api/instructor/v1/course/{}/tasks
+    **Response Values**
+        {
+          "tasks": [
+            {
+              "status": "Incomplete",
+              "task_type": "grade_problems",
+              "task_id": "2519ff31-22d9-4a62-91e2-55495895b355",
+              "created": "2019-01-15T18:00:15.902470+00:00",
+              "task_input": "{}",
+              "duration_sec": "unknown",
+              "task_message": "No status information available",
+              "requester": "staff",
+              "task_state": "PROGRESS"
+            }
+          ]
+        }
     """
-    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    problem_location_str = strip_if_string(request.POST.get('problem_location_str', False))
-    student = request.POST.get('unique_student_identifier', None)
-    if student is not None:
-        student = get_student_from_identifier(student)
+    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, IsCourseStaff)
 
-    if student and not problem_location_str:
-        return HttpResponseBadRequest(
-            "unique_student_identifier must accompany problem_location_str"
-        )
+    @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+    def post(self, request, course_id):
+        """
+        List instructor tasks.
+        """
+        course_id = CourseKey.from_string(course_id)
+        problem_location_str = strip_if_string(request.POST.get('problem_location_str', False))
+        student = request.POST.get('unique_student_identifier', None)
+        if student is not None:
+            student = get_student_from_identifier(student)
 
-    if problem_location_str:
-        try:
-            module_state_key = course_id.make_usage_key_from_deprecated_string(problem_location_str)
-        except InvalidKeyError:
-            return HttpResponseBadRequest()
-        if student:
-            # Specifying for a single student's history on this problem
-            tasks = lms.djangoapps.instructor_task.api.get_instructor_task_history(course_id, module_state_key, student)
+        if student and not problem_location_str:
+            return HttpResponseBadRequest(
+                "unique_student_identifier must accompany problem_location_str"
+            )
+
+        if problem_location_str:
+            try:
+                module_state_key = course_id.make_usage_key_from_deprecated_string(problem_location_str)
+            except InvalidKeyError:
+                return HttpResponseBadRequest()
+            if student:
+                # Specifying for a single student's history on this problem
+                tasks = lms.djangoapps.instructor_task.api.get_instructor_task_history(
+                    course_id,
+                    module_state_key,
+                    student
+                )
+            else:
+                # Specifying for single problem's history
+                tasks = lms.djangoapps.instructor_task.api.get_instructor_task_history(
+                    course_id,
+                    module_state_key
+                )
         else:
-            # Specifying for single problem's history
-            tasks = lms.djangoapps.instructor_task.api.get_instructor_task_history(course_id, module_state_key)
-    else:
-        # If no problem or student, just get currently running tasks
-        tasks = lms.djangoapps.instructor_task.api.get_running_instructor_tasks(course_id)
+            # If no problem or student, just get currently running tasks
+            tasks = lms.djangoapps.instructor_task.api.get_running_instructor_tasks(course_id)
 
-    response_payload = {
-        'tasks': map(extract_task_features, tasks),
-    }
-    return JsonResponse(response_payload)
+        response_payload = {
+            'tasks': map(extract_task_features, tasks),
+        }
+        return JsonResponse(response_payload)
 
 
 @require_POST
@@ -2385,24 +2430,44 @@ def list_entrance_exam_instructor_tasks(request, course_id):  # pylint: disable=
     return JsonResponse(response_payload)
 
 
-@require_POST
-@ensure_csrf_cookie
-@cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_level('staff')
-def list_report_downloads(_request, course_id):
+class ReportDownloadsList(DeveloperErrorViewMixin, APIView):
     """
-    List grade CSV files that are available for download for this course.
+    **Use Cases**
+        Lists reports available for download
+    **Example Requests**:
+        POST /api/instructor/v1/course/{}/tasks
+    **Response Values**
+        {
+            "downloads": [
+                {
+                    "url": "https://1.mock.url",
+                    "link": "<a href=\"https://1.mock.url\">mock_file_name_1</a>",
+                    "name": "mock_file_name_1"
+                }
+            ]
+        }
     """
-    course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
-    report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
+    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, IsCourseStaff)
 
-    response_payload = {
-        'downloads': [
-            dict(name=name, url=url, link=HTML('<a href="{}">{}</a>').format(HTML(url), Text(name)))
-            for name, url in report_store.links_for(course_id)
-        ]
-    }
-    return JsonResponse(response_payload)
+    @cache_control(no_cache=True, no_store=True, must_revalidate=True)
+    def post(self, request, course_id):
+        """
+        List grade CSV files that are available for download for this course.
+        Takes the following query parameters:
+        - (optional) report_name - name of the report
+        """
+        course_id = CourseKey.from_string(course_id)
+        report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
+        report_name = request.POST.get("report_name", None)
+
+        response_payload = {
+            'downloads': [
+                dict(name=name, url=url, link=HTML('<a href="{}">{}</a>').format(HTML(url), Text(name)))
+                for name, url in report_store.links_for(course_id) if report_name is None or name == report_name
+            ]
+        }
+        return JsonResponse(response_payload)
 
 
 @require_POST

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -17,8 +17,6 @@ urlpatterns = patterns(
         'lms.djangoapps.instructor.views.api.modify_access', name="modify_access"),
     url(r'^bulk_beta_modify_access$',
         'lms.djangoapps.instructor.views.api.bulk_beta_modify_access', name="bulk_beta_modify_access"),
-    url(r'^get_problem_responses$',
-        'lms.djangoapps.instructor.views.api.get_problem_responses', name="get_problem_responses"),
     url(r'^get_grading_config$',
         'lms.djangoapps.instructor.views.api.get_grading_config', name="get_grading_config"),
     url(r'^get_students_features(?P<csv>/csv)?$',
@@ -63,8 +61,6 @@ urlpatterns = patterns(
         name="mark_student_can_skip_entrance_exam"
     ),
 
-    url(r'^list_instructor_tasks$',
-        'lms.djangoapps.instructor.views.api.list_instructor_tasks', name="list_instructor_tasks"),
     url(r'^list_background_email_tasks$',
         'lms.djangoapps.instructor.views.api.list_background_email_tasks', name="list_background_email_tasks"),
     url(r'^list_email_content$',
@@ -89,8 +85,6 @@ urlpatterns = patterns(
         'lms.djangoapps.instructor.views.api.get_proctored_exam_results', name="get_proctored_exam_results"),
 
     # Grade downloads...
-    url(r'^list_report_downloads$',
-        'lms.djangoapps.instructor.views.api.list_report_downloads', name="list_report_downloads"),
     url(r'calculate_grades_csv$',
         'lms.djangoapps.instructor.views.api.calculate_grades_csv', name="calculate_grades_csv"),
     url(r'problem_grade_report$',

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -291,7 +291,10 @@ def _section_e_commerce(course, access, paid_mode, coupons_enabled, reports_enab
         'exec_summary_report_url': reverse('get_exec_summary_report', kwargs={'course_id': unicode(course_key)}),
         'list_financial_report_downloads_url': reverse('list_financial_report_downloads',
                                                        kwargs={'course_id': unicode(course_key)}),
-        'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
+        'list_instructor_tasks_url': reverse(
+            'api_instructor:list_instructor_tasks',
+            kwargs={'course_id': unicode(course_key)}
+        ),
         'look_up_registration_code': reverse('look_up_registration_code', kwargs={'course_id': unicode(course_key)}),
         'coupons': coupons,
         'sales_admin': access['sales_admin'],
@@ -388,7 +391,7 @@ def _section_certificates(course):
                 kwargs={'course_id': course.id}
             ),
             'list_instructor_tasks_url': reverse(
-                'list_instructor_tasks',
+                'api_instructor:list_instructor_tasks',
                 kwargs={'course_id': course.id}
             ),
         }
@@ -446,7 +449,10 @@ def _section_course_info(course, access):
         'start_date': course.start,
         'end_date': course.end,
         'num_sections': len(course.children),
-        'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
+        'list_instructor_tasks_url': reverse(
+            'api_instructor:list_instructor_tasks',
+            kwargs={'course_id': unicode(course_key)}
+        ),
     }
 
     if settings.FEATURES.get('DISPLAY_ANALYTICS_ENROLLMENTS'):
@@ -572,7 +578,10 @@ def _section_student_admin(course, access):
             'mark_student_can_skip_entrance_exam',
             kwargs={'course_id': unicode(course_key)},
         ),
-        'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
+        'list_instructor_tasks_url': reverse(
+            'api_instructor:list_instructor_tasks',
+            kwargs={'course_id': unicode(course_key)}
+        ),
         'list_entrace_exam_instructor_tasks_url': reverse('list_entrance_exam_instructor_tasks',
                                                           kwargs={'course_id': unicode(course_key)}),
         'spoc_gradebook_url': reverse('spoc_gradebook', kwargs={'course_id': unicode(course_key)}),
@@ -609,7 +618,10 @@ def _section_data_download(course, access):
         'section_display_name': _('Data Download'),
         'access': access,
         'show_generate_proctored_exam_report_button': show_proctored_report_button,
-        'get_problem_responses_url': reverse('get_problem_responses', kwargs={'course_id': unicode(course_key)}),
+        'get_problem_responses_url': reverse(
+            'api_instructor:get_problem_responses',
+            kwargs={'course_id': unicode(course_key)}
+        ),
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': unicode(course_key)}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': unicode(course_key)}),
         'get_issued_certificates_url': reverse(
@@ -620,8 +632,14 @@ def _section_data_download(course, access):
         ),
         'get_anon_ids_url': reverse('get_anon_ids', kwargs={'course_id': unicode(course_key)}),
         'list_proctored_results_url': reverse('get_proctored_exam_results', kwargs={'course_id': unicode(course_key)}),
-        'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
-        'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': unicode(course_key)}),
+        'list_instructor_tasks_url': reverse(
+            'api_instructor:list_instructor_tasks',
+            kwargs={'course_id': unicode(course_key)}
+        ),
+        'list_report_downloads_url': reverse(
+            'api_instructor:list_report_downloads',
+            kwargs={'course_id': unicode(course_key)}
+        ),
         'calculate_grades_csv_url': reverse('calculate_grades_csv', kwargs={'course_id': unicode(course_key)}),
         'problem_grade_report_url': reverse('problem_grade_report', kwargs={'course_id': unicode(course_key)}),
         'course_has_survey': True if course.course_survey_name else False,
@@ -678,7 +696,7 @@ def _section_send_email(course, access):
         'course_modes': course_modes,
         'default_cohort_name': DEFAULT_COHORT_NAME,
         'list_instructor_tasks_url': reverse(
-            'list_instructor_tasks', kwargs={'course_id': unicode(course_key)}
+            'api_instructor:list_instructor_tasks', kwargs={'course_id': unicode(course_key)}
         ),
         'email_background_tasks_url': reverse(
             'list_background_email_tasks', kwargs={'course_id': unicode(course_key)}

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -535,6 +535,9 @@ urlpatterns += (
         include(COURSE_URLS)
     ),
 
+    # Instructor API (accessible via OAuth)
+    url(r'^api/instructor/', include('lms.djangoapps.instructor.urls', namespace='api_instructor')),
+
     # Discussions Management
     url(
         r'^courses/{}/discussions/settings$'.format(


### PR DESCRIPTION
This PR enables OAuth access of the endpoints necessary to generate, get status and download problem response reports.

**JIRA tickets**: [OSPR-2983](https://openedx.atlassian.net/browse/OSPR-2983), [BB-728](https://tasks.opencraft.com/browse/BB-728)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 25/01/2019 (end of Sprint 186).

**Testing instructions**:

1. Run tests related to this new endpoint:
```
paver test_system -t lms/djangoapps/instructor/tests/test_api.py
```
2. [Go to the `DemoX edX Demonstration Course` as **staff** user.
](http://lms.mcka.local/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download)
3. Check if the generation of problem response reports is working correctly via the instructor interface.
4. [Create an Oauth client here if one does not exists for testing.](http://localhost:18000/admin/oauth2/client)
5. Use the Oauth2 endpoint to get an auth token (cUrl, Postman or other tool).
6. Check get_response_report endpoint. Example:
Request:
```
POST /courses/course-v1:edX+DemoX+Demo_Course/instructor/api/get_problem_responses
Body:
{
    "problem_location": "block-v1:edX+DemoX+Demo_Course+type@problem+block@c554538a57664fac80783b99d9d6da7c"
}
```
Response:
```
{
  "status": "The problem responses report is being created. To view the status of the report, see Pending Tasks below."
}
```
7. Check list_instructor_tasks endpoint. Example:
Request:
```
POST /courses/course-v1:edX+DemoX+Demo_Course/instructor/api/list_instructor_tasks
Body: {}
```
Response:
```
{
  "tasks": [
    {
      "status": "Incomplete", 
      "task_type": "grade_course", 
      "task_id": "4f78e78c-3d66-4265-af21-ca75c43036a3", 
      "created": "2019-01-15T18:00:14.088198+00:00", 
      "task_input": "{}", 
      "duration_sec": "unknown", 
      "task_message": "No status information available", 
      "requester": "staff", 
      "task_state": "PROGRESS"
    }
  ]
}
```
8. Check list_report_downloads endpoint. Example:
Request:
```
POST /courses/course-v1:edX+DemoX+Demo_Course/instructor/api/list_report_downloads
Body: {}
```
Response:
```
{
  "downloads": [
    {
      "url": "/media/bb6d638a296059742509a0d319ddf8456b6dbf9a/edX_DemoX_Demo_Course_student_state_from_block-v1_edX%2BDemoX%2BDemo_Course%2Btype%40problem%2Bblock%40c554538a57664fac80783b99d9d6da7c_2019-01-18-1353.csv", 
      "link": "<a href=\"/media/bb6d638a296059742509a0d319ddf8456b6dbf9a/edX_DemoX_Demo_Course_student_state_from_block-v1_edX%2BDemoX%2BDemo_Course%2Btype%40problem%2Bblock%40c554538a57664fac80783b99d9d6da7c_2019-01-18-1353.csv\">edX_DemoX_Demo_Course_student_state_from_block-v1_edX+DemoX+Demo_Course+type@problem+block@c554538a57664fac80783b99d9d6da7c_2019-01-18-1353.csv</a>", 
      "name": "edX_DemoX_Demo_Course_student_state_from_block-v1_edX+DemoX+Demo_Course+type@problem+block@c554538a57664fac80783b99d9d6da7c_2019-01-18-1353.csv"
    }
  ]
}
```

**Author notes and concerns**:

1. I'm not sure if it's better to move these endpoints to `/api/v1/instructor`. I've left them in the same place as before for now.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
