### PR TITLE
MCKIN-10975: fix double initialization of blocks

### DIFF
--- a/lms/static/coffee/src/courseware.coffee
+++ b/lms/static/coffee/src/courseware.coffee
@@ -9,8 +9,6 @@ class @Courseware
     new Courseware
 
   render: ->
-    XBlock.initializeBlocks($('.course-content'))
-    
     courseContentElement = $('.course-content')[0]
     blocks = XBlock.initializeBlocks(courseContentElement)
 


### PR DESCRIPTION
Xblocks were initializing twice causing issues in the initialization of Xblock Drag and Drop, This PR removes duplicate initialization of xblocks.