### PR TITLE
[MCKIN-8916] Delete CourseModuleCompletion before User

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -588,6 +588,7 @@ def delete_users(users):
     # Finally delete user and related models
     for user in users.exclude(email__in=failed):
         try:
+            user.course_completions.all().delete()
             user.delete()
         except Exception as e:
             failed[user.email] = str(e)


### PR DESCRIPTION
This PR simply deletes the CourseModuleCompletion related to an User before deleting the User to prevent IntegrityErrors.

**Testing instructions**:

1. Checkout this branch and restart edxapp.
2. Create a test user and browse a course.
3. With an admin user, delete the test.
4. Assure no error occurs.

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD
