### PR TITLE
MCKIN-12234 discussion content update focus update accordingly

### DIFF
--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -1,5 +1,5 @@
 <form class="forum-new-post-form">
-    <h<%- startHeader %> class="thread-title"><%- gettext("Add a Post") %></h<%- startHeader %>>
+    <h<%- startHeader %> class="thread-title" tabindex= "-1"><%- gettext("Add a Post") %></h<%- startHeader %>>
 
     <% if (mode === 'inline') { %>
         <button class="btn-default add-post-cancel">


### PR DESCRIPTION
When either the "Show Discussion" button or the "Add a Post" button is activated new content appears below, but focus remains on the button rather than moving to the new content.

Tab index added in order to get focus.