### PR TITLE
MCKIN-9654 Ssla Config: handle scorm popup close

### DIFF
--- a/lms/static/scorm/ssla/config_override.js
+++ b/lms/static/scorm/ssla/config_override.js
@@ -13,8 +13,10 @@ var sslaConfig = {
     studentName: studentName,
 	
     // McKA specific configurations
-    closePopupSingleScoBehavior: "",
-    closePopupMultiScoBehavior: "",
+    closePopupSingleScoBehavior: "custom",
+    closePopupMultiScoBehavior: "custom",
+    closePopupSingleScoCustomFunction: closePopupSingleSco,
+    closePopupMultiScoCustomFunction: closePopupMultiSco,
     singleScoView: "HIDE_ALL",
     popupMainContentMessageAfterOpen: function() {
         return '';
@@ -142,4 +144,18 @@ function studentName() {
   catch (e){
     return "";
   }
+}
+
+function closePopupSingleSco(){
+    console.log('Closing single sco popup');
+    handlePopupClosed();
+}
+
+function closePopupMultiSco() {
+    console.log('Closing multi sco popup');
+    handlePopupClosed();
+}
+
+function handlePopupClosed() {
+    parent.document.handleScormPopupClosed()
 }


### PR DESCRIPTION
This PR makes changes in the SSLA player configuration to add hooks to the event of "Scorm popup closing".

**Background:**
The SSLA player has been integrated on edx-platform to work with Scorm xblock. Together, the xblock and the player enable users to launch Third party authored scorm courses.

**Author's Notes:**
Please refer to the ssla player's [public documentation](https://www.jcasolutions.com/wp-content/uploads/2018/01/SSLA_Documentation.pdf) for any queries.