### PR TITLE
[WIP] MCKIN-13610 Temporary: bypass LTI headers

### DIFF
--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -83,13 +83,13 @@ def lti_launch(request, course_id, usage_id):
         return HttpResponseForbidden()
 
     # Check the OAuth signature on the message
-    if not SignatureValidator(lti_consumer).verify(request):
-        log.error(
-            'LTI Consumer not valid for course %s, usage_id %s',
-            course_id,
-            usage_id,
-        )
-        return HttpResponseForbidden()
+    # if not SignatureValidator(lti_consumer).verify(request):
+    #    log.error(
+    #        'LTI Consumer not valid for course %s, usage_id %s',
+    #        course_id,
+    #        usage_id,
+    #    )
+    #    return HttpResponseForbidden()
 
     # Add the course and usage keys to the parameters array
     try:


### PR DESCRIPTION
Signature validation is only checking for `Content-Type` header right now.
Currently the only LTi provider we have on board is not adding this header. Hence removing this check temporarily for initial demos until header is added.