### PR TITLE
MCKIN-9407 Remove string on iframe after launching popup

### DIFF
--- a/lms/static/scorm/ssla/config_override.js
+++ b/lms/static/scorm/ssla/config_override.js
@@ -17,7 +17,7 @@ var sslaConfig = {
     closePopupMultiScoBehavior: "",
     singleScoView: "HIDE_ALL",
     popupMainContentMessageAfterOpen: function() {
-        return '<a style="pointer-events: none; font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #cccccc;" href="#">Click here to open the content experience.</a>';
+        return '';
     },
     popupMainContentMessageFailed: function() {
         return '<a style="font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #3384CA;" onclick="parent.ssla.ssla.popupManually();" href="#">Click here to open the content experience.</a>';


### PR DESCRIPTION
Once a user launches a scorm course in a popup, a string would appear on the iframe(scormxblock) that seemed visually clickable but was not, and was unnecessary. This PR removes that string.