### PR TITLE
[YONK-1748] Update group projects version to include fix for unnecessary error logs

### DIFF
--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -19,7 +19,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@0.1.3#egg=xblock-g
 -e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.8.0#egg=xblock-eoc-journal==0.8.0
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@v2.2#egg=xblock-scorm==2.2
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.2.5#egg=xblock-diagnostic-feedback==0.2.5
--e git+https://github.com/open-craft/xblock-group-project-v2.git@0.8.1#egg=xblock-group-project-v2==0.8.1
+-e git+https://github.com/open-craft/xblock-group-project-v2.git@0.9.1#egg=xblock-group-project-v2==0.9.1
 -e git+https://github.com/open-craft/xblock-virtualreality.git@v0.1.5#egg=xblock-virtualreality==0.1.5
 -e git+https://github.com/edx/edx-notifications.git@2.0.0#egg=edx-notifications==2.0.0
 


### PR DESCRIPTION
Bumps version of group project XBlock to include changes from https://github.com/open-craft/xblock-group-project-v2/pull/145

That PR fixes unnecessary error logs in studio. 