### PR TITLE
MCKIN-9820: Version bump aggregator v1.5.21

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.3.0#egg=mobileapps-edx-platform-extensions==1.3.0
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.20
+openedx-completion-aggregator==1.5.21
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.1.0#egg=openedx-user-manager-api==1.1.0


### PR DESCRIPTION
MCKIN-9820, BB-941

Version bump of openedx-completion-aggregator to handle KeyError more gracefully.

See https://github.com/open-craft/openedx-completion-aggregator/pull/53

Reviewer: @xitij2000 