### PR TITLE
MCKIN-12240: Discussion: on all topics click move focus to sidebar posts filter

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -98,6 +98,7 @@
                     selectedTopicList.removeClass('is-focused');
                     this.$('.forum-nav-browse-menu-wrapper').hide();
                     this.$('.forum-nav-thread-list-wrapper').show();
+                    this.$('.forum-nav-filter-main-control').focus();
                     if (this.selectedTopicId !== 'undefined') {
                         this.$('.forum-nav-browse-filter-input').attr('aria-activedescendant', this.selectedTopicId);
                     }


### PR DESCRIPTION
**Issue**: When "All Topics" button or a discussion title link is activated new content appears on the screen, but focus remains on the button rather than moving to the new content. 

**User Impact**: Screen reader users and users with low vision who may be zoomed in may not easily notice/located the new content when focus does not automatically move there.

This PR move focus to sidebar posts filter dropdown when user clicks 'all topics' link.