### PR TITLE
MCKIN-32454: bump xblock eoc journal version to 0.10.1

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -113,7 +113,7 @@ pa11ycrawler                        # Python crawler (using Scrapy) that uses Pa
 pdfminer.six                        # Used in shoppingcart for extracting/parsing pdf text
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
+
 PyContracts
 pycountry
 pycryptodomex

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -183,7 +183,7 @@ pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.in
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2   # via -r requirements/edx/github.in
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi

--- a/requirements/edx/custom.txt
+++ b/requirements/edx/custom.txt
@@ -13,7 +13,7 @@ git+https://github.com/edx-solutions/xblock-group-project.git@1.0.0#egg=xblock-g
 -e git+https://github.com/open-craft/problem-builder.git@v4.1.9#egg=xblock-problem-builder==4.1.9
 #-e git+https://github.com/OfficeDev/xblock-officemix.git@86238f5968a08db005717dbddc1.9.6346808f1ed3716#egg=xblock-officemix
 -e git+https://github.com/open-craft/xblock-chat.git@v0.3.0#egg=chat-xblock==0.3.0
--e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.10.0#egg=xblock-eoc-journal==0.10.0
+-e git+https://github.com/open-craft/xblock-eoc-journal.git@v0.10.1#egg=xblock-eoc-journal==0.10.1
 -e git+https://github.com/mckinseyacademy/xblock-scorm.git@v3.2.2#egg=xblock-scorm==3.2.2
 -e git+https://github.com/mckinseyacademy/xblock-diagnosticfeedback.git@v0.4.1#egg=xblock-diagnostic-feedback==0.4.1
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -219,7 +219,7 @@ pkgconfig==1.5.1          # via -r requirements/edx/testing.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/testing.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2 # via -r requirements/edx/github.in
 py==1.8.1                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -210,7 +210,7 @@ pkgconfig==1.5.1          # via -r requirements/edx/base.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
-py2neo==3.1.2             # via -r requirements/edx/base.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2 # via -r requirements/edx/github.in
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client


### PR DESCRIPTION
This PR bump xblock eoc journal version to 0.10.1 and Also cherry-picks `py2neo` fix from `release-freeze` to fix build failures on CI on development branch