### PR TITLE
MCKIN-12722: lock course assets

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/toggle_assets_lock.py
+++ b/cms/djangoapps/contentstore/management/commands/toggle_assets_lock.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                 course_key = CourseKey.from_string(course_id)
             except InvalidKeyError:
                 raise CommandError("Invalid course_id: '%s'." % course_id)
-            
+
             toggle_course_assets_lock(course_key, locked)
         else:
             courses = modulestore().get_courses()
@@ -48,7 +48,7 @@ def toggle_course_assets_lock(course_key, locked):
 
     for asset in assets:
         content_store.set_attr(asset['asset_key'], 'locked', locked)
-        
         # Delete the asset from the cache so that asset is locked/unlocked the next time it is requested.
         del_cached_content(asset['asset_key'])
+
     logger.info('Assets for course: {} successfully {}'.format(course_key, 'locked' if locked else 'unlocked'))

--- a/cms/djangoapps/contentstore/management/commands/toggle_assets_lock.py
+++ b/cms/djangoapps/contentstore/management/commands/toggle_assets_lock.py
@@ -1,0 +1,54 @@
+"""
+A Django command that toggles lock for assets of all/given courses.
+"""
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.core.djangoapps.contentserver.caching import del_cached_content
+from xmodule.contentstore.django import contentstore
+from xmodule.modulestore.django import modulestore
+
+logger = logging.getLogger(__name__)  # pylint: disable=locally-disabled, invalid-name
+
+
+class Command(BaseCommand):
+    """
+    Toggle lock for assets of all/given courses.
+    """
+    def add_arguments(self, parser):
+        parser.add_argument('--course-id', dest='course_id')
+        lock_parser = parser.add_mutually_exclusive_group(required=False)
+        lock_parser.add_argument('--lock', dest='locked', action='store_true')
+        lock_parser.add_argument('--unlock', dest='locked', action='store_false')
+        parser.set_defaults(locked=True)
+
+    def handle(self, *args, **options):
+        course_id = options.get('course_id', None)
+        locked = options.get('locked', True)
+        if course_id:
+            try:
+                course_key = CourseKey.from_string(course_id)
+            except InvalidKeyError:
+                raise CommandError("Invalid course_id: '%s'." % course_id)
+            
+            toggle_course_assets_lock(course_key, locked)
+        else:
+            courses = modulestore().get_courses()
+            for course in courses:
+                toggle_course_assets_lock(course.id, locked)
+
+
+def toggle_course_assets_lock(course_key, locked):
+    """Toggle course assets lock"""
+    content_store = contentstore()
+    assets, __ = content_store.get_all_content_for_course(course_key)
+
+    for asset in assets:
+        content_store.set_attr(asset['asset_key'], 'locked', locked)
+        
+        # Delete the asset from the cache so that asset is locked/unlocked the next time it is requested.
+        del_cached_content(asset['asset_key'])
+    logger.info('Assets for course: {} successfully {}'.format(course_key, 'locked' if locked else 'unlocked'))

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -274,6 +274,8 @@ def _upload_asset(request, course_key):
     if thumbnail_content is not None:
         content.thumbnail_location = thumbnail_location
 
+    # lock assets by default
+    setattr(content, 'locked', True)
     # then commit the content
     contentstore().save(content)
     del_cached_content(content.location)


### PR DESCRIPTION
This PR adds a management command to lock/unlock assets course assets and makes newly uploaded assets locked by default.