### PR TITLE
[BB-3205] Fix showing links with none on breadcrumb

### DIFF
--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -100,9 +100,14 @@ from openedx.core.djangolib.markup import HTML, Text
                             <div class="nav-sub">
                                 <ul>
                                 % for child in block['children']:
-                                <li class="nav-item">
-                                    <a href="${xblock_studio_url(child)}">${child.display_name_with_default}</a>
-                                </li>
+                                    <%
+                                    url = xblock_studio_url(child)
+                                    %>
+                                    % if url:
+                                        <li class="nav-item">
+                                            <a href="${url}">${child.display_name_with_default}</a>
+                                        </li>
+                                    % endif
                                 % endfor
                                 </ul>
                             </div>


### PR DESCRIPTION
This fix is to only show those xblock in navigation bar/breadcrumb which have their pages.

**JIRA tickets**: [BB-3205](https://tasks.opencraft.com/browse/BB-3205)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

~~**Dependencies**: None~~

**Screenshots**:
Before:
![image](https://user-images.githubusercontent.com/7670449/100526364-07eecc80-31ee-11eb-929d-2ac32ba4ef41.png)


After:
![image](https://user-images.githubusercontent.com/7670449/100526328-c78f4e80-31ed-11eb-80ce-e01d3cc94e9b.png)


~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

* Get the devstack to run
* Install problem-builder in the devstack
* Configure [problem-builder](https://github.com/open-craft/problem-builder/blob/master/doc/Usage.md) by adding it to advance module in studio
* Create a step-builder in demo course
* Navigate through the mentorship step
* Check all the URL in breadcrumbs and see none of them are pointing to `None`

**Author notes and concerns**:

Mostly breadcrumbs should be tested

**Reviewers**
- [ ] @xitij2000 
