### PR TITLE
MCKIN-17536: bump xblock-poll version to v1.9.7

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -12,7 +12,7 @@
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@v3.0.2#egg=xblock-ooyala==3.0.2
 git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-group-project==0.1.2
 -e git+https://github.com/edx-solutions/xblock-adventure.git@v0.1.1#egg=xblock-adventure==0.1.1
--e git+https://github.com/open-craft/xblock-poll.git@v1.9.3#egg=xblock-poll==1.9.3
+-e git+https://github.com/open-craft/xblock-poll.git@v1.9.7#egg=xblock-poll==1.9.7
 -e git+https://github.com/edx/edx-notifications.git@0.9.0#egg=edx-notifications==0.9.0
 -e git+https://github.com/open-craft/problem-builder.git@v3.4.17#egg=xblock-problem-builder==3.4.17
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix


### PR DESCRIPTION
This PR bumps `xblock-poll` version to `v1.9.7`