### PR TITLE
MCKIN-24663 sorting alphanumeric list

### DIFF
--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -286,6 +286,13 @@ def _filter_unstarted_categories(category_map, course):
     return result_map
 
 
+def _sort_alphanumeric_list(l):
+    convert = lambda text: int(text) if text.isdigit() else text
+    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key[1]["sort_key"])] \
+        if key[1]["sort_key"] is not None else key[1]["sort_key"]
+    return sorted(l, key = alphanum_key)
+
+
 def _sort_map_entries(category_map, sort_alpha):
     """
     Internal helper method to list category entries according to the provided sort order
@@ -298,7 +305,7 @@ def _sort_map_entries(category_map, sort_alpha):
     for title, category in category_map["subcategories"].items():
         things.append((title, category, TYPE_SUBCATEGORY))
         _sort_map_entries(category_map["subcategories"][title], sort_alpha)
-    category_map["children"] = [(x[0], x[2]) for x in sorted(things, key=lambda x: x[1]["sort_key"])]
+    category_map["children"] = [(x[0], x[2]) for x in _sort_alphanumeric_list(things)]
 
 
 def get_discussion_category_map(course, user, divided_only_if_explicit=False, exclude_unstarted=True):

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -290,7 +290,7 @@ def _sort_alphanumeric_list(l):
     convert = lambda text: int(text) if text.isdigit() else text
     alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key[1]["sort_key"])] \
         if key[1]["sort_key"] is not None else key[1]["sort_key"]
-    return sorted(l, key = alphanum_key)
+    return sorted(l, key=alphanum_key)
 
 
 def _sort_map_entries(category_map, sort_alpha):


### PR DESCRIPTION
`sorted` function does not order the list containing alphanumeric strings in some cases. For example:

`>>> test_list = [('General', 'General', 'entry'), ('Lesson 4', 'Lesson 4', 'subcategory'), ('Lesson 5', 'Lesson 5', 'subcategory'), ('Lesson 6', 'Lesson 6', 'subcategory'), ('Lesson 7', 'Lesson 7', 'subcategory'), ('Lesson 2', 'Lesson 2', 'subcategory'), ('Lesson 3', 'Lesson 3', 'subcategory'), ('Lesson 8', 'Lesson 8', 'subcategory'), ('Lesson 9', 'Lesson 9', 'subcategory'), ('Lesson 11', 'Lesson 11', 'subcategory'), ('Week 1', 'Week 1', 'subcategory'), ('Lesson 10', 'Lesson 10', 'subcategory'), ('Lesson 1', 'Lesson 1', 'subcategory')]`

`>>> [(x[0], x[2]) for x in sorted(test_list, key=lambda x: x[1])]`
`[('General', 'entry'), ('Lesson 1', 'subcategory'), ('Lesson 10', 'subcategory'), ('Lesson 11', 'subcategory'), ('Lesson 2', 'subcategory'), ('Lesson 3', 'subcategory'), ('Lesson 4', 'subcategory'), ('Lesson 5', 'subcategory'), ('Lesson 6', 'subcategory'), ('Lesson 7', 'subcategory'), ('Lesson 8', 'subcategory'), ('Lesson 9', 'subcategory'), ('Week 1', 'subcategory')]`

while the result should be this:

> [('General', 'entry'), ('Lesson 1', 'subcategory'), ('Lesson 2', 'subcategory'), ('Lesson 3', 'subcategory'), ('Lesson 4', 'subcategory'), ('Lesson 5', 'subcategory'), ('Lesson 6', 'subcategory'), ('Lesson 7', 'subcategory'), ('Lesson 8', 'subcategory'), ('Lesson 9', 'subcategory'), ('Lesson 10', 'subcategory'), ('Lesson 11', 'subcategory'), ('Week 1', 'subcategory')]

so will try to handle it in natural sort order like `Lesson 1, Lesson2, Lesson 3 ....., Lesson 10 ..... Lesson N` if we have a list containing alphanumeric strings in sorted function.