### PR TITLE
MEI-7725 - Upgrade django-ses version

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -56,7 +56,7 @@ django-pyfs
 django-ratelimit-backend
 django-require
 django-sekizai
-django-ses
+django-ses>=2.0.0                   # Pinned to use AWS Signature V4 as older versions are deprecated
 django-simple-history
 django-splash
 django-statici18n

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -79,7 +79,7 @@ django-pyfs==2.1          # via -r requirements/edx/base.in
 django-ratelimit-backend==2.0  # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki
-django-ses==0.8.14        # via -r requirements/edx/base.in
+django-ses==2.0.0         # via -r requirements/edx/base.in
 django-simple-history==2.10.0  # via -r requirements/edx/base.in, edx-enterprise, edx-organizations, ora2
 django-splash==0.2.9      # via -r requirements/edx/base.in
 django-statici18n==1.9.0  # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -90,7 +90,7 @@ django-pyfs==2.1          # via -r requirements/edx/testing.txt
 django-ratelimit-backend==2.0  # via -r requirements/edx/testing.txt
 django-require==1.0.11    # via -r requirements/edx/testing.txt
 django-sekizai==1.1.0     # via -r requirements/edx/testing.txt, django-wiki
-django-ses==0.8.14        # via -r requirements/edx/testing.txt
+django-ses==2.0.0         # via -r requirements/edx/testing.txt
 django-simple-history==2.10.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations, ora2
 django-splash==0.2.9      # via -r requirements/edx/testing.txt
 django-statici18n==1.9.0  # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -88,7 +88,7 @@ django-pyfs==2.1          # via -r requirements/edx/base.txt
 django-ratelimit-backend==2.0  # via -r requirements/edx/base.txt
 django-require==1.0.11    # via -r requirements/edx/base.txt
 django-sekizai==1.1.0     # via -r requirements/edx/base.txt, django-wiki
-django-ses==0.8.14        # via -r requirements/edx/base.txt
+django-ses==2.0.0         # via -r requirements/edx/base.txt
 django-simple-history==2.10.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-organizations, ora2
 django-splash==0.2.9      # via -r requirements/edx/base.txt
 django-statici18n==1.9.0  # via -r requirements/edx/base.txt


### PR DESCRIPTION
Upgrading `django-ses` version to `2.0.0`. This version uses AWS Signature V4 as older versions are deprecated. 