### PR TITLE
MCKIN-24991 - Fix for reports with no responses

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -958,9 +958,6 @@ class ProblemResponses(object):
                             if max_count <= 0:
                                 break
 
-            if not student_data:
-                break
-
             # Keep the keys in a useful order, starting with username, title and location,
             # then the columns returned by the xblock report generator in sorted order and
             # finally end with the more machine friendly block_key and state.
@@ -971,6 +968,9 @@ class ProblemResponses(object):
             )
 
             yield student_data, student_data_keys_list, batch_no
+
+            if not student_data:
+                break
             batch_no += 1
 
     @classmethod


### PR DESCRIPTION
Fixing error in case where there is no response to the poll/survey when generating poll/survey report.

In case when the poll/survey do not have any response, `student_data` inside `_build_student_data` function is an empty array in the first iteration. Previously the `break` statement was above the yield statement and in the above mentioned scenario, the function did not returned anything. This would cause the while loop in `generate` function to not run. The `output_buffer` remains `None` and gives an error on `output_buffer.seek(0)`.

Also in implementation before this ticket, in case of no response, `student_data_keys_list` was returned from `_build_student_data` function which would be the only row in resulting csv file.

By moving the `break` statement below `yield`, we ensure that `student_data_keys_list` is returned even if there is no response. This will also make sure that `output_buffer` is set on line 1028. 

In other cases where there are responses, this change wont have any effect. In last iteration of  `_build_student_data`, previously the code was hitting `break` before yielding but this time it will return empty array for `student_data` along with `student_data_keys_list`. As `student_data_keys_list` are only added to the file in first batch, no more rows would be added in the last iteration.