### PR TITLE
[MCKIN-9951] Remove profile links for retired user posts

### DIFF
--- a/common/static/common/templates/discussion/post-user-display.underscore
+++ b/common/static/common/templates/discussion/post-user-display.underscore
@@ -1,4 +1,6 @@
-<% if (username) { %>
+<% if (username && username == retiredUsername) { %>
+    <%- username %>
+<% } else if(username) { %>
 <a href="<%- user_url %>" class="username"><%- username %></a>
     <% if (is_community_ta) { %>
     <span class="user-label-community-ta"><%- gettext("(Community TA)") %></span>

--- a/common/static/common/templates/discussion/profile-thread.underscore
+++ b/common/static/common/templates/discussion/profile-thread.underscore
@@ -3,7 +3,9 @@
         <header>
             <h3><%- title %></h3>
             <p class="posted-details">
-                <% if (user) { %>
+                <% if (user && user == retiredUsername) { %>
+                    <%- user.username %>
+                <% } else if(user) %>
                     <a href="<%- user.url %>" class="username"><%- user.username %></a>
                 <% } else { %>
                     <%- gettext("anonymous") %>

--- a/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
+++ b/lms/djangoapps/discussion/static/discussion/js/discussion_board_factory.js
@@ -38,6 +38,7 @@
                 window.$$roles = options.roles;
                 DiscussionUtil.setUser(user);
                 window.user = user;
+                window.retiredUsername = options.retiredUsername;
                 Content.loadContentInfos(contentInfo);
 
                 // Create a discussion model

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board_js.template
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board_js.template
@@ -60,7 +60,8 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
                 contentInfo: ${annotated_content_info | n, dump_js_escaped_json},
                 courseName: '${course.display_name_with_default | n, js_escaped_string}',
                 courseSettings: ${course_settings | n, dump_js_escaped_json},
-                isCommentableDivided: ${is_commentable_divided | n, dump_js_escaped_json}
+                isCommentableDivided: ${is_commentable_divided | n, dump_js_escaped_json},
+                retiredUsername: '${retired_username | n, js_escaped_string}'
             });
         });
     });

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -53,6 +53,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 )
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
+from openedx.core.djangoapps.user_api.accounts.api import RETIRED_USERNAME
 
 log = logging.getLogger("edx.discussions")
 try:
@@ -485,6 +486,7 @@ def _create_discussion_board_context(request, course_key, discussion_id=None, th
         'upgrade_link': check_and_get_upgrade_link(request, user, course.id),
         'upgrade_price': get_cosmetic_verified_display_price(course),
         # ENDTODO
+        'retired_username': RETIRED_USERNAME,
     })
     return context
 

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -42,6 +42,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
 
 # Public access point for this function.
+RETIRED_USERNAME = 'Deleted user'
 visible_fields = _visible_fields
 
 
@@ -543,7 +544,7 @@ def retire_user_comments(user):
     Retire the user's discussion comments
     """
     try:
-        CCUser.from_django_user(user).retire('Deleted user')
+        CCUser.from_django_user(user).retire(RETIRED_USERNAME)
     except CommentClientRequestError as e:
         # Ignore error if discussion user does not exist
         if e.status_code != 404:

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -26,8 +26,8 @@ from ...errors import (
 )
 from ..api import (
     get_account_settings, update_account_settings, create_account, activate_account, request_password_change,
-    delete_users
-)
+    delete_users,
+    RETIRED_USERNAME)
 from .. import USERNAME_MAX_LENGTH, EMAIL_MAX_LENGTH, PASSWORD_MAX_LENGTH, PRIVATE_VISIBILITY
 
 
@@ -516,9 +516,9 @@ class UserDeletionTest(TestCase):
         # Verify that the comments of the users are retired
         mock_ccuser.from_django_user.assert_has_calls([
             call(user1),
-            call().retire('Deleted user'),
+            call().retire(RETIRED_USERNAME),
             call(user2),
-            call().retire('Deleted user'),
+            call().retire(RETIRED_USERNAME),
         ])
 
         # Verify that the delete_profile_images task is called


### PR DESCRIPTION
This PR removes the username links in discussions comment whenever the user has been retired.

**Testing instructions**:

1. Checkout this branch and restart the `edxapp`.
2. Navigate to the discussions and browse a post where a retired user made a comment.
3. Make sure the retired username does not show a link to the profile.

![image](https://user-images.githubusercontent.com/5691347/53597189-48846680-3b80-11e9-82fc-17a088328e2f.png)

**Reviewers**
- [ ] @lgp171188 
- [ ] edX reviewer[s] TBD