### PR TITLE
MCKIN-18600: bump xblock chat version to v0.2.7

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -16,7 +16,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-g
 -e git+https://github.com/edx/edx-notifications.git@0.9.0#egg=edx-notifications==0.9.0
 -e git+https://github.com/open-craft/problem-builder.git@v3.4.18#egg=xblock-problem-builder==3.4.18
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
--e git+https://github.com/open-craft/xblock-chat.git@v0.2.6#egg=xblock-chat==0.2.6
+-e git+https://github.com/open-craft/xblock-chat.git@v0.2.7#egg=xblock-chat==0.2.7
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.4#egg=xblock-eoc-journal==0.4
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.7.1#egg=xblock-group-project-v2==0.7.1


### PR DESCRIPTION
This PR bumps xblock chat version to v0.2.7