### PR TITLE
MCKIN-11119 Consider white-space as punctuation during password validation

### DIFF
--- a/common/djangoapps/util/password_policy_validators.py
+++ b/common/djangoapps/util/password_policy_validators.py
@@ -95,6 +95,8 @@ def validate_password_complexity(value):
             digits.append(character)
         elif character in string.punctuation:
             punctuation.append(character)
+        elif character in string.whitespace:
+            punctuation.append(character)
         else:
             non_ascii.append(character)
 


### PR DESCRIPTION
**Ticket**: https://edx-wiki.atlassian.net/browse/MCKIN-11119

**Description:**
White-space is now considered as special character during password validation.