### PR TITLE
MCKIN-10480 - Rate limit backend limit made configurable

### DIFF
--- a/common/djangoapps/util/bad_request_rate_limiter.py
+++ b/common/djangoapps/util/bad_request_rate_limiter.py
@@ -2,6 +2,8 @@
 A utility class which wraps the RateLimitMixin 3rd party class to do bad request counting
 which can be used for rate limiting
 """
+from django.conf import settings
+
 from ratelimitbackend.backends import RateLimitMixin
 
 
@@ -9,6 +11,7 @@ class BadRequestRateLimiter(RateLimitMixin):
     """
     Use the 3rd party RateLimitMixin to help do rate limiting on the Password Reset flows
     """
+    requests = settings.FEATURES.get('RATE_LIMIT_BACKEND_MAX_REQUESTS', 30)
 
     def is_rate_limit_exceeded(self, request):
         """

--- a/common/djangoapps/util/bad_request_rate_limiter.py
+++ b/common/djangoapps/util/bad_request_rate_limiter.py
@@ -11,7 +11,7 @@ class BadRequestRateLimiter(RateLimitMixin):
     """
     Use the 3rd party RateLimitMixin to help do rate limiting on the Password Reset flows
     """
-    requests = settings.FEATURES.get('RATE_LIMIT_BACKEND_MAX_REQUESTS', 30)
+    requests = settings.RATE_LIMIT_BACKEND_MAX_REQUESTS
 
     def is_rate_limit_exceeded(self, request):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -216,9 +216,6 @@ FEATURES = {
     # Turn off account locking if failed login attempts exceeds a limit
     'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True,
 
-    # Max no. of bad requests after which ratelimitier backend will block IP's access
-    'RATE_LIMIT_BACKEND_MAX_REQUESTS': 30,
-
     # Hide any Personally Identifiable Information from application logs
     'SQUELCH_PII_IN_LOGS': True,
 
@@ -3396,3 +3393,6 @@ COMPLETION_AGGREGATOR_BLOCK_TYPES = {
 ############### Settings for user-state-client ##################
 # Maximum number of rows to fetch in XBlockUserStateClient calls. Adjust for performance
 USER_STATE_BATCH_SIZE = 5000
+
+# Max no. of bad requests after which ratelimitier backend will block IP's access
+RATE_LIMIT_BACKEND_MAX_REQUESTS = 30

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -216,6 +216,9 @@ FEATURES = {
     # Turn off account locking if failed login attempts exceeds a limit
     'ENABLE_MAX_FAILED_LOGIN_ATTEMPTS': True,
 
+    # Max no. of bad requests after which ratelimitier backend will block IP's access
+    'RATE_LIMIT_BACKEND_MAX_REQUESTS': 30,
+
     # Hide any Personally Identifiable Information from application logs
     'SQUELCH_PII_IN_LOGS': True,
 


### PR DESCRIPTION
Rate limit backend has a hardcoded max. limit of 30 requests after which it blocks an IP for 5 minutes. We've been having instances recently where this limit get reached due to high usage. As a quick solution we'r increasing the rate limit; for that the rate limit has been made configurable, default is kept at 30, but the value will be set according to servers in Mcka internal repo 