### PR TITLE
Bump edx-completion to 0.1.10.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -218,6 +218,3 @@ edx-sga==0.6.2
 
 # Redis version
 redis==2.10.6
-
-# Completion
-edx-completion==0.1.10

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,3 +90,6 @@ git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 
 # Third Party XBlocks
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@4cc813c02b1fe259d3da7192f706a6fce5548d3a#egg=xblock-drag-and-drop-v2==2.1.7
+
+# Forked completion for mobile app
+git+https://github.com/open-craft/completion.git@eb4396ec9a86ae879bfa2328dbd56da299b4274f#egg=edx-completion==0.1.10.1

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -92,4 +92,4 @@ git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@4cc813c02b1fe259d3da7192f706a6fce5548d3a#egg=xblock-drag-and-drop-v2==2.1.7
 
 # Forked completion for mobile app
-git+https://github.com/open-craft/completion.git@eb4396ec9a86ae879bfa2328dbd56da299b4274f#egg=edx-completion==0.1.10.1
+git+https://github.com/open-craft/completion.git@5256e9de45fcce3c45c1c7b2c629bd881867b038#egg=edx-completion==0.1.10.1


### PR DESCRIPTION
This PR bumps completions to add OAuth authentication to POST endpoint.

**Testing instructions**:

1. Create an OAuth token to test the POST endpoint.
2. Perform a POST request to set completion, i.e.
```
curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"username":"<username>","course_key":"<course_key>","blocks":{"<block_id>":1.0}}' localhost:8000/api/completion/v1/completion-batch
```

**Reviewers**
- [x] @jcdyer 
- [ ] edX reviewer[s] TBD
