### PR TITLE
MCKIN-24885 Add user_tasks to lms installed apps

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2296,6 +2296,9 @@ INSTALLED_APPS = [
     # be retried
     'celery_utils',
 
+    # management of user-triggered async tasks (course import/export, etc.)
+    'user_tasks',
+
     # Ability to detect and special-case crawler behavior
     'openedx.core.djangoapps.crawlers',
 


### PR DESCRIPTION
User deletion fails for users who have entries in user_tasks__usertaskstatus table. 
Users have entries in this table who have attempted to export/import a course on studio.

This happens becuase lms is not able to detect user_tasks django app.
This PR fixes that.