### PR TITLE
[MCKIN-8914] Delete notifications mentioning an user

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -586,11 +586,9 @@ def delete_users(users):
     user_ids = users.values_list('id', flat=True)
     notification_admin.purge_user_data(user_ids)
 
-    for user in users:
-        # Delete CourseModuleCompletion
-        user.course_completions.all().delete()
-        # Delete notifications that mention the users, e.g. group work
-        payload = '"action_username": "{}"'.format(user.username)
+    # Delete notifications that mention the users, e.g. group work
+    for username in usernames:
+        payload = '"action_username": "{}"'.format(username)
         notification_admin.purge_notifications_with_payload(payload)
 
     # Finally delete user and related models

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -586,9 +586,11 @@ def delete_users(users):
     user_ids = users.values_list('id', flat=True)
     notification_admin.purge_user_data(user_ids)
 
-    # Delete notifications that mention the users, e.g. group work
-    for username in usernames:
-        payload = '"action_username": "{}"'.format(username)
+    for user in users:
+        # Delete CourseModuleCompletion
+        user.course_completions.all().delete()
+        # Delete notifications that mention the users, e.g. group work
+        payload = '"action_username": "{}"'.format(user.username)
         notification_admin.purge_notifications_with_payload(payload)
 
     # Finally delete user and related models

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-group-project==0.1.2
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
 -e git+https://github.com/open-craft/xblock-poll.git@1.8.2#egg=xblock-poll==1.8.2
--e git+https://github.com/open-craft/edx-notifications.git@db2e6e1838daa66aba2c8076ece420e69c0a6fbc#egg=edx-notifications==0.8.4
+-e git+https://github.com/open-craft/edx-notifications.git@9930a7069dd496e3229145d0dee8f750c9d1d7cc#egg=edx-notifications==0.8.4
 -e git+https://github.com/open-craft/problem-builder.git@v3.3.1#egg=xblock-problem-builder==3.3.1
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.3#egg=xblock-chat==0.2.3


### PR DESCRIPTION
This PR changes the user deletion to also remove notifications mentioning an user.

**Testing instructions**:

1. Checkout this branch and restart edxapp.
2. Go to the discussions and create a thread with an user.
3. Create a test user and make a comment on the thread created above.
4. With the first user, confirm a notification is received containing the test user username.
5. Perform the deletion of the test user.
6. With the first user, confirm the notification does not show any longer.

BONUS: Check the MySQL table directly:
```
mysql> SELECT * from edx_notifications_notificationmessage WHERE payload LIKE '%test_user%';
Empty set (0.00 sec)
```

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD