### PR TITLE
MCKIN-8902: bump xblock problem-builder version to v3.3.4

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-g
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
 -e git+https://github.com/open-craft/xblock-poll.git@1.8.5#egg=xblock-poll==1.8.5
 -e git+https://github.com/open-craft/edx-notifications.git@9930a7069dd496e3229145d0dee8f750c9d1d7cc#egg=edx-notifications==0.8.4
--e git+https://github.com/open-craft/problem-builder.git@v3.3.3#egg=xblock-problem-builder==3.3.3
+-e git+https://github.com/open-craft/problem-builder.git@v3.3.4#egg=xblock-problem-builder==3.3.4
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.3#egg=xblock-chat==0.2.3
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.3.0#egg=xblock-eoc-journal==0.3.0


### PR DESCRIPTION
This PR bumps xblock problem-builder version to v3.3.4.

cc: @attiyaIshaque