### PR TITLE
[MCKIN-9476] Add instructor tasks list to a path inside /api

### DIFF
--- a/lms/djangoapps/instructor/urls.py
+++ b/lms/djangoapps/instructor/urls.py
@@ -31,3 +31,12 @@ urlpatterns = [
         name='get_problem_responses',
     ),
 ]
+
+if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+    urlpatterns += [
+        url(
+            r'^v1/tasks$',
+            'lms.djangoapps.instructor_task.views.instructor_task_status',
+            name='get_instructor_task_status',
+        ),
+    ]


### PR DESCRIPTION
Adds an alternative path to instructor task API as /api/instructor/v1/tasks 