### PR TITLE
issue resolved in import function

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -395,6 +395,10 @@ class ImportManager(object):
                     if self.verbose:
                         log.debug('importing module location %s', child.location)
 
+                    if child.category == 'eoc-journal':
+                        blocks = fix_selected_pb_answer_blocks_course_key(child.selected_pb_answer_blocks)
+                        child.selected_pb_answer_blocks = blocks
+
                     _update_and_import_module(
                         child,
                         self.store,
@@ -406,6 +410,21 @@ class ImportManager(object):
                     )
 
                     depth_first(child)
+
+        def fix_selected_pb_answer_blocks_course_key(selected_pb_answer_blocks):
+            blocks = []
+            course = self.target_id
+            course_name = str(course.course)
+            org_name = str(course.org)
+            if org_name and course_name:
+                for item in selected_pb_answer_blocks:
+                    blocks_parts = item.rsplit('/')
+                    blocks_parts[2] = org_name
+                    blocks_parts[3] = course_name
+                    blocks.append('/'.join(blocks_parts))
+                return blocks
+            else:
+                return selected_pb_answer_blocks
 
         depth_first(source_courselike)
 


### PR DESCRIPTION
## [MCKIN-8813](https://edx-wiki.atlassian.net/browse/MCKIN-8813)

### Description
In EOC xblock Studio side, the status of the fields (Checkbox of PB) does not sync with the exported course. It doesn't export the checked items as part of the TAR file when we export.

The issue is that the selected_pb_answer_blocks field contains blocks that are selected and the keys which are stored in the field contains the course_key like this e.g ('i4x://testing/tst202/pb-answer/7c8b626df2ea475789d46eff41cebf20') here "testing/tst202" is course key
but when we export the course then the selected blocks which are imported in the new course contains the course_key of old course so that is why when we see them in the new course then they are not selected because the keys are not matched

The issue is fixed by adding a function in the import module by manually replacing the old course key with the new course key.

### Testing
- [ ] Run coverage command and mention new % coverage
- [ ] This PR ensures security is maintained w.r.t input validations, output escaping/encoding and privileges against user roles

### Performance
- [ ] Can impact performance (Flag if these changes can affect app performance and add a corresponding JIRA ticket here to conduct performance testing)

### Dependencies
- [ ] This PR is dependent on any other PR or configuration or JIRA issue number; please mention here
- [ ] Includes migration
 
### Post-review
- [ ] Rebase and squash commits before merge
