### PR TITLE
MCKIN-9579 Add button when ssla fails to launch scorm popup

### DIFF
--- a/lms/static/scorm/ssla/config_override.js
+++ b/lms/static/scorm/ssla/config_override.js
@@ -20,7 +20,7 @@ var sslaConfig = {
         return '';
     },
     popupMainContentMessageFailed: function() {
-        return '<a style="font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #3384CA;" onclick="parent.ssla.ssla.popupManually();" href="#">Click here to open the content experience.</a>';
+        return '<p style="font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #000000; margin: 0px;">It looks like your browser settings has pop-ups disabled. <br>The content takes place in a new window.</p> <br><br> <button onclick="parent.ssla.ssla.popupManually();" style="background-color: #3385C7; color: white; padding: 1rem 2rem; font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; border-width: 0; font-weight: 700; border-color: #2s6a9f; border-radius: 5px;">Launch pop-up to continue</button>';
     },
     popupWindowParams: "status=1,toolbar=1,scrollbars=yes,resizable=yes,alwaysRaised=1"
 };

--- a/lms/static/scorm/ssla/config_override.js
+++ b/lms/static/scorm/ssla/config_override.js
@@ -20,7 +20,7 @@ var sslaConfig = {
         return '';
     },
     popupMainContentMessageFailed: function() {
-        return '<p style="font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #000000; margin: 0px;">It looks like your browser settings has pop-ups disabled. <br>The content takes place in a new window.</p> <br><br> <button onclick="parent.ssla.ssla.popupManually();" style="background-color: #3385C7; color: white; padding: 1rem 2rem; font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; border-width: 0; font-weight: 700; border-color: #2s6a9f; border-radius: 5px;">Launch pop-up to continue</button>';
+        return '<div style="background-color:rgb(250,250,250); width: 100%; height: 100%"> <p style="font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; color: #000000; padding-top: 54px;">It looks like your browser settings has pop-ups disabled. <br>The content takes place in a new window.</p> <br><br> <button onclick="parent.ssla.ssla.popupManually();" style="background-color: #3385C7; color: white; padding: 1rem 2rem; font-family: \'Open Sans\', Arial, sans-serif; font-size: 14px; border-width: 0; font-weight: 700; border-color: #2s6a9f; border-radius: 5px;">Launch pop-up to continue</button></div>';
     },
     popupWindowParams: "status=1,toolbar=1,scrollbars=yes,resizable=yes,alwaysRaised=1"
 };


### PR DESCRIPTION
This PR makes changes in the SSLA confiuration for the scorm xblock.
In case a popup fails to launch, change the UI shown to the user in the iframe.

Steps to reproduce: 
1. Block popups in your browser settings your local server domain.
2. Attempt to launch a scorm popup from apros (auto/manual)
3. Check that the UI is now similar to the one posted in the ticket. Also posted below for ease of review.
<img width="872" alt="screen shot 2019-02-18 at 10 45 52 pm" src="https://user-images.githubusercontent.com/17109504/52998573-6eee2780-3445-11e9-892a-42e97c09650e.png">
