### PR TITLE
[BB-2765] Add `reverse_sql` to `database_fixups/0002` migration

### DIFF
--- a/common/djangoapps/database_fixups/migrations/0002_remove_foreign_keys_from_progress_extensions.py
+++ b/common/djangoapps/database_fixups/migrations/0002_remove_foreign_keys_from_progress_extensions.py
@@ -28,7 +28,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("""
+        migrations.RunSQL(
+            """
             -- Drop a procedure if it already exists - safety check.
             DROP PROCEDURE IF EXISTS drop_foreign_key_from_table;
 
@@ -60,5 +61,11 @@ class Migration(migrations.Migration):
 
             -- Clean up.
             DROP PROCEDURE IF EXISTS drop_foreign_key_from_table;
-        """)
+        """,
+            reverse_sql="""
+            ALTER TABLE progress_coursemodulecompletion ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
+            ALTER TABLE progress_studentprogress ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
+            ALTER TABLE progress_studentprogresshistory ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
+        """,
+        )
     ]


### PR DESCRIPTION
This is a follow up PR to #1874. It adds `reverse_sql` to the migration introduced there.

**Testing instructions**:
1. Run `./manage.py lms migrate database_fixups`.
1. Go to `dbshell`, run `SHOW CREATE TABLE progress_coursemodulecompletion` and check that the `CONSTRAINT` is no longer present there.
1. Run `./manage.py lms migrate database_fixups 0001`.
1. Go to `dbshell`, run `SHOW CREATE TABLE progress_coursemodulecompletion` and check that the `CONSTRAINT` is present now.

**Author's concerns**:
Applying this migration is rather fast, but reverting it is around 15 times slower on my machine. I tried disabling `FOREIGN_KEY_CHECKS`, but it didn't help. Also when I run these 3 SQL queries manually via the `dbshell`, they take around 0.01s each.
```bash
time ./manage.py lms migrate database_fixups
…  # Loads of warnings.
Operations to perform:
  Apply all migrations: database_fixups
Running migrations:
  Applying database_fixups.0002_remove_foreign_keys_from_progress_extensions...2020-09-10 17:13:54,985 WARNING 9066 [py.warnings] cursors.py:117 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/mysql/base.py:101: Warning: PROCEDURE edxapp.drop_foreign_key_from_table does not exist
  return self.cursor.execute(query, args)

 OK

real    0m6.249s
user    0m4.652s
sys     0m1.240s


time ./manage.py lms migrate database_fixups 0001
…  # Loads of warnings.
Operations to perform:
  Target specific migration: 0001_initial, from database_fixups
Running migrations:
  Rendering model states... DONE
  Unapplying database_fixups.0002_remove_foreign_keys_from_progress_extensions... OK  # This one appears after a few seconds, but everything waits for something then.

real    1m29.240s
user    1m27.516s
sys     0m1.276s

```

```sql
mysql> ALTER TABLE progress_coursemodulecompletion ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
Query OK, 0 rows affected (0.02 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> ALTER TABLE progress_studentprogress ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> ALTER TABLE progress_studentprogresshistory ADD FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`);
Query OK, 0 rows affected (0.02 sec)
Records: 0  Duplicates: 0  Warnings: 0
```