### PR TITLE
BB-991: Fix user deletion celery task

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1056,6 +1056,9 @@ INSTALLED_APPS = (
     # Completion
     'completion',
     'completion_aggregator',
+
+    # Profile image
+    'openedx.core.djangoapps.profile_images',
 )
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2273,6 +2273,9 @@ INSTALLED_APPS = (
 
     # User Manager API
     'user_manager',
+
+    # Profile image
+    'openedx.core.djangoapps.profile_images',
 )
 
 ######################### CSRF #########################################

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -572,6 +572,8 @@ def delete_users(users):
     for user in users:
         retire_user_comments(user)
 
-    delete_profile_images.delay(users)
+    # Delete user profile images on background task
+    usernames = list(users.values_list('username', flat=True))
+    delete_profile_images.delay(usernames)
 
     users.delete()

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -572,7 +572,7 @@ def delete_users(users):
     for user in users:
         retire_user_comments(user)
 
-    # Delete user profile images on background task
+    # Delete user profile images in background task
     usernames = list(users.values_list('username', flat=True))
     delete_profile_images.delay(usernames)
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -507,7 +507,8 @@ class UserDeletionTest(TestCase):
         user1 = UserFactory.create(password='secret')
         user2 = UserFactory.create(password='secret')
 
-        users_qs = User.objects.filter(username__in=[user1.username, user2.username])
+        usernames = [user1.username, user2.username]
+        users_qs = User.objects.filter(username__in=usernames)
 
         # Delete the users
         delete_users(users_qs)
@@ -521,7 +522,7 @@ class UserDeletionTest(TestCase):
         ])
 
         # Verify that the delete_profile_images task is called
-        mock_delete_profile_images.delay.assert_called_with(users_qs)
+        mock_delete_profile_images.delay.assert_called_with(usernames)
 
         # Verify that the user objects have been deleted
         self.assertEqual(User.objects.filter(username__in=[user1.username, user2.username]).count(), 0)


### PR DESCRIPTION
This PR fixes two small bugs in user deletion that affects both participant and company deletion.

**1. An object was passed as argument for the profile image deletion Celery task** 
Recently, a new deletion function was create in order to delete user profile images asynchronously by using a Celery task.
Because we're using the devstack to test the settings, the default setting is `CELERY_ALWAYS_EAGER = True` which runs the function synchronously by passing arguments as a normal function, without ever going through the broker.
The problem with that is that in Celery tasks the parameters need to go serialized through the message broker, when using a production environment, meaning we can't pass any Python objects. Which is exactly what's happening on [this line:](https://github.com/edx-solutions/edx-platform/blob/development/openedx/core/djangoapps/user_api/accounts/api.py#L575)
```
delete_profile_images.delay(users)  # users is a QuerySet
```
**Fix:** The `delete_profile_images` only needs usernames, so the only thing passed as parameter now are usernames, instead of the entire user_model.

**2. The delete_profile_images Celery task isn't automatically discovered by Celery**
The Celery task autodiscovery wasn't catching this task.
**Fix:** Add the Django App path to `lms/envs/common.py` and `cms/envs/common.py` 

## Testing instructions:
1. Set up `edx-platform` from your solutions devstack to runs tasks on the Celery process. You can do that by setting `CELERY_ALWAYS_EAGER = False` in `/opencraft/devstack-solutions/edx-platform/lms/envs/devstack.py`.
2. Spin up your devstack, run all the services (Forum, LMS, Studio, Apros) and additionally, you'll need to run `paver celery` from `edxapp` user.
3. Log in Apros, create a company and add a few users. You can generate a CSV and import users with the below script (don't forget to add the company id as indicated):
```
with open('/tmp/participants.csv', 'w') as f:
    for i in range(int(1e2)):
        f.write(f"Bruce,Wayne,bruce{i}@wayne.com,COMPANY-ID-HERE,course-v1:edX+DemoX+Demo_Course,participant\n")
```
4. Try to delete the company from http://apros.mcka.local/admin/companies. You will get an error where `paver devstack lms` is running like this: 
```
EncodeError: [<APIUser: asdfasdfasfcom>] is not JSON serializable 
```
5. Check out this branch, **restart LMS and the celery broker**.
6. Check that `delete_profile_images` is correctly discovered by Celery when it starts:
```
[tasks]
   ...
    . openedx.core.djangoapps.profile_images.tasks.delete_profile_images
   ...
``` 
6. Try to delete the company again, this time you won't get any errors and you'll see profile images being deleted on the Celery log output:
```
2019-02-26 18:50:06,776 INFO 20443 [celery.worker.strategy] strategy.py:55 - Received task: openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]
[2019-02-26 18:50:06,781: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce10waynecom...
[2019-02-26 18:50:06,783: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce11waynecom...
[2019-02-26 18:50:06,784: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce12waynecom...
[2019-02-26 18:50:06,785: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce1waynecom...
[2019-02-26 18:50:06,785: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce2waynecom...
[2019-02-26 18:50:06,786: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce3waynecom...
[2019-02-26 18:50:06,786: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce4waynecom...
[2019-02-26 18:50:06,787: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce5waynecom...
[2019-02-26 18:50:06,787: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce6waynecom...
[2019-02-26 18:50:06,787: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce7waynecom...
[2019-02-26 18:50:06,788: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce8waynecom...
[2019-02-26 18:50:06,788: INFO/Worker-2] openedx.core.djangoapps.profile_images.tasks.delete_profile_images[b47d2c81-10da-4758-b8f3-d517e8ff2ddf]: Deleting profile images for bruce9waynecom...
```

## Reviewers:
- [x] @Agrendalath 
- [ ] @viadanna 

Kudos to @Agrendalath for the handy user generation script.