### PR TITLE
MCKIN-12722 - assets locking put behind feature flag

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -275,7 +275,9 @@ def _upload_asset(request, course_key):
         content.thumbnail_location = thumbnail_location
 
     # lock assets by default
-    setattr(content, 'locked', True)
+    if settings.ASSETS_LOCKED_BY_DEFAULT:
+        setattr(content, 'locked', True)
+
     # then commit the content
     contentstore().save(content)
     del_cached_content(content.location)

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -547,3 +547,6 @@ PARENTAL_CONSENT_AGE_LIMIT = ENV_TOKENS.get(
 # completion aggregation data asynchronously using the run_aggregator_service
 # management command.
 COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = ENV_TOKENS.get('COMPLETION_AGGREGATOR_ASYNC_AGGREGATION', False)
+
+######### Settings for Course Assets locking #########
+ASSETS_LOCKED_BY_DEFAULT = ENV_TOKENS.get('ASSETS_LOCKED_BY_DEFAULT', ASSETS_LOCKED_BY_DEFAULT)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1440,3 +1440,6 @@ COURSEGRAPH_JOB_QUEUE = LOW_PRIORITY_QUEUE
 
 # Max no. of bad requests after which ratelimitier backend will block IP's access
 RATE_LIMIT_BACKEND_MAX_REQUESTS = 30
+
+######### Settings for Course Assets locking #########
+ASSETS_LOCKED_BY_DEFAULT = True

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -874,6 +874,7 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
             "content_type": "Video"
         })
 
+    @unittest.skip('Content no longer on youtube')
     def test_video_with_youtube_subs_index_dictionary(self):
         """
         Test index dictionary of a video module with YouTube subtitles.
@@ -892,7 +893,6 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
               <handout src="http://www.example.com/handout"/>
             </video>
         '''
-
         descriptor = instantiate_descriptor(data=xml_data_sub)
         download_youtube_subs('OEoXaMPEzfM', descriptor, settings)
         self.assertEqual(descriptor.index_dictionary(), {
@@ -903,6 +903,7 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
             "content_type": "Video"
         })
 
+    @unittest.skip('Content no longer on youtube')
     def test_video_with_subs_and_transcript_index_dictionary(self):
         """
         Test index dictionary of a video module with


### PR DESCRIPTION
This PR put assets locking behind feature flag so it could be controlled environment wise.

Related flag PR: https://github.com/edx/mckinsey-internal/pull/291

p.s fixes test failures as per upstream: https://github.com/edx/edx-platform/pull/23679