### PR TITLE
[MCKIN-27241] Merge user progress when target is enrolled but has no progress

### DIFF
--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -136,8 +136,9 @@ def _migrate_progress(course, source, target):
 
     try:
         assert not BlockCompletion.user_course_completion_queryset(user=target, course_key=course_key).exists()
-        assert not AnonymousUserId.objects.filter(user=source, course_id=course_key).exists()
         assert not StudentModule.objects.filter(student=source, course_id=course_key).exists()
+        anonymous_ids = AnonymousUserId.objects.filter(user=target, course_id=course_key).values('anonymous_user_id')
+        assert not StudentItem.filter(course_id=course_key, student_id__in=anonymous_ids).exists()
     except AssertionError:
         log.warning(
             'Migration failed. Target user with email "%s" already enrolled in "%s" course and progress is present.', target.email, course_key

--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -136,9 +136,8 @@ def _migrate_progress(course, source, target):
 
     try:
         assert not BlockCompletion.user_course_completion_queryset(user=target, course_key=course_key).exists()
-        assert not StudentModule.objects.filter(student=source, course_id=course_key).exists()
         anonymous_ids = AnonymousUserId.objects.filter(user=target, course_id=course_key).values('anonymous_user_id')
-        assert not StudentItem.filter(course_id=course_key, student_id__in=anonymous_ids).exists()
+        assert not StudentItem.objects.filter(course_id=course_key, student_id__in=anonymous_ids).exists()
     except AssertionError:
         log.warning(
             'Migration failed. Target user with email "%s" already enrolled in "%s" course and progress is present.', target.email, course_key
@@ -161,7 +160,7 @@ def _migrate_progress(course, source, target):
     try:
         # Modify enrollment
         try:
-            target_enrollment = CourseEnrollment.objects.select_for_update().get(user=source, course=course_key)
+            target_enrollment = CourseEnrollment.objects.select_for_update().get(user=target, course=course_key)
         except ObjectDoesNotExist:
             enrollment.user = target
         else:

--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -121,7 +121,9 @@ def _migrate_progress(course, source, target):
         return OUTCOME_SOURCE_NOT_FOUND
 
     try:
-        enrollment = CourseEnrollment.objects.select_for_update().get(user=source, course=course_key)
+        assert not BlockCompletion.user_course_completion_queryset(user=target, course_key=course_key).exists()
+        assert not AnonymousUserId.objects.filter(user=source, course_id=course_key).exists()
+        assert not StudentModule.objects.filter(student=source, course_id=course_key).exists()
     except ObjectDoesNotExist:
         log.warning(
             'Migration failed. Source user with email "%s" not enrolled in "%s" course', source.email, course_key

--- a/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
@@ -46,7 +46,7 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
         )
         self.course_id = str(self.course.id)
 
-    def _create_user(self, username=None, enrolled=None):
+    def _create_user(self, username=None, enrolled=None, create_progress=False):
         """
         Shortcut to create users and enroll them in some course.
         """
@@ -59,6 +59,8 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
         )
         if enrolled:
             CourseEnrollment.enroll(user, self.course.id, mode='audit')
+            if create_progress:
+                self._create_user_progress(user)
         return user
 
     def _create_user_progress(self, user):
@@ -136,7 +138,7 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
 
     def test_target_already_enrolled(self):
         source = self._create_user(enrolled=self.course)
-        target = self._create_user(enrolled=self.course)
+        target = self._create_user(enrolled=self.course, create_progress=True)
         self.assertEqual(
             _migrate_progress(self.course_id, source.email, target.email),
             OUTCOME_TARGET_ALREADY_ENROLLED
@@ -192,7 +194,13 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
             {
                 'course': self.course_id,
                 'source_email': self._create_user(enrolled=self.course).email,
-                'dest_email': self._create_user(enrolled=self.course).email,
+                'dest_email': self._create_user(enrolled=self.course, create_progress=False).email,
+                'outcome': OUTCOME_MIGRATED
+            },
+            {
+                'course': self.course_id,
+                'source_email': self._create_user(enrolled=self.course).email,
+                'dest_email': self._create_user(enrolled=self.course, create_progress=True).email,
                 'outcome': OUTCOME_TARGET_ALREADY_ENROLLED
             },
             {


### PR DESCRIPTION
This PR contains fixes to the merging of user accounts, specifically merging when the target is already enrolled in the course but has no progress in it.

**JIRA tickets**: MCKIN-27241

**Discussions**: Jira ticket

**Merge deadline**: ASAP

**Testing instructions**:

1. Checkout this branch in your devstack.
1. Create three users, e.g. A, B, and C, and enroll all in a test course.
1. Browse the test course with users A and B, generating progress.
1. Run the migration from user A to B and see it fail, as user B already has progress.
1. Unenroll user C from test course, making the enrollment inactive.
1. Run the migrate from user A to C, and watch it succeed.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD