### PR TITLE
MCKIN-12139-AF#27-Discussion_Page-Ensure color is not the sole means of communicating information

### DIFF
--- a/common/static/common/templates/discussion/thread-list-item.underscore
+++ b/common/static/common/templates/discussion/thread-list-item.underscore
@@ -1,6 +1,6 @@
 <li data-id="<%- id %>" class="forum-nav-thread<% if (!hideReadState && neverRead) { %> never-read<% } %>">
   <% if (!hideReadState && neverRead) { %>
-    <span class="sr">Never Read</span>
+    <span class="sr"><%- gettext("Never Read") %></span>
   <% } %>
   <a href="<%- threadUrl %>" class="forum-nav-thread-link">
     <div class="forum-nav-thread-wrapper-0">

--- a/common/static/common/templates/discussion/thread-list-item.underscore
+++ b/common/static/common/templates/discussion/thread-list-item.underscore
@@ -1,4 +1,7 @@
 <li data-id="<%- id %>" class="forum-nav-thread<% if (!hideReadState && neverRead) { %> never-read<% } %>">
+  <% if (!hideReadState && neverRead) { %>
+    <span class="sr">Never Read</span>
+  <% } %>
   <a href="<%- threadUrl %>" class="forum-nav-thread-link">
     <div class="forum-nav-thread-wrapper-0">
       <%


### PR DESCRIPTION
Description

[Issue]  
Color alone is used to communicate discussion status.  The meaning provided by color is not available in textual format. For example, the blue vertical line that is used to indicate 'never read' does not have textual representation. 

[Impact]
Screen-reader users are not able to know the discussion status communicated via color alone. 

```
<li data-id="5d91fadf1398d9091ce4685d" class="forum-nav-thread never-read">
<a href="/courses/DEV/MCKA_SHOWCASE/NOV2018/discussion/forum/f0c5437e8a016eae9a849b5a4edb885b0b413f6c/threads/5d91fadf1398d9091ce4685d" class="forum-nav-thread-link">
<div class="forum-nav-thread-wrapper-0">
```


Environment

[Recommendation]
Developers must ensure information or meaning conveyed through color or sensory character is also available in textual format.