### PR TITLE
MCKIN-11613 Admin is unable to generate a report on course detail page.

### DIFF
--- a/lms/djangoapps/instructor_task/migrations/0003_auto_20191008_1151.py
+++ b/lms/djangoapps/instructor_task/migrations/0003_auto_20191008_1151.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instructor_task', '0002_gradereportsetting'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='instructortask',
+            name='task_input',
+            field=models.CharField(max_length=512),
+        ),
+    ]

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -59,7 +59,7 @@ class InstructorTask(models.Model):
     task_type = models.CharField(max_length=50, db_index=True)
     course_id = CourseKeyField(max_length=255, db_index=True)
     task_key = models.CharField(max_length=255, db_index=True)
-    task_input = models.CharField(max_length=255)
+    task_input = models.CharField(max_length=512)
     task_id = models.CharField(max_length=255, db_index=True)  # max_length from celery_taskmeta
     task_state = models.CharField(max_length=50, null=True, db_index=True)  # max_length from celery_taskmeta
     task_output = models.CharField(max_length=1024, null=True)
@@ -92,8 +92,8 @@ class InstructorTask(models.Model):
         json_task_input = json.dumps(task_input)
 
         # check length of task_input, and return an exception if it's too long:
-        if len(json_task_input) > 255:
-            fmt = 'Task input longer than 255: "{input}" for "{task}" of "{course}"'
+        if len(json_task_input) > 512:
+            fmt = 'Task input longer than 512: "{input}" for "{task}" of "{course}"'
             msg = fmt.format(input=json_task_input, task=task_type, course=course_id)
             raise ValueError(msg)
 

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -123,7 +123,7 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
             submit_rescore_problem_for_all_students(request, problem_url)
 
     def _test_submit_with_long_url(self, task_function, student=None):
-        problem_url_name = 'x' * 255
+        problem_url_name = 'x' * 512
         self.define_option_problem(problem_url_name)
         location = InstructorTaskModuleTestCase.problem_location(problem_url_name)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Admin was unable to generate a report on the course detail page facing the error for 3 rows when a course has a larger course id than the normal/usual course id. Now, an admin will be able to generate a report in case of selecting 3 rows.