### PR TITLE
MCKIN-18602: use forked xblock-eoc-journal to support ginkgo

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -17,7 +17,9 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.2#egg=xblock-g
 -e git+https://github.com/open-craft/problem-builder.git@v3.4.19#egg=xblock-problem-builder==3.4.19
 -e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.2.7#egg=xblock-chat==0.2.7
--e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.6#egg=xblock-eoc-journal==0.6
+# xblock-eoc-journal at open-craft github is not compatible with ginko anymore, they have updated it to support ironwood
+# use v0.6 from open-craft github repo when ironwood is released.
+-e git+https://github.com/msaqib52/xblock-eoc-journal.git@ginkgo-master#egg=xblock-eoc-journal==0.5
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.4#egg=xblock-diagnostic-feedback==0.2.4
 -e git+https://github.com/open-craft/xblock-group-project-v2.git@0.7.1#egg=xblock-group-project-v2==0.7.1
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.3#egg=xblock-virtualreality==0.1.3


### PR DESCRIPTION
xblock-eoc-journal at open-craft github repo is not compatible with ginkgo anymore, they have updated it to support ironwood.

We will use v0.6 from open-craft github repo when ironwood is released.