### PR TITLE
MCKIN-12234 Discussion moving focus to new content

### DIFF
--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -1,5 +1,5 @@
 <form class="forum-new-post-form">
-    <h<%- startHeader %> class="thread-title" tabindex= "-1"><%- gettext("Add a Post") %></h<%- startHeader %>>
+    <h<%- startHeader %> class="thread-title" tabindex= "0"><%- gettext("Add a Post") %></h<%- startHeader %>>
 
     <% if (mode === 'inline') { %>
         <button class="btn-default add-post-cancel">


### PR DESCRIPTION
Move programmatic focus to the top of the new content. In the case of activating "Show Discussion" focus should move to the "Add a Post" button. When "Add a Post" is activated focus should move to the heading "Add a Post".