### PR TITLE
YONK-967: Integrity error fixed on set_scores

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -27,7 +27,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict, namedtuple
 
 from contracts import contract, new_contract
-from django.db import DatabaseError
+from django.db import DatabaseError, IntegrityError, transaction
 from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.block_types import BlockTypeKeyV1
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -994,15 +994,26 @@ def set_score(user_id, usage_key, score, max_score):
     """
     Set the score and max_score for the specified user and xblock usage.
     """
-    student_module, created = StudentModule.objects.get_or_create(
-        student_id=user_id,
-        module_state_key=usage_key,
-        course_id=usage_key.course_key,
-        defaults={
-            'grade': score,
-            'max_grade': max_score,
-        }
-    )
+    created = False
+    kwargs = {"student_id": user_id, "module_state_key": usage_key, "course_id": usage_key.course_key}
+    try:
+        with transaction.atomic():
+            student_module, created = StudentModule.objects.get_or_create(
+                defaults={
+                    'grade': score,
+                    'max_grade': max_score,
+                },
+                **kwargs
+            )
+    except IntegrityError:
+        # log information for duplicate entry and get the record as above command failed.
+        log.exception(
+            'set_score: IntegrityError for student %s - course_id %s - usage_key %s having '
+            'score %d and max_score %d',
+            str(user_id), usage_key.course_key, usage_key, score, max_score
+        )
+        student_module = StudentModule.objects.get(**kwargs)
+
     if not created:
         student_module.grade = score
         student_module.max_grade = max_score


### PR DESCRIPTION
Implemented the try/except block on saving a user's score as implemented in Hawthorn release [link](https://github.com/edx/edx-platform/blob/open-release/hawthorn.master/lms/djangoapps/courseware/model_data.py#L993)

It will avoid raising database errors on New Relic.

Upstream PR: https://github.com/edx/edx-platform/pull/16912/files