### PR TITLE
Bump completion to v0.1.15

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -218,5 +218,5 @@ edx-sga==0.6.2
 # Redis version
 redis==2.10.6
 
-# Completion
-edx-completion==0.1.10
+# Completion - using custom.txt for Github branch
+# edx-completion==0.1.10

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -31,4 +31,5 @@ git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#e
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.3.0#egg=mobileapps-edx-platform-extensions==1.3.0
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
 openedx-completion-aggregator==1.5.19
+-e git+https://github.com/open-craft/completion.git@0.1.15#egg=edx-completion==0.1.15
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -31,5 +31,5 @@ git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#e
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.3.0#egg=mobileapps-edx-platform-extensions==1.3.0
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
 openedx-completion-aggregator==1.5.19
--e git+https://github.com/open-craft/completion.git@0.1.15#egg=edx-completion==0.1.15
+-e git+https://github.com/edx/completion.git@4c96b3fd2955cb5833ba7e717c8e7a6a544beb9b#egg=edx-completion==0.1.15
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.0.1#egg=openedx-user-manager-api==1.0.1


### PR DESCRIPTION
This PR bumps completions to add OAuth authentication to POST endpoint.

**Testing instructions**:

1. Create an OAuth token to test the POST endpoint.
2. Perform a POST request to set completion, i.e.
```
curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"username":"<username>","course_key":"<course_key>","blocks":{"<block_id>":1.0}}' localhost:8000/api/completion/v1/completion-batch
```

**Reviewers**
- [x] @jcdyer 
- [ ] edX reviewer[s] TBD
