### PR TITLE
[MCKIN-27241] Cherry Pick Commit

### DIFF
--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -136,7 +136,9 @@ def _migrate_progress(course, source, target):
         return OUTCOME_TARGET_NOT_FOUND
 
     try:
-        assert not BlockCompletion.user_course_completion_queryset(user=target, course_key=course_key).exists()
+        assert not BlockCompletion.user_learning_context_completion_queryset(
+            user=target, context_key=course_key
+        ).exists()
         anonymous_ids = AnonymousUserId.objects.filter(user=target, course_id=course_key).values('anonymous_user_id')
         assert not StudentItem.objects.filter(course_id=course_key, student_id__in=anonymous_ids).exists()
     except AssertionError:

--- a/openedx/core/djangoapps/user_api/completion/tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tasks.py
@@ -135,9 +135,13 @@ def _migrate_progress(course, source, target):
         log.warning('Migration failed. Target user with such email not found: %s', target)
         return OUTCOME_TARGET_NOT_FOUND
 
-    if CourseEnrollment.objects.filter(user=target, course=course_key).exists():
+    try:
+        assert not BlockCompletion.user_course_completion_queryset(user=target, course_key=course_key).exists()
+        anonymous_ids = AnonymousUserId.objects.filter(user=target, course_id=course_key).values('anonymous_user_id')
+        assert not StudentItem.objects.filter(course_id=course_key, student_id__in=anonymous_ids).exists()
+    except AssertionError:
         log.warning(
-            'Migration failed. Target user with email "%s" already enrolled in "%s" course', target.email, course_key
+            'Migration failed. Target user with email "%s" already enrolled in "%s" course and progress is present.', target.email, course_key
         )
         return OUTCOME_TARGET_ALREADY_ENROLLED
 
@@ -156,8 +160,16 @@ def _migrate_progress(course, source, target):
     # Actually migrate completions and progress
     try:
         # Modify enrollment
-        enrollment.user = target
-        enrollment.save()
+        try:
+            target_enrollment = CourseEnrollment.objects.select_for_update().get(user=target, course=course_key)
+        except ObjectDoesNotExist:
+            enrollment.user = target
+        else:
+            enrollment.is_active = False
+            target_enrollment.is_active = True
+            target_enrollment.save()
+        finally:
+            enrollment.save()
 
         # Migrate completions for user
         for completion in completions:

--- a/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
@@ -47,7 +47,7 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
         )
         self.course_id = str(self.course.id)
 
-    def _create_user(self, username=None, enrolled=None):
+    def _create_user(self, username=None, enrolled=None, create_progress=False):
         """
         Shortcut to create users and enroll them in some course.
         """
@@ -60,6 +60,8 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
         )
         if enrolled:
             CourseEnrollment.enroll(user, self.course.id, mode='audit')
+            if create_progress:
+                self._create_user_progress(user)
         return user
 
     def _create_user_progress(self, user):
@@ -136,7 +138,7 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
 
     def test_target_already_enrolled(self):
         source = self._create_user(enrolled=self.course)
-        target = self._create_user(enrolled=self.course)
+        target = self._create_user(enrolled=self.course, create_progress=True)
         self.assertEqual(
             _migrate_progress(self.course_id, source.email, target.email),
             OUTCOME_TARGET_ALREADY_ENROLLED
@@ -193,7 +195,13 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
             {
                 'course': self.course_id,
                 'source_email': self._create_user(enrolled=self.course).email,
-                'dest_email': self._create_user(enrolled=self.course).email,
+                'dest_email': self._create_user(enrolled=self.course, create_progress=False).email,
+                'outcome': OUTCOME_MIGRATED
+            },
+            {
+                'course': self.course_id,
+                'source_email': self._create_user(enrolled=self.course).email,
+                'dest_email': self._create_user(enrolled=self.course, create_progress=True).email,
                 'outcome': OUTCOME_TARGET_ALREADY_ENROLLED
             },
             {

--- a/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
+++ b/openedx/core/djangoapps/user_api/completion/tests/test_tasks.py
@@ -35,6 +35,7 @@ from mock import call, patch
 import uuid
 
 
+@skip_unless_lms
 class ProgressMigrationTestCase(ModuleStoreTestCase):
     """
     Parent test case for progress migration tests.
@@ -144,7 +145,6 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
             OUTCOME_TARGET_ALREADY_ENROLLED
         )
 
-    @skip_unless_lms
     def test_migrated(self):
         source = self._create_user(enrolled=self.course)
         target = self._create_user()
@@ -178,6 +178,7 @@ class ProgressMigrationTestCase(ModuleStoreTestCase):
                 OUTCOME_FAILED_MIGRATION
             )
 
+    @skip_unless_lms
     def test_migrate_progress(self):
         """
         Integration test, that checks that:


### PR DESCRIPTION
Merge user progress when target is enrolled but has noprogress (#2065)

During user progress migration, targets already enrolled in the course are now acceptable if they have no progress in that course already. In case progress already exists, the migration to that user will be skipped.