### PR TITLE
MCKIN-25091 fixed Discussion post Anonymously

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -223,6 +223,7 @@
             this.toggleDiscussionBtn.addClass('shown');
             this.toggleDiscussionBtn.find('.button-text').text(gettext('Hide Discussion'));
             this.showed = true;
+            this.$('label[for=anonymous]').removeClass('selected');
             $('.new-post-btn').focusout();
             $('.thread-title').focus();
         },

--- a/common/static/common/templates/discussion/thread-list-item.underscore
+++ b/common/static/common/templates/discussion/thread-list-item.underscore
@@ -26,7 +26,15 @@
       <span class="forum-nav-thread-title"><%- title %></span>
       <% if(typeof(username) !== "undefined" && typeof(created_at) !== "undefined") { %>
         <div class="posted-details">
-          <%- gettext("discussion posted") %> <span class="timeago" title="<%- created_at %>"><%- created_at %></span>
+          <%
+            var post_type;
+            if (thread_type === "discussion") {
+               post_type = gettext("discussion posted");
+            } else {
+                post_type = gettext("question posted");
+            }
+          %>
+          <%= post_type %> <span class="timeago" title="<%- created_at %>"><%- created_at %></span>
            <%- gettext("by") %> <span class="username"><%- username %></span>
         </div>
       <% } %>

--- a/lms/djangoapps/discussion/static/discussion/js/discussion_router.js
+++ b/lms/djangoapps/discussion/static/discussion/js/discussion_router.js
@@ -140,6 +140,7 @@
                         complete: function() {
                             var attr = self.newPostView.$el.fadeIn(200).focus();
                             $('.thread-title').focus();
+                            $('label[for=anonymous]').removeClass('selected');
                             return attr;
                         }
                     });


### PR DESCRIPTION
Fixed the followings:

1. Post Anonymously is not working accordingly. On posting 2nd time, the user has to select the checkbox again for the anonymous post.

2.  On posting a question, the string is shown as follows: "discussion posted 4 minutes ago by {user}". It should be written as a "question posted 4 minutes ago".