### PR TITLE
MCKIN-26666: fix unit tests for lms badges app

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -195,7 +195,7 @@ urlpatterns += [
 
 if settings.FEATURES.get('ENABLE_OPENBADGES'):
     urlpatterns += [
-        url(r'^api/badges/v1/', include('badges.api.urls', app_name='badges', namespace='badges_api')),
+        url(r'^api/badges/v1/', include(('badges.api.urls', 'badges'), namespace='badges_api')),
     ]
 
 urlpatterns += [


### PR DESCRIPTION
This PR fixes broken unit tests of `edx-platform` under `lms/djangoapps/badges`.