### PR TITLE
MCKIN-21791 renaming the discussion button

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -238,7 +238,7 @@ def get_component_templates(courselike, library=False):
         }
 
     component_display_names = {
-        'discussion': _("Discussion"),
+        'discussion': _("Discussion - Do not use"),
         'html': _("HTML"),
         'problem': _("Problem"),
         'video': _("Video")

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -133,7 +133,9 @@
 
       // green button
       .add-xblock-component-button {
-        @extend %t-action3;
+          @extend %t-action3;
+          min-height:($baseline*6);
+          vertical-align: top;
 
         @include margin-right($baseline*0.75);
 


### PR DESCRIPTION
Renamed the following discussion button as a caution to not use it to create a discussion block. There is another option to create a discussion block rather than this.
<img width="1438" alt="Screenshot 2020-07-27 at 6 48 27 PM" src="https://user-images.githubusercontent.com/41048311/88549607-f035ea80-d039-11ea-9450-9933083302f1.png">
