### PR TITLE
[MCKIN-10708] Bump xblock-poll to v1.8.5.

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v2.0.24#egg=xblock-ooyala==2.0.24
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-group-project==0.1.2
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
--e git+https://github.com/open-craft/xblock-poll.git@1.8.4#egg=xblock-poll==1.8.4
+-e git+https://github.com/open-craft/xblock-poll.git@1.8.5#egg=xblock-poll==1.8.5
 -e git+https://github.com/open-craft/edx-notifications.git@9930a7069dd496e3229145d0dee8f750c9d1d7cc#egg=edx-notifications==0.8.4
 -e git+https://github.com/open-craft/problem-builder.git@v3.3.3#egg=xblock-problem-builder==3.3.3
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix


### PR DESCRIPTION
This branch bumps the xblock-poll requirement to v1.8.5 to incorporate a fix for multiple survey blocks in the same unit interfering with each other.