### PR TITLE
[YONK-1822][BB-3217] Added namespace to URL to avoid warnings

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -177,7 +177,7 @@ if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
 if settings.FEATURES.get('EDX_SOLUTIONS_API'):
     urlpatterns += [
         url(r'^api/server/', include('edx_solutions_api_integration.urls')),
-        url(r'^api/completion/v0/', include('completion_aggregator.api.v0.urls'))
+        url(r'^api/completion/v0/', include('completion_aggregator.api.v0.urls', namespace='aggregation_api_v0'))
     ]
 
 # COMPLETION


### PR DESCRIPTION
This PR solves the warning produced when a server is started for namespace of URL.

**JIRA tickets**: [YONK-1822](https://openedx.atlassian.net/browse/YONK-1822)

~~**Screenshots**: Always include screenshots if there is any change to the UI. Can be useful for people that are not reviewer but want to know what's going on.~~

~~**Sandbox URL**: TBD - sandbox is being provisioned (if needed).~~

**Testing instructions**:

1. Clone this repo and checkout to the branch
2. Restart the server and observer the logs, you should not see `?: (urls.W005) URL namespace 'completion_aggregator' isn't unique. You may not be able to reverse all URLs in this namespace` warning.

**Author notes and concerns**:

None

**Reviewers**
- [ ] 