### PR TITLE
[MCKIN-8913] BB-785 Bump problem-builder version

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.1#egg=xblock-g
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
 -e git+https://github.com/open-craft/xblock-poll.git@1.6.3#egg=xblock-poll==1.6.3
 -e git+https://github.com/edx/edx-notifications.git@0.8.3#egg=edx-notifications==0.8.3
--e git+https://github.com/open-craft/problem-builder.git@v3.2.1#egg=xblock-problem-builder==3.2.1
+-e git+https://github.com/open-craft/problem-builder.git@v3.3.0#egg=xblock-problem-builder==3.3.0
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.3#egg=xblock-chat==0.2.3
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@53c6b6e4e8764627ed352e30fe2c60755e91d262#egg=xblock-eoc-journal


### PR DESCRIPTION
This PR bumps the version for problem-builder. The changes from problem-builder introduces a pre_delete signal receiver to delete `Answer` records when a User is deleted. See https://github.com/open-craft/problem-builder/pull/225.