### PR TITLE
[MCKIN-9274] Version bump for problem builder

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
 -e git+https://github.com/open-craft/xblock-poll.git@1.6.3#egg=xblock-poll==1.6.3
 -e git+https://github.com/edx/edx-notifications.git@0.8.2#egg=edx-notifications==0.8.2
--e git+https://github.com/open-craft/problem-builder.git@v3.2.0#egg=xblock-problem-builder==3.2.0
+-e git+https://github.com/open-craft/problem-builder.git@v3.2.1#egg=xblock-problem-builder==3.2.1
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.3#egg=xblock-chat==0.2.3
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@53c6b6e4e8764627ed352e30fe2c60755e91d262#egg=xblock-eoc-journal


### PR DESCRIPTION
Version bump for problem builder to v3.2.1.

Already tested on https://github.com/open-craft/problem-builder/pull/224.