### PR TITLE
MCKIN-13610 Fix failure to add LTI config

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -126,8 +126,6 @@ class LTIProviderConfigAdmin(KeyedConfigurationModelAdmin):
     """ Django Admin class for LTIProviderConfig """
 
     exclude = (
-        'icon_class',
-        'icon_image',
         'secondary',
     )
 

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -196,7 +196,7 @@ class ProviderConfig(ConfigurationModel):
     def clean(self):
         """ Ensure that either `icon_class` or `icon_image` is set """
         super(ProviderConfig, self).clean()
-        if bool(self.icon_class) == bool(self.icon_image):
+        if bool(self.icon_class) == bool(self.icon_image) and bool(self.icon_class):
             raise ValidationError('Either an icon class or an icon image must be given (but not both)')
 
     @property

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -196,7 +196,7 @@ class ProviderConfig(ConfigurationModel):
     def clean(self):
         """ Ensure that either `icon_class` or `icon_image` is set """
         super(ProviderConfig, self).clean()
-        if bool(self.icon_class) == bool(self.icon_image) and bool(self.icon_class):
+        if bool(self.icon_class) == bool(self.icon_image):
             raise ValidationError('Either an icon class or an icon image must be given (but not both)')
 
     @property


### PR DESCRIPTION
Fields icon_class and icon_image do not appear in django admin.
If they one of them is not set, LTI Config addition fails.
Issue:
<img width="460" alt="Screen Shot 2020-03-13 at 12 51 23 PM" src="https://user-images.githubusercontent.com/17109504/76602834-9242b380-652d-11ea-9321-689d7177abac.png">

This PR allows these fields to be displayed in django admin so either of them can be set.

**Url to verify:** http://courses.integration.mckinsey.edx.org/admin/third_party_auth/ltiproviderconfig/add/

**Code that causes the error:**
https://github.com/edx-solutions/edx-platform/blob/f55f1461d8b6f2e889ee9f2011c6d062fbefbe23/common/djangoapps/third_party_auth/models.py#L199