### PR TITLE
MCKIN-24885 CMS: Add missing app_label

### DIFF
--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -43,6 +43,9 @@ class CourseCreator(models.Model):
     note = models.CharField(max_length=512, blank=True, help_text=_("Optional notes about this user (for example, "
                                                                     "why course creation access was denied)"))
 
+    class Meta:
+        app_label = 'course_creators'
+
     def __unicode__(self):
         return u"{0} | {1} [{2}]".format(self.user, self.state, self.state_changed)
 


### PR DESCRIPTION
Jira ticket: https://edx-wiki.atlassian.net/browse/MCKIN-24885

LMS is not able to access the model CourseCreator, due to missing app label.
The result is it failure of user deletion since MYSQL does not know what to do with the foreign_key between CourseCreator and User in absence of django model code.