### PR TITLE
MCKIN-17522 Added set-cookie in the student view response

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1314,11 +1314,14 @@ def xblock_view(request, course_id, usage_id, view_name):
         for resource in fragment.resources:
             hashed_resources[hash_resource(resource)] = resource
 
-        return JsonResponse({
+        csrf_token = csrf(request)['csrf_token']
+        response = JsonResponse({
             'html': fragment.content,
             'resources': hashed_resources.items(),
-            'csrf_token': unicode(csrf(request)['csrf_token']),
+            'csrf_token': unicode(csrf_token),
         })
+        request.META['CSRF_COOKIE'] = csrf_token
+        return response
 
 
 def _check_files_limits(files):


### PR DESCRIPTION
**Issue:** 
csrf_token in the response body and header doesn't match.
Request Headers:
![image](https://user-images.githubusercontent.com/22004703/83516486-93fa9280-a4f0-11ea-905f-c828aae74c94.png)
Request Body:
![image](https://user-images.githubusercontent.com/22004703/83516495-9826b000-a4f0-11ea-9791-76812439f9ce.png)


**Reason:**
In Django 1.8 `from django.template.context_processors import csrf` function used to return the same [csrf token](https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/middleware/csrf.py#L40-L51) from the request.
Since we've updated the Django to 1.11 as part of Ironwood.
Now in Django 1.11`from django.template.context_processors import csrf` function returns a new [csrf token](https://github.com/django/django/blob/c669cf279ae7b3e02a61db4fb077030a4db80e4f/django/middleware/csrf.py#L80-L96) created from the last one.


**Solution:**
Update the set-cookie in response headers so that we have the same csrf_token in response body and headers.