### PR TITLE
MCKIN-29165 - Discussion post deletion fix

### DIFF
--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1048,7 +1048,6 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
         A paginated result containing a list of comments
 
     """
-    import pdb;pdb.set_trace()
     try:
         cc_comment = Comment(id=comment_id).retrieve()
         cc_thread, context = _get_thread_and_context(

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1048,6 +1048,7 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
         A paginated result containing a list of comments
 
     """
+    import pdb;pdb.set_trace()
     try:
         cc_comment = Comment(id=comment_id).retrieve()
         cc_thread, context = _get_thread_and_context(
@@ -1078,7 +1079,7 @@ def get_response_comments(request, comment_id, page, page_size, requested_fields
         )
 
         comments_count = len(response_comments)
-        num_pages = (comments_count + page_size - 1) / page_size if comments_count else 1
+        num_pages = (comments_count + page_size - 1) // page_size if comments_count else 1
         paginator = DiscussionAPIPagination(request, page, num_pages, comments_count)
         return paginator.get_paginated_response(results)
     except CommentClientRequestError:


### PR DESCRIPTION
While deleting a post, the number of comments are retrieved where API reports wrong number of total pages due to PY3 incompatible division:
```
response.data["pagination"]
{'previous': None, 'count': 3, 'num_pages': 1.02, 'next': 'http://apros.devstack.lms?ajax=1&page=2'}
```
Which results in `PageNotFoundError`:
```
is_thread)):
  File "/edx/src/discussion-edx-platform-extensions/social_engagement/engagement.py", line 382, in _get_paginated_results
    has_next = response.data["pagination"]["next"]
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/views.py", line 526, in retrieve
    form.cleaned_data["requested_fields"],
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/rest_api/api.py", line 1074, in get_response_comments
    raise PageNotFoundError("Page not found (No results on this page).")
openedx.core.lib.exceptions.PageNotFoundError: Page not found (No results on this page).
```