### PR TITLE
MCKIN-9466: bump api-integration version to v2.5.1

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -22,7 +22,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.4.10#egg=xblock-group-project-v2==0.4.10
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.1#egg=xblock-virtualreality==0.1.1
-git+https://github.com/edx-solutions/api-integration.git@v2.5.0#egg=api-integration==2.5.0
+git+https://github.com/edx-solutions/api-integration.git@v2.5.1#egg=api-integration==2.5.1
 git+https://github.com/edx-solutions/organizations-edx-platform-extensions.git@v1.2.7#egg=organizations-edx-platform-extensions==1.2.7
 git+https://github.com/edx-solutions/gradebook-edx-platform-extensions.git@1.1.13#egg=gradebook-edx-platform-extensions==1.1.13
 git+https://github.com/edx-solutions/projects-edx-platform-extensions.git@v1.1.6#egg=projects-edx-platform-extensions==1.1.6


### PR DESCRIPTION
This PR bumps api-integration version to v2.5.1, which adds new API for fetching course engagement summary.