### PR TITLE
MCKIN-11136-version-bump-urllib3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -115,6 +115,7 @@ sympy==0.7.1
 xmltodict==0.4.1
 django-ratelimit-backend==1.0
 unicodecsv==0.9.4
+urllib3==1.25.3
 django-require==1.0.11
 django-webpack-loader==0.4.1
 pyuca==1.1


### PR DESCRIPTION
Upgrading version of urllib3 because of group-work dependency (boto3).
Error can be found [here](https://rpm.newrelic.com/accounts/631098/applications/4390895/traced_errors/940c162e-9c9e-11e9-9258-0242ac110011_0_6625)
