### PR TITLE
MCKIN-18602: bump xblock eoc-journal version to 0.6

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -17,7 +17,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-g
 -e git+https://github.com/open-craft/problem-builder.git@v3.4.18#egg=xblock-problem-builder==3.4.18
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.6#egg=xblock-chat==0.2.6
--e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.4#egg=xblock-eoc-journal==0.4
+-e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.6#egg=xblock-eoc-journal==0.6
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.7.1#egg=xblock-group-project-v2==0.7.1
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.2#egg=xblock-virtualreality==0.1.2


### PR DESCRIPTION
This PR bumps xblock eoc-journal version to 0.6