### PR TITLE
[BB-3434] Remove stale aggregators

### DIFF
--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -7,6 +7,7 @@ from io import BytesIO
 
 from celery.task import task
 from completion.models import BlockCompletion
+from completion_aggregator.models import Aggregator
 from courseware.courses import get_course
 from courseware.models import StudentModule
 from django.conf import settings
@@ -171,6 +172,9 @@ def _migrate_progress(course, source, target):
         for state in student_states:
             state.student = target
             state.save()
+
+        log.info('Removing stale aggregators for source user.')
+        Aggregator.objects.filter(user=source, course_key=course_key).delete()
 
     except Exception:
         log.exception("Unexpected error while migrating user progress.")


### PR DESCRIPTION
This PR adds removal of stale aggregators. Without this, [users_above_qs queryset](https://github.com/edx-solutions/api-integration/blob/c46d1f3f4834fbcba3913462853552f8acb7815b/edx_solutions_api_integration/courses/utils.py#L128-L133) returns an incorrect set of users, which results in generating of incorrect metrics.

**JIRA tickets**:
[BB-3434](https://tasks.opencraft.com/browse/BB-3434)

**Reviewers**
- [ ] @xitij2000 