### PR TITLE
MCKIN-29636 <MckA> Discussion (forum + inline) - Content is not loading quickly in Preview box

### DIFF
--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -15,6 +15,7 @@ if (typeof MathJax === 'undefined') {
             setMathJaxDisplayDivSettings;
         MathJax.Hub.Config({
             tex2jax: {
+                ignoreClass: "djdt-hidden",// don't parse Django Debug Toolbar for Math Equations.
                 inlineMath: [
                     ['\\(', '\\)'],
                     ['[mathjaxinline]', '[/mathjaxinline]']
@@ -23,6 +24,9 @@ if (typeof MathJax === 'undefined') {
                     ['\\[', '\\]'],
                     ['[mathjax]', '[/mathjax]']
                 ]
+            },
+            asciimath2jax: {
+               ignoreClass: "djdt-hidden",  // don't parse Django Debug Toolbar for Math Equations.
             }
         });
         if (disableFastPreview) {


### PR DESCRIPTION
MathJax was also parsing the Django Debug Tool bar which caused performance issues.

'djdt-hidden' class is added in the filter to ignore during parsing.
