### PR TITLE
MCKIN-22396 Fix samesite cookie issue for Scorm Shell login flow

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -114,6 +114,7 @@ def add_email_marketing_cookies(sender, response=None, user=None,
             max_age=365 * 24 * 60 * 60,  # set for 1 year
             domain=settings.SESSION_COOKIE_DOMAIN,
             path='/',
+            secure=request.is_secure()
         )
         log.info("sailthru_hid cookie:%s successfully retrieved for user %s", cookie, user.email)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -950,6 +950,8 @@ USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+SESSION_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 
 # CMS base
 CMS_BASE = 'localhost:8001'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1247,6 +1247,9 @@ CREDIT_NOTIFICATION_CACHE_TIMEOUT = 5 * 60 * 60
 MIDDLEWARE_CLASSES = [
     'openedx.core.lib.x_forwarded_for.middleware.XForwardedForMiddleware',
 
+    # Avoid issue with https://blog.heroku.com/chrome-changes-samesite-cookie
+    'django_cookies_samesite.middleware.CookiesSameSite',
+
     'crum.CurrentRequestUserMiddleware',
 
     # A newer and safer request cache.

--- a/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_middleware.py
@@ -269,7 +269,9 @@ class TestCsrfCrossDomainCookieMiddleware(TestCase):
                 domain=self.COOKIE_DOMAIN
             )
             self.assertIn(expected, cookie_header)
-            self.assertIn('Max-Age=31449600; Path=/; secure', cookie_header)
+            self.assertIn('Max-Age=31449600;', cookie_header)
+            self.assertIn('Path=/;', cookie_header)
+            self.assertIn('secure', cookie_header.lower())
 
         else:
             self.assertNotIn(self.COOKIE_NAME, response.cookies)

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -77,6 +77,7 @@ class LanguagePreferenceMiddleware(object):
                     value=user_pref,
                     domain=settings.SESSION_COOKIE_DOMAIN,
                     max_age=COOKIE_DURATION,
+                    secure=request.is_secure()
                 )
             else:
                 response.delete_cookie(

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -70,6 +70,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
                 value=lang_pref_out,
                 domain=settings.SESSION_COOKIE_DOMAIN,
                 max_age=COOKIE_DURATION,
+                secure=self.request.is_secure(),
             )
         else:
             response.delete_cookie.assert_called_with(

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -27,6 +27,7 @@ def update_session_language(request):
             settings.LANGUAGE_COOKIE,
             language,
             domain=settings.SESSION_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION
+            max_age=COOKIE_DURATION,
+            secure=request.is_secure(),
         )
     return response

--- a/openedx/core/djangoapps/user_authn/views/auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/auto_auth.py
@@ -177,7 +177,7 @@ def auto_auth(request):  # pylint: disable=too-many-statements
             'user_id': user.id,
             'anonymous_id': anonymous_id_for_user(user, None),
         })
-    response.set_cookie('csrftoken', csrf(request)['csrf_token'])
+    response.set_cookie('csrftoken', csrf(request)['csrf_token'], secure=request.is_secure())
     return response
 
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -40,6 +40,7 @@ Django==1.11.29                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models>=0.2.2         # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests
+django-cookies-samesite             # Middleware which sets SameSite flag for session and csrf cookies in Django<2.2
 django-countries==4.6.1             # Country data for Django forms and model fields
 django-crum                         # Middleware that stores the current request and user in thread local storage
 django-fernet-fields                # via edx-enterprise (should be added to its setup.py)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -73,6 +73,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
 django-classy-tags==0.8.0  # via django-sekizai
 django-config-models==0.2.2
+django-cookies-samesite==0.6.6
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -90,6 +90,7 @@ django-babel==0.6.2
 django-classy-tags==0.8.0
 django-config-models==0.2.2
 django-cors-headers==2.1.0
+django-cookies-samesite==0.6.6
 django-countries==4.6.1
 django-crum==0.7.3
 django-debug-toolbar==1.8

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -87,6 +87,7 @@ django-babel==0.6.2
 django-classy-tags==0.8.0
 django-config-models==0.2.2
 django-cors-headers==2.1.0
+django-cookies-samesite==0.6.6
 django-countries==4.6.1
 django-crum==0.7.3
 django-fernet-fields==0.5


### PR DESCRIPTION
Ticket: https://edx-wiki.atlassian.net/browse/MCKIN-22396

In Scorm shell login flow, the platform is loaded in an iframe from a cross origin ancestor. Hence we need the `sessionid` and `csrftoken` cookies to have samesite='None' and secure=True (after chrome update).

This has also been done for edx/edx-platform [here](https://github.com/edx/edx-platform/commit/7b3525278ebe3efbd7138a65343aff609de41838)