### PR TITLE
MCKIN-10256: Version bump aggregator 1.5.22.  Resolve dangling StaleCompletions

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -30,5 +30,5 @@ git+https://github.com/edx-solutions/discussion-edx-platform-extensions.git@v1.2
 git+https://github.com/edx-solutions/course-edx-platform-extensions.git@v1.1.1#egg=course-edx-platform-extensions==1.1.1
 git+https://github.com/edx-solutions/mobileapps-edx-platform-extensions.git@v1.3.0#egg=mobileapps-edx-platform-extensions==1.3.0
 git+https://github.com/edx-solutions/progress-edx-platform-extensions.git@1.0.8#egg=progress-edx-platform-extensions==1.0.8
-openedx-completion-aggregator==1.5.21
+openedx-completion-aggregator==1.5.22
 git+https://github.com/mckinseyacademy/openedx-user-manager-api@v1.1.0#egg=openedx-user-manager-api==1.1.0


### PR DESCRIPTION
Version bump openedx-completion-aggregator to 1.5.22.  This pulls in https://github.com/open-craft/openedx-completion-aggregator/pull/57

**JIRA tickets**: MCKIN-10256

**Discussions**: 

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

Already tested on linked aggregator PR.

**Reviewers**
- [x] @xitij2000 

