### PR TITLE
edx-notifications version bump

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -14,7 +14,7 @@
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-group-project==0.1.2
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
 -e git+https://github.com/open-craft/xblock-poll.git@v1.8.9#egg=xblock-poll==1.8.9
--e git+https://github.com/open-craft/edx-notifications.git@0.9.0#egg=edx-notifications==0.9.0
+-e git+https://github.com/edx/edx-notifications.git@0.9.0#egg=edx-notifications==0.9.0
 -e git+https://github.com/open-craft/problem-builder.git@v3.4.3#egg=xblock-problem-builder==3.4.3
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.5#egg=xblock-chat==0.2.5


### PR DESCRIPTION
merged OpenCraft [PR](https://github.com/edx/edx-notifications/pull/190) into edx-notifactions and updating edx-notifications links to openedx GitHub organisations. 
It was changed to OpenCraft organisations for some urgent changes. Those changes have been merged into development of edx-notifications.