### PR TITLE
BB-1060: Use latest edx completion

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,7 +44,8 @@ djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.4
-edx-drf-extensions==1.2.2
+edx-completion==1.0.3
+edx-drf-extensions==1.11.0
 edx-i18n-tools==0.3.7
 edx-lint==0.4.3
 # astroid 1.3.8 is an unmet dependency of the version of pylint used in edx-lint 0.4.3

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v2.0.0#egg=course-edx-platform-extensions==2.0.0
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.3.0#egg=mobileapps-edx-platform-extensions==1.3.0
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.22
+openedx-completion-aggregator==1.5.23
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.1.0#egg=openedx-user-manager-api==1.1.0

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,6 +90,3 @@ git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 
 # Third Party XBlocks
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2.git@4cc813c02b1fe259d3da7192f706a6fce5548d3a#egg=xblock-drag-and-drop-v2==2.1.7
-
-# Forked completion for mobile app
-git+https://github.com/open-craft/completion.git@5256e9de45fcce3c45c1c7b2c629bd881867b038#egg=edx-completion==0.1.10.1


### PR DESCRIPTION
Version bump to use the latest version of edx-completion.  This removes the need for a separate fork for ginkgo.
 
**NOTE**  This should not be merged until the edx-completion PR merges, and gets a fresh PyPI deployment.

**JIRA tickets**: BB-1060 

**Discussions**: 

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: N/A

**Testing instructions**:

1. Verify that all completion endpoints work, directly, through apros, and via mobile.

**Author notes and concerns**:

1. We are aware that there is a glitch affecting the UI for this feature in the following way: ...
   Currently looking for ways to fix it.
2. We tried to optimize for accessibility, but there are still some open questions: ...

**Reviewers**
- [ ] @xitij2000 
- [ ] @viadanna: We need to verify that this doesn't break the mobile work you did.
