### PR TITLE
MCKIN-12871 PBReport: Return task_id for already running task

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1011,13 +1011,14 @@ class ProblemResponseReport(DeveloperErrorViewMixin, APIView):
                 " To view the status of the report, see Pending Tasks below."
             )
             return JsonResponse({"status": success_status, "task_id": task.task_id})
-        except AlreadyRunningError:
+        except AlreadyRunningError as e:
             already_running_status = _(
                 "A problem responses report generation task is already in progress. "
                 "Check the 'Pending Tasks' table for the status of the task. "
                 "When completed, the report will be available for download in the table below."
             )
-            return JsonResponse({"status": already_running_status})
+            running_task_id = getattr(e, 'message', e)
+            return JsonResponse({"status": already_running_status, "task_id": running_task_id})
 
 
 @require_POST

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1017,8 +1017,7 @@ class ProblemResponseReport(DeveloperErrorViewMixin, APIView):
                 "Check the 'Pending Tasks' table for the status of the task. "
                 "When completed, the report will be available for download in the table below."
             )
-            running_task_id = getattr(e, 'message', e)
-            return JsonResponse({"status": already_running_status, "task_id": running_task_id})
+            return JsonResponse({"status": already_running_status, "task_id": getattr(e, 'running_task_id')})
 
 
 @require_POST

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1017,7 +1017,7 @@ class ProblemResponseReport(DeveloperErrorViewMixin, APIView):
                 "Check the 'Pending Tasks' table for the status of the task. "
                 "When completed, the report will be available for download in the table below."
             )
-            return JsonResponse({"status": already_running_status, "task_id": getattr(e, 'running_task_id')})
+            return JsonResponse({"status": already_running_status, "task_id": getattr(e, 'running_task_id', None)})
 
 
 @require_POST

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -41,6 +41,7 @@ def _task_is_running(course_id, task_type, task_key):
         running_tasks = running_tasks.exclude(task_state=state)
     return len(running_tasks) > 0
 
+
 def _get_running_task_id(course_id, task_type, task_key):
     """Returns task_id for running task with task_key, course_id"""
 
@@ -70,7 +71,6 @@ def _reserve_task(course_id, task_type, task_key, task_input, requester):
     tasks simultaneously.  This is deemed a small enough risk to not
     put in further safeguards.
     """
-
 
     if _task_is_running(course_id, task_type, task_key):
         log.warning("Duplicate task found for task_type %s and task_key %s", task_type, task_key)

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -61,7 +61,9 @@ def _reserve_task(course_id, task_type, task_key, task_input, requester):
     task_id = _get_running_task_id(course_id, task_type, task_key)
     if task_id:
         log.warning("Duplicate task found for task_type %s and task_key %s", task_type, task_key)
-        raise AlreadyRunningError(task_id)
+        error = AlreadyRunningError("requested task is already running")
+        setattr(error, 'running_task_id', task_id)
+        raise error
 
     try:
         most_recent_id = InstructorTask.objects.latest('id').id


### PR DESCRIPTION
A task generation request for an already running task returned just the status, and not the task id. We need the task_id on apros side to check for progress of task after intervals.