### PR TITLE
MCKIN-22514 Proficiency is not rounding off correctly

### DIFF
--- a/common/lib/xmodule/xmodule/graders.py
+++ b/common/lib/xmodule/xmodule/graders.py
@@ -394,7 +394,7 @@ class AssignmentFormatGrader(CourseGrader):
                     possible = scores[i].graded_total.possible
                     section_name = scores[i].display_name
 
-                percentage = scores[i].percent_graded
+                percentage = earned / possible
                 summary_format = u"{section_type} {index} - {name} - {percent:.0%} ({earned:.3n}/{possible:.3n})"
                 summary = summary_format.format(
                     index=i + self.starting_index,

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 
 import ddt
 from pytz import UTC
-from lms.djangoapps.grades.scores import compute_percent
 from six import text_type
 from xmodule import graders
 from xmodule.graders import (
@@ -101,10 +100,6 @@ class GraderTest(unittest.TestCase):
             self.graded_total = graded_total
             self.display_name = display_name
 
-        @property
-        def percent_graded(self):
-            return compute_percent(self.graded_total.earned, self.graded_total.possible)
-
     common_fields = dict(graded=True, first_attempted=datetime.now())
     test_gradesheet = {
         'Homework': {
@@ -161,11 +156,11 @@ class GraderTest(unittest.TestCase):
         self.assertEqual(len(graded['section_breakdown']), 12 + 1)
 
         graded = overflow_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.8879999999999999)  # 100% + 10% / 5 assignments
+        self.assertAlmostEqual(graded['percent'], 0.8880952380952382)  # 100% + 10% / 5 assignments
         self.assertEqual(len(graded['section_breakdown']), 7 + 1)
 
         graded = lab_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.92249999999999999)
+        self.assertAlmostEqual(graded['percent'], 0.9226190476190477)
         self.assertEqual(len(graded['section_breakdown']), 7 + 1)
 
     def test_assignment_format_grader_on_single_section_entry(self):
@@ -181,7 +176,7 @@ class GraderTest(unittest.TestCase):
             self.assertEqual(graded['section_breakdown'][0]['label'], 'Midterm')
 
         graded = midterm_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.50)
+        self.assertAlmostEqual(graded['percent'], 0.505)
         self.assertEqual(len(graded['section_breakdown']), 0 + 1)
 
     def test_weighted_subsections_grader(self):
@@ -219,17 +214,17 @@ class GraderTest(unittest.TestCase):
         empty_grader = graders.WeightedSubsectionsGrader([])
 
         graded = weighted_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.50812499999999994)
+        self.assertAlmostEqual(graded['percent'], 0.5106547619047619)
         self.assertEqual(len(graded['section_breakdown']), (12 + 1) + (7 + 1) + 1)
         self.assertEqual(len(graded['grade_breakdown']), 3)
 
         graded = over_one_weights_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.76624999999999999)
+        self.assertAlmostEqual(graded['percent'], 0.7688095238095238)
         self.assertEqual(len(graded['section_breakdown']), (12 + 1) + (7 + 1) + 1)
         self.assertEqual(len(graded['grade_breakdown']), 3)
 
         graded = zero_weights_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.25)
+        self.assertAlmostEqual(graded['percent'], 0.2525)
         self.assertEqual(len(graded['section_breakdown']), (12 + 1) + (7 + 1) + 1)
         self.assertEqual(len(graded['grade_breakdown']), 3)
 
@@ -286,7 +281,7 @@ class GraderTest(unittest.TestCase):
         empty_grader = graders.grader_from_conf([])
 
         graded = weighted_grader.grade(self.test_gradesheet)
-        self.assertAlmostEqual(graded['percent'], 0.50812499999999994)
+        self.assertAlmostEqual(graded['percent'], 0.5106547619047619)
         self.assertEqual(len(graded['section_breakdown']), (12 + 1) + (7 + 1) + 1)
         self.assertEqual(len(graded['grade_breakdown']), 3)
 

--- a/lms/djangoapps/gating/api.py
+++ b/lms/djangoapps/gating/api.py
@@ -38,6 +38,20 @@ def evaluate_prerequisite(course, subsection_grade, user):
                 )
 
 
+def _get_subsection_percentage(subsection_grade):
+    """
+    Returns the percentage value of the given subsection_grade.
+    """
+    return _calculate_ratio(subsection_grade.graded_total.earned, subsection_grade.graded_total.possible) * 100.0
+
+
+def _calculate_ratio(earned, possible):
+    """
+    Returns the percentage of the given earned and possible values.
+    """
+    return float(earned) / float(possible) if possible else 0.0
+
+
 def evaluate_entrance_exam(course_grade, user):
     """
     Evaluates any entrance exam milestone relationships attached
@@ -76,8 +90,8 @@ def get_entrance_exam_score_ratio(course_grade, exam_chapter_key):
     decimal value less than 1.
     """
     try:
-        entrance_exam_score_ratio = course_grade.chapter_percentage(exam_chapter_key)
+        earned, possible = course_grade.score_for_chapter(exam_chapter_key)
     except KeyError:
-        entrance_exam_score_ratio = 0.0, 0.0
+        earned, possible = 0.0, 0.0
         log.warning(u'Gating: Unexpectedly failed to find chapter_grade for %s.', exam_chapter_key)
-    return entrance_exam_score_ratio
+    return _calculate_ratio(earned, possible)

--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -13,7 +13,6 @@ from xmodule import block_metadata_utils
 from .config import assume_zero_if_absent
 from .subsection_grade import ZeroSubsectionGrade
 from .subsection_grade_factory import SubsectionGradeFactory
-from .scores import compute_percent
 
 
 class CourseGradeBase(object):
@@ -109,9 +108,9 @@ class CourseGradeBase(object):
                 problem_scores.update(subsection_grade.problem_scores)
         return problem_scores
 
-    def chapter_percentage(self, chapter_key):
+    def score_for_chapter(self, chapter_key):
         """
-        Returns the rounded aggregate weighted percentage for the given chapter.
+        Returns the aggregate weighted score for the given chapter.
         Raises:
             KeyError if the chapter is not found.
         """
@@ -120,7 +119,7 @@ class CourseGradeBase(object):
         for section in chapter_grade['sections']:
             earned += section.graded_total.earned
             possible += section.graded_total.possible
-        return compute_percent(earned, possible)
+        return earned, possible
 
     def score_for_module(self, location):
         """

--- a/lms/djangoapps/grades/scores.py
+++ b/lms/djangoapps/grades/scores.py
@@ -7,7 +7,6 @@ from xblock.core import XBlock
 
 from openedx.core.lib.cache_utils import process_cached
 from xmodule.graders import ProblemScore
-from numpy import around
 
 from .transformer import GradesTransformer
 
@@ -142,17 +141,6 @@ def weighted_score(raw_earned, raw_possible, weight):
         return raw_earned, raw_possible
     else:
         return float(raw_earned) * weight / raw_possible, float(weight)
-
-
-def compute_percent(earned, possible):
-    """
-     Returns the percentage of the given earned and possible values.
-     """
-    if possible > 0:
-        # Rounds to two decimal places.
-        return around(earned / possible, decimals=2)
-    else:
-        return 0.0
 
 
 def _get_score_from_submissions(submissions_scores, block):

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -9,9 +9,10 @@ from django.utils.html import escape
 from lazy import lazy
 
 from lms.djangoapps.grades.models import BlockRecord, PersistentSubsectionGrade
-from lms.djangoapps.grades.scores import get_score, possibly_scored, compute_percent
+from lms.djangoapps.grades.scores import get_score, possibly_scored
 from xmodule import block_metadata_utils, graders
 from xmodule.graders import AggregatedScore, ShowCorrectness
+
 
 log = getLogger(__name__)
 
@@ -156,7 +157,10 @@ class NonZeroSubsectionGrade(SubsectionGradeBase):
 
     @property
     def percent_graded(self):
-        return compute_percent(self.graded_total.earned, self.graded_total.possible)
+        if self.graded_total.possible > 0:
+            return self.graded_total.earned / self.graded_total.possible
+        else:
+            return 0.0
 
     @staticmethod
     def _compute_block_score(

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -1,22 +1,17 @@
 """
 Tests of the SubsectionGrade classes.
 """
-from ddt import data, ddt, unpack
-
 from ..models import PersistentSubsectionGrade
 from ..subsection_grade import CreateSubsectionGrade, ReadSubsectionGrade
 from .utils import mock_get_score
 from .base import GradeTestBase
 
 
-@ddt
 class SubsectionGradeTest(GradeTestBase):
     shard = 4
 
-    @data((50, 100, .50), (59.49, 100, .59), (59.51, 100, .60), (59.50, 100, .60), (60.5, 100, .60))
-    @unpack
-    def test_create_and_read(self, mock_earned, mock_possible, expected_result):
-        with mock_get_score(mock_earned, mock_possible):
+    def test_create_and_read(self):
+        with mock_get_score(1, 2):
             # Create a grade that *isn't* saved to the database
             created_grade = CreateSubsectionGrade(
                 self.sequence,
@@ -25,7 +20,7 @@ class SubsectionGradeTest(GradeTestBase):
                 self.subsection_grade_factory._csm_scores,
             )
             self.assertEqual(PersistentSubsectionGrade.objects.count(), 0)
-            self.assertEqual(created_grade.percent_graded, expected_result)
+            self.assertEqual(created_grade.percent_graded, 0.5)
 
             # save to db, and verify object is in database
             created_grade.update_or_create_model(self.request.user)
@@ -45,7 +40,7 @@ class SubsectionGradeTest(GradeTestBase):
             self.assertEqual(created_grade.url_name, read_grade.url_name)
             read_grade.all_total.first_attempted = created_grade.all_total.first_attempted = None
             self.assertEqual(created_grade.all_total, read_grade.all_total)
-            self.assertEqual(created_grade.percent_graded, expected_result)
+            self.assertEqual(created_grade.percent_graded, 0.5)
 
     def test_zero(self):
         with mock_get_score(1, 0):

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -170,8 +170,7 @@ username = get_enterprise_learner_generic_name(request) or student.username
                                         <%
                                         earned = section.all_total.earned
                                         total = section.all_total.possible
-
-                                        percentageString = "{0:.0%}".format(section.percent_graded) if earned > 0 and total > 0 else ""
+                                        percentageString = "{0:.0%}".format( float(earned)/total) if earned > 0 and total > 0 else ""
                                         %>
                                         <h4 class="hd hd-4">
                                             <a href="${reverse('courseware_section', kwargs=dict(course_id=text_type(course.id), chapter=chapter['url_name'], section=section.url_name))}">


### PR DESCRIPTION
This reverts commit fde830b73aae88227869588e83752bf5b38c0842.

this commit introduced in ironwood rebase and was being used for specific rounding criteria which is conflicting to Apros as well as Xblocks rounding.


